### PR TITLE
test(e2e): add e2e scripts + CI; chore: Makefile & compose env_file

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -3,4 +3,9 @@ APP_NAME=trading-bot-config
 POSTGRES_DSN=postgresql+psycopg2://trading:trading@postgres:5432/trading
 REDIS_URL=redis://redis:6379/0
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672//
+
+# ==== Auth/User defaults for local dev ====
+DATABASE_URL=postgresql+psycopg2://trading:trading@postgres:5432/trading
+PYTHONPATH=/app
 JWT_SECRET=dev-secret-change-me
+JWT_ALGO=HS256

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,26 @@
+name: e2e
+on:
+  push:
+    branches: [ "main", "feat/**" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Up infra
+        run: |
+          docker compose up -d postgres redis
+          docker compose up -d --build auth-service
+      - name: Wait for auth-service
+        run: |
+          for i in {1..30}; do
+            curl -sf http://127.0.0.1:8011/health && exit 0
+            sleep 2
+          done
+          echo "auth-service not ready" && exit 1
+      - name: Run E2E (bash)
+        run: bash ./scripts/e2e/auth_e2e.sh

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,10 +1,258 @@
 {
-  "version": "1.0.0",
+  "version": "1.5.0",
   "plugins_used": [
-    {"name": "Base64HighEntropyString"},
-    {"name": "HexHighEntropyString"},
-    {"name": "KeywordDetector"}
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
   ],
-  "filters_used": [],
-  "results": {}
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".env.dev": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.dev",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 3
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.dev",
+        "hashed_secret": "35675e68f4b5af7b995d9205ad0fc43842f16450",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    ".env.example": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.example",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 6
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.example",
+        "hashed_secret": "35675e68f4b5af7b995d9205ad0fc43842f16450",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "codex.plan.yaml": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "codex.plan.yaml",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "codex.plan.yaml",
+        "hashed_secret": "e0bd681cf9ddf1cd4607ccb6a1712adb991f3f63",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "data/config.dev.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "data/config.dev.json",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "data/config.dev.json",
+        "hashed_secret": "35675e68f4b5af7b995d9205ad0fc43842f16450",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.yml",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docker-compose.yml",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "infra/migrations/alembic.ini": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "infra/migrations/alembic.ini",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "libs/db/db.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "libs/db/db.py",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "services/config-service/app/__init__.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "services/config-service/app/__init__.py",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "services/config-service/app/__init__.py",
+        "hashed_secret": "35675e68f4b5af7b995d9205ad0fc43842f16450",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "services/config-service/app/settings.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "services/config-service/app/settings.py",
+        "hashed_secret": "a31f0db8caea0a61995e27920e5a1da0c0128998",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "services/config-service/app/settings.py",
+        "hashed_secret": "35675e68f4b5af7b995d9205ad0fc43842f16450",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ]
+  },
+  "generated_at": "2025-08-12T22:30:59Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 SHELL := /bin/bash
 
-.PHONY: setup dev-up dev-down lint test
+.PHONY: setup dev-up dev-down lint test e2e e2e-sh
 
 setup:
 	pipx install pre-commit || pip install pre-commit
 	pre-commit install
 
 dev-up:
-	docker compose up -d --build
+	docker compose up -d postgres redis
+	docker compose up -d --build auth-service user-service
 
 dev-down:
 	docker compose down -v
@@ -18,3 +19,9 @@ lint:
 test:
 	python -m pip install -r services/config-service/requirements-dev.txt
 	pytest
+
+e2e:
+	pwsh -NoProfile -File ./scripts/e2e/auth_e2e.ps1
+
+e2e-sh:
+	bash ./scripts/e2e/auth_e2e.sh

--- a/codex.plan.yaml
+++ b/codex.plan.yaml
@@ -1,33 +1,148 @@
-﻿tickets:
-  - key: TICKET-001
-    title: "Initialisation du repository et structure"
-    priority: "Critique"
-    estimate_days: 3
-    acceptance:
-      - "README, LICENSE, CONTRIBUTING, CODE_OF_CONDUCT prÃ©sents"
-      - "Structure microservices crÃ©Ã©e"
-      - "pre-commit configurÃ©"
-      - "Templates Issues/PR en place"
-      - "CI GitHub Actions opÃ©rationnelle (lint + tests)"
-  - key: TICKET-002
-    title: "Environnement de dÃ©veloppement Docker"
-    priority: "Critique"
-    estimate_days: 2
-    dependencies: ["TICKET-001"]
-    acceptance:
-      - "Dockerfile multi-stage par service"
-      - "docker-compose.yml (dev) avec Postgres, Redis, RabbitMQ"
-      - "Scripts start/stop"
-      - "Volumes persistants configurÃ©s"
-      - "Doc d'installation/dÃ©marrage"
-  - key: TICKET-003
-    title: "Service de configuration centralisÃ©e"
-    priority: "Haute"
-    estimate_days: 4
-    dependencies: ["TICKET-002"]
-    acceptance:
-      - "ModÃ¨les Pydantic pour toutes confs"
-      - "Support variables d'environnement et fichiers"
-      - "Validation auto au dÃ©marrage"
-      - "Profils env: dev/test/prod"
-      - "API REST de gestion"
+version: 1
+name: "bootstrap-e2e-and-ci"
+description: "Ajoute tests e2e (register/login/me), CI GitHub Actions, cibles Makefile et petits ajustements docker-compose."
+
+tasks:
+  - id: create-branch
+    run: |
+      git checkout -b feat/e2e-and-ci || git checkout feat/e2e-and-ci
+
+  - id: ensure-env
+    files:
+      - path: ".env.dev"
+        ensure_exists: true
+        append_if_missing: |
+          # ==== Auth/User defaults for local dev ====
+          DATABASE_URL=postgresql+psycopg2://trading:trading@postgres:5432/trading
+          PYTHONPATH=/app
+          JWT_SECRET=dev-secret-change-me  # pragma: allowlist secret
+          JWT_ALGO=HS256
+
+  - id: compose-tweak
+    edit:
+      path: "docker-compose.yml"
+      instructions: |
+        - For both services "auth-service" and "user-service", add:
+            env_file:
+              - .env.dev
+        - Do not change ports or depends_on.
+        - Keep YAML indentation consistent.
+
+  - id: makefile
+    write:
+      path: "Makefile"
+      content: |
+        .PHONY: dev-up dev-down e2e e2e-sh
+        dev-up:
+        docker compose up -d postgres redis
+        docker compose up -d --build auth-service user-service
+        dev-down:
+        docker compose down -v
+        e2e:
+        pwsh -NoProfile -File ./scripts/e2e/auth_e2e.ps1
+        e2e-sh:
+        bash ./scripts/e2e/auth_e2e.sh
+
+  - id: e2e-powershell
+    write:
+      path: "scripts/e2e/auth_e2e.ps1"
+      mode: "0755"
+      content: |
+        $ErrorActionPreference = "Stop"
+        $env:NO_PROXY="localhost,127.0.0.1"; $env:no_proxy=$env:NO_PROXY
+
+        function Assert($ok, $msg) {
+          if (-not $ok) { Write-Error $msg; exit 1 } else { Write-Host "OK - $msg" }
+        }
+
+        # Health
+        $h1 = curl.exe --noproxy "*" http://127.0.0.1:8011/health 2>$null
+        $h2 = curl.exe --noproxy "*" http://127.0.0.1:8012/health 2>$null
+        Assert ($h1 -match '"ok"' -or $h1 -match 'status' -or $h1 -match 'OK') "auth-service /health"
+        # user-service peut ne pas répondre encore, on tolère (enlève ce commentaire quand prêt)
+
+        # Register
+        $email="dev$(Get-Date -Format 'yyyyMMddHHmmss')@example.com"
+        $reg = curl.exe -s -X POST "http://127.0.0.1:8011/auth/register" `
+          -H "Content-Type: application/json" `
+          -d "{\"email\": \"$email\", \"password\": \"Passw0rd!\"}"
+        Assert ($LASTEXITCODE -eq 0) "register call"
+        Write-Host "REGISTER => $reg"
+
+        # Login
+        $login = curl.exe -s -X POST "http://127.0.0.1:8011/auth/login" `
+          -H "Content-Type: application/json" `
+          -d "{\"email\": \"$email\", \"password\": \"Passw0rd!\"}"
+        Assert ($LASTEXITCODE -eq 0) "login call"
+        $json = $login | ConvertFrom-Json
+        $token = $json.access_token
+        Assert ($token) "access_token extracted"
+
+        # Me
+        $me = curl.exe -s -H "Authorization: Bearer $token" "http://127.0.0.1:8011/auth/me"
+        Assert ($LASTEXITCODE -eq 0) "/auth/me call"
+        Write-Host "ME => $me"
+        Write-Host "E2E DONE ✅"
+
+  - id: e2e-bash
+    write:
+      path: "scripts/e2e/auth_e2e.sh"
+      mode: "0755"
+      content: |
+        set -euo pipefail
+        export NO_PROXY="localhost,127.0.0.1"; export no_proxy="$NO_PROXY"
+
+        curl --noproxy "*" -sf http://127.0.0.1:8011/health >/dev/null
+
+        email="dev$(date +%Y%m%d%H%M%S)@example.com"
+        curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/register \
+          -H "Content-Type: application/json" \
+          -d "{\"email\":\"$email\",\"password\":\"Passw0rd!\"}" >/dev/null
+
+        token=$(curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/login \
+          -H "Content-Type: application/json" \
+          -d "{\"email\":\"$email\",\"password\":\"Passw0rd!\"}" | python -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+        curl --noproxy "*" -sS -H "Authorization: Bearer $token" http://127.0.0.1:8011/auth/me >/dev/null
+        echo "E2E DONE ✅"
+
+  - id: workflow-e2e
+    write:
+      path: ".github/workflows/e2e.yml"
+      content: |
+        name: e2e
+        on:
+          push:
+            branches: [ "main", "feat/**" ]
+          pull_request:
+            branches: [ "main" ]
+        jobs:
+          e2e:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v4
+              - name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v3
+              - name: Build & Up infra
+                run: |
+                  docker compose up -d postgres redis
+                  docker compose up -d --build auth-service
+              - name: Wait for auth-service
+                run: |
+                  for i in {1..30}; do
+                    curl -sf http://127.0.0.1:8011/health && exit 0
+                    sleep 2
+                  done
+                  echo "auth-service not ready" && exit 1
+              - name: Run E2E (bash)
+                run: bash ./scripts/e2e/auth_e2e.sh
+
+  - id: git-commit
+    run: |
+      git add .
+      git commit -m "test(e2e): add e2e scripts + CI; chore: Makefile & compose env_file"
+
+  - id: push-and-pr
+    run: |
+      git push -u origin feat/e2e-and-ci
+      echo "::notice::Create a PR from feat/e2e-and-ci → main"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@
     build:
       context: .
       dockerfile: services/auth-service/Dockerfile
+    env_file:
+      - .env.dev
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql+psycopg2://trading:trading@postgres:5432/trading
@@ -32,6 +34,8 @@
     build:
       context: .
       dockerfile: services/user-service/Dockerfile
+    env_file:
+      - .env.dev
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql+psycopg2://trading:trading@postgres:5432/trading

--- a/scripts/e2e/auth_e2e.ps1
+++ b/scripts/e2e/auth_e2e.ps1
@@ -1,0 +1,35 @@
+$ErrorActionPreference = "Stop"
+$env:NO_PROXY="localhost,127.0.0.1"; $env:no_proxy=$env:NO_PROXY
+
+function Assert($ok, $msg) {
+  if (-not $ok) { Write-Error $msg; exit 1 } else { Write-Host "OK - $msg" }
+}
+
+# Health
+$h1 = curl.exe --noproxy "*" http://127.0.0.1:8011/health 2>$null
+$h2 = curl.exe --noproxy "*" http://127.0.0.1:8012/health 2>$null
+Assert ($h1 -match '"ok"' -or $h1 -match 'status' -or $h1 -match 'OK') "auth-service /health"
+# user-service peut ne pas répondre encore, on tolère (enlève ce commentaire quand prêt)
+
+# Register
+$email="dev$(Get-Date -Format 'yyyyMMddHHmmss')@example.com"
+$reg = curl.exe -s -X POST "http://127.0.0.1:8011/auth/register" `
+  -H "Content-Type: application/json" `
+  -d "{\"email\": \"$email\", \"password\": \"Passw0rd!\"}"
+Assert ($LASTEXITCODE -eq 0) "register call"
+Write-Host "REGISTER => $reg"
+
+# Login
+$login = curl.exe -s -X POST "http://127.0.0.1:8011/auth/login" `
+  -H "Content-Type: application/json" `
+  -d "{\"email\": \"$email\", \"password\": \"Passw0rd!\"}"
+Assert ($LASTEXITCODE -eq 0) "login call"
+$json = $login | ConvertFrom-Json
+$token = $json.access_token
+Assert ($token) "access_token extracted"
+
+# Me
+$me = curl.exe -s -H "Authorization: Bearer $token" "http://127.0.0.1:8011/auth/me"
+Assert ($LASTEXITCODE -eq 0) "/auth/me call"
+Write-Host "ME => $me"
+Write-Host "E2E DONE ✅"

--- a/scripts/e2e/auth_e2e.sh
+++ b/scripts/e2e/auth_e2e.sh
@@ -1,0 +1,16 @@
+set -euo pipefail
+export NO_PROXY="localhost,127.0.0.1"; export no_proxy="$NO_PROXY"
+
+curl --noproxy "*" -sf http://127.0.0.1:8011/health >/dev/null
+
+email="dev$(date +%Y%m%d%H%M%S)@example.com"
+curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/register \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$email\",\"password\":\"Passw0rd!\"}" >/dev/null
+
+token=$(curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$email\",\"password\":\"Passw0rd!\"}" | python -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+curl --noproxy "*" -sS -H "Authorization: Bearer $token" http://127.0.0.1:8011/auth/me >/dev/null
+echo "E2E DONE ✅"


### PR DESCRIPTION
## Summary
- wire docker-compose services with shared `.env.dev`
- add Makefile targets and e2e scripts for auth flow
- set up GitHub Actions workflow running e2e tests
- refresh secrets baseline to satisfy detect-secrets hook

## Testing
- `pre-commit run --files .secrets.baseline`
- `bash ./scripts/e2e/auth_e2e.sh` *(fails: auth-service unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bbd92dcf88332ba009ffbadd6dfb7