### PR TITLE
Add screener service with FMP integration

### DIFF
--- a/docs/screener.md
+++ b/docs/screener.md
@@ -1,0 +1,84 @@
+# Screener Service
+
+Le service **Screener** expose une API REST permettant d'exécuter des screeners actions
+sur des fournisseurs tiers (Financial Modeling Prep) et de gérer des presets personnels.
+
+## Exécution d'un screener
+
+```
+GET /screener/run
+```
+
+Paramètres :
+
+| Nom        | Type      | Description                                                                 |
+|------------|-----------|-----------------------------------------------------------------------------|
+| `provider` | string    | Provider à utiliser. Seule la valeur `fmp` est supportée pour l'instant.    |
+| `limit`    | entier    | Nombre maximum de valeurs retournées (1-200, défaut 50).                    |
+| `preset_id`| entier    | Identifiant d'un preset enregistré à réutiliser pour le filtre.             |
+| `filters`  | string    | Objet JSON encodé dans la query string décrivant les filtres additionnels.  |
+
+En-têtes requis :
+
+- `x-customer-id` : identifiant numérique de l'utilisateur.
+
+La réponse contient l'identifiant du snapshot créé, les filtres appliqués ainsi que
+les résultats bruts retournés par le provider.
+
+## Gestion des presets
+
+Le service permet de gérer des presets utilisateurs, avec suivi des favoris stocké via le
+`user-service`. Toutes les opérations requièrent les en-têtes `x-customer-id` et `Authorization`.
+
+### Lister les presets
+
+```
+GET /screener/presets
+```
+
+Retourne la liste des presets de l'utilisateur courant, avec un indicateur `favorite` basé sur les
+préférences récupérées via `user-service`.
+
+### Créer un preset
+
+```
+POST /screener/presets
+Content-Type: application/json
+{
+  "name": "Growth",
+  "filters": {"marketCapMoreThan": 1000000000},
+  "description": "Screener croissance",
+  "favorite": true
+}
+```
+
+- `favorite` optionnel permet d'enregistrer immédiatement le preset comme favori. Le quota
+  `limit.watchlists` des entitlements est appliqué.
+
+### Marquer un preset comme favori
+
+```
+POST /screener/presets/{preset_id}/favorite
+Content-Type: application/json
+{
+  "favorite": true
+}
+```
+
+Met à jour la liste des favoris dans `user-service` en respectant le quota `limit.watchlists`.
+
+### Tables persistées
+
+Les tables suivantes sont créées via les migrations Alembic :
+
+- `screener_presets` : définitions des presets utilisateurs.
+- `screener_snapshots` : historique des exécutions (filtres appliqués, provider, preset associé).
+- `screener_results` : résultats détaillés de chaque snapshot (ordre, score, payload brut).
+
+Chaque exécution `/screener/run` insère un snapshot et les résultats associés.
+
+## Tests
+
+Les tests unitaires du service utilisent des mocks HTTP pour le provider FMP et le `user-service`
+afin de vérifier la persistance des snapshots, l'application des quotas de favoris et les mises à jour
+de préférences.

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -8,6 +8,12 @@ from .entitlements_models import (
     PlanFeature,
     Subscription,
 )
+from .screener_models import (
+    ScreenerBase,
+    ScreenerPreset,
+    ScreenerResult,
+    ScreenerSnapshot,
+)
 
 __all__ = [
     "EntitlementsBase",
@@ -16,4 +22,8 @@ __all__ = [
     "Plan",
     "PlanFeature",
     "Subscription",
+    "ScreenerBase",
+    "ScreenerPreset",
+    "ScreenerResult",
+    "ScreenerSnapshot",
 ]

--- a/infra/migrations/versions/0003_screener.py
+++ b/infra/migrations/versions/0003_screener.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0003_screener"
+down_revision = "0002_market_data"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "screener_presets",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.Integer, nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("filters", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_screener_presets_user_id", "screener_presets", ["user_id"])
+
+    op.create_table(
+        "screener_snapshots",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.Integer, nullable=True),
+        sa.Column("preset_id", sa.Integer, sa.ForeignKey("screener_presets.id", ondelete="SET NULL")),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("filters", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_screener_snapshots_user_id", "screener_snapshots", ["user_id"])
+
+    op.create_table(
+        "screener_results",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("snapshot_id", sa.Integer, sa.ForeignKey("screener_snapshots.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("symbol", sa.String(length=32), nullable=False),
+        sa.Column("rank", sa.Integer, nullable=False),
+        sa.Column("score", sa.Float, nullable=True),
+        sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+    )
+    op.create_index("ix_screener_results_snapshot_id", "screener_results", ["snapshot_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_screener_results_snapshot_id", table_name="screener_results")
+    op.drop_table("screener_results")
+    op.drop_index("ix_screener_snapshots_user_id", table_name="screener_snapshots")
+    op.drop_table("screener_snapshots")
+    op.drop_index("ix_screener_presets_user_id", table_name="screener_presets")
+    op.drop_table("screener_presets")

--- a/infra/screener_models.py
+++ b/infra/screener_models.py
@@ -1,0 +1,65 @@
+"""SQLAlchemy models backing the screener service."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, JSON, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class ScreenerBase(DeclarativeBase):
+    """Declarative base for screener related tables."""
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ScreenerPreset(ScreenerBase):
+    __tablename__ = "screener_presets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(length=255))
+    filters: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, onupdate=_utcnow)
+
+    snapshots: Mapped[list["ScreenerSnapshot"]] = relationship(back_populates="preset")
+
+
+class ScreenerSnapshot(ScreenerBase):
+    __tablename__ = "screener_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    preset_id: Mapped[int | None] = mapped_column(ForeignKey("screener_presets.id", ondelete="SET NULL"))
+    provider: Mapped[str] = mapped_column(String(length=32), nullable=False)
+    filters: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+    preset: Mapped[Optional["ScreenerPreset"]] = relationship(back_populates="snapshots")
+    results: Mapped[list["ScreenerResult"]] = relationship(back_populates="snapshot", cascade="all, delete-orphan")
+
+
+class ScreenerResult(ScreenerBase):
+    __tablename__ = "screener_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    snapshot_id: Mapped[int] = mapped_column(ForeignKey("screener_snapshots.id", ondelete="CASCADE"), index=True)
+    symbol: Mapped[str] = mapped_column(String(length=32), nullable=False)
+    rank: Mapped[int] = mapped_column(Integer, nullable=False)
+    score: Mapped[float | None] = mapped_column(Float)
+    data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+
+    snapshot: Mapped[ScreenerSnapshot] = relationship(back_populates="results")
+
+
+__all__ = [
+    "ScreenerBase",
+    "ScreenerPreset",
+    "ScreenerSnapshot",
+    "ScreenerResult",
+]

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,0 +1,5 @@
+"""External market data providers used across services."""
+
+from .fmp import FinancialModelingPrepClient, FinancialModelingPrepError
+
+__all__ = ["FinancialModelingPrepClient", "FinancialModelingPrepError"]

--- a/providers/fmp.py
+++ b/providers/fmp.py
@@ -1,0 +1,73 @@
+"""Client for the Financial Modeling Prep screener API."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+import httpx
+
+
+class FinancialModelingPrepError(RuntimeError):
+    """Raised when the Financial Modeling Prep API answers with an error."""
+
+
+class FinancialModelingPrepClient:
+    """Lightweight async client dedicated to the screener endpoint."""
+
+    def __init__(
+        self,
+        api_key: Optional[str],
+        *,
+        base_url: str = "https://financialmodelingprep.com/api/v3",
+        timeout: float = 10.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._client = client
+        self.name = "fmp"
+
+    async def __aenter__(self) -> "FinancialModelingPrepClient":
+        if self._client is None:
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout)
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def screen(self, *, filters: Dict[str, Any] | None = None, limit: int = 50) -> list[dict[str, Any]]:
+        """Execute the screener endpoint with the provided filters."""
+
+        if self._client is None:
+            raise RuntimeError("Client must be used as an async context manager")
+        if not self._api_key:
+            raise FinancialModelingPrepError("Missing Financial Modeling Prep API key")
+
+        params: Dict[str, Any] = {"apikey": self._api_key, "limit": limit}
+        if filters:
+            for key, value in filters.items():
+                if value is None:
+                    continue
+                if isinstance(value, (list, tuple, set)):
+                    params[key] = ",".join(str(item) for item in value)
+                elif isinstance(value, bool):
+                    params[key] = json.dumps(value)
+                else:
+                    params[key] = value
+
+        response = await self._client.get("/stock-screener", params=params)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - straight passthrough
+            raise FinancialModelingPrepError(str(exc)) from exc
+
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise FinancialModelingPrepError("Unexpected response payload from FMP")
+        return [row if isinstance(row, dict) else {"value": row} for row in payload]
+
+
+__all__ = ["FinancialModelingPrepClient", "FinancialModelingPrepError"]

--- a/services/conftest.py
+++ b/services/conftest.py
@@ -21,5 +21,7 @@ if os.environ["DATABASE_URL"].startswith("sqlite"):
     Path(TEST_DB).touch()
 
 from infra import EntitlementsBase  # noqa: E402
+from infra import ScreenerBase  # noqa: E402
 
 EntitlementsBase.metadata.create_all(bind=db.engine)
+ScreenerBase.metadata.create_all(bind=db.engine)

--- a/services/screener/app/__init__.py
+++ b/services/screener/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for the screener service."""

--- a/services/screener/app/main.py
+++ b/services/screener/app/main.py
@@ -1,0 +1,326 @@
+"""FastAPI application exposing screener capabilities."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from infra import ScreenerPreset, ScreenerResult, ScreenerSnapshot
+from libs.db.db import get_db
+from libs.entitlements import install_entitlements_middleware
+from libs.entitlements.client import Entitlements
+from providers import FinancialModelingPrepClient, FinancialModelingPrepError
+
+from .schemas import (
+    ScreenerPresetCreate,
+    ScreenerPresetFavoriteUpdate,
+    ScreenerPresetOut,
+    ScreenerRunResponse,
+)
+
+app = FastAPI(title="Screener Service", version="0.1.0")
+install_entitlements_middleware(
+    app,
+    required_capabilities=["can.use_screener"],
+    required_quotas={},
+)
+
+
+async def get_fmp_client() -> FinancialModelingPrepClient:
+    base_url = os.getenv("FMP_BASE_URL", "https://financialmodelingprep.com/api/v3")
+    api_key = os.getenv("FMP_API_KEY")
+    client = FinancialModelingPrepClient(api_key=api_key, base_url=base_url)
+    async with client as session:
+        yield session
+
+
+class UserServiceClient:
+    """Minimal async client used to read and write user preferences."""
+
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = None
+
+    async def __aenter__(self) -> "UserServiceClient":
+        import httpx
+
+        self._client = httpx.AsyncClient(base_url=self._base_url, timeout=5.0)
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def get_preferences(self, authorization: str) -> dict[str, Any]:
+        if self._client is None:  # pragma: no cover - defensive
+            raise RuntimeError("UserServiceClient must be awaited as a context manager")
+        response = await self._client.get("/users/me", headers={"Authorization": authorization})
+        if response.status_code == 401:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized user")
+        response.raise_for_status()
+        payload = response.json()
+        return payload.get("preferences") or {}
+
+    async def update_preferences(self, authorization: str, preferences: dict[str, Any]) -> None:
+        if self._client is None:  # pragma: no cover - defensive
+            raise RuntimeError("UserServiceClient must be awaited as a context manager")
+        response = await self._client.put(
+            "/users/me/preferences",
+            headers={"Authorization": authorization},
+            json=preferences,
+        )
+        if response.status_code == 401:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized user")
+        response.raise_for_status()
+
+
+async def get_user_service_client() -> UserServiceClient:
+    base_url = os.getenv("USER_SERVICE_URL", "http://user-service:8000")
+    client = UserServiceClient(base_url)
+    async with client as session:
+        yield session
+
+
+def get_entitlements(request: Request) -> Entitlements:
+    entitlements = getattr(request.state, "entitlements", None)
+    if entitlements is None:
+        return Entitlements(customer_id="anonymous", features={}, quotas={})
+    return entitlements
+
+
+def require_authorization(authorization: str | None = Header(default=None)) -> str:
+    if not authorization:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
+    return authorization
+
+
+def require_customer_id(request: Request) -> int:
+    header_value = request.headers.get("x-customer-id") or request.headers.get("x-user-id")
+    if not header_value:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing x-customer-id header")
+    try:
+        return int(header_value)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid customer id") from exc
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+def _extract_filters(filters: str | None) -> dict[str, Any]:
+    if not filters:
+        return {}
+    try:
+        parsed = json.loads(filters)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid filters payload") from exc
+    if not isinstance(parsed, dict):
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Filters must be a JSON object")
+    return parsed
+
+
+def _preferences_favorites(preferences: dict[str, Any]) -> list[int]:
+    screener_section = preferences.get("screener") or {}
+    favorites = screener_section.get("favorites") or []
+    normalized: list[int] = []
+    for pid in favorites:
+        if isinstance(pid, int):
+            normalized.append(pid)
+        elif isinstance(pid, str) and pid.isdigit():
+            normalized.append(int(pid))
+    return normalized
+
+
+def _update_favorites(preferences: dict[str, Any], favorite_ids: list[int]) -> dict[str, Any]:
+    updated = dict(preferences)
+    screener_section = dict(updated.get("screener") or {})
+    screener_section["favorites"] = favorite_ids
+    updated["screener"] = screener_section
+    return updated
+
+
+def _ensure_quota(entitlements: Entitlements, desired: int) -> None:
+    limit = entitlements.quota("limit.watchlists")
+    if limit is not None and desired > limit:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Watchlist quota exceeded ({desired}/{limit})",
+        )
+
+
+@app.get("/screener/run", response_model=ScreenerRunResponse)
+async def run_screener(
+    request: Request,
+    provider: str = Query("fmp"),
+    limit: int = Query(50, ge=1, le=200),
+    preset_id: int | None = Query(default=None),
+    filters: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+    fmp_client: FinancialModelingPrepClient = Depends(get_fmp_client),
+) -> ScreenerRunResponse:
+    if provider != "fmp":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unsupported provider '{provider}'")
+
+    user_id = require_customer_id(request)
+
+    payload_filters: dict[str, Any] = {}
+    resolved_preset_id: int | None = None
+    if preset_id is not None:
+        preset = db.get(ScreenerPreset, preset_id)
+        if preset is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Preset not found")
+        if preset.user_id != user_id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Preset does not belong to the user")
+        payload_filters.update(preset.filters)
+        resolved_preset_id = preset.id
+
+    payload_filters.update(_extract_filters(filters))
+
+    try:
+        results = await fmp_client.screen(filters=payload_filters, limit=limit)
+    except FinancialModelingPrepError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+    snapshot = ScreenerSnapshot(user_id=user_id, preset_id=resolved_preset_id, provider=provider, filters=payload_filters)
+    db.add(snapshot)
+    db.flush()
+
+    for index, row in enumerate(results, start=1):
+        symbol = row.get("symbol") or row.get("ticker") or ""
+        if not symbol:
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Provider response missing symbol")
+        result = ScreenerResult(
+            snapshot_id=snapshot.id,
+            symbol=symbol,
+            rank=index,
+            score=row.get("score"),
+            data=row,
+        )
+        db.add(result)
+
+    db.commit()
+
+    return ScreenerRunResponse(
+        snapshot_id=snapshot.id,
+        provider=provider,
+        preset_id=resolved_preset_id,
+        filters=payload_filters,
+        results=results,
+    )
+
+
+@app.get("/screener/presets", response_model=list[ScreenerPresetOut])
+async def list_presets(
+    request: Request,
+    authorization: str = Depends(require_authorization),
+    user_client: UserServiceClient = Depends(get_user_service_client),
+    db: Session = Depends(get_db),
+) -> list[ScreenerPresetOut]:
+    user_id = require_customer_id(request)
+
+    preferences = await user_client.get_preferences(authorization)
+    favorites = set(_preferences_favorites(preferences))
+
+    presets = db.scalars(select(ScreenerPreset).where(ScreenerPreset.user_id == user_id).order_by(ScreenerPreset.created_at.desc())).all()
+
+    response: list[ScreenerPresetOut] = []
+    for preset in presets:
+        response.append(
+            ScreenerPresetOut(
+                id=preset.id,
+                name=preset.name,
+                description=preset.description,
+                filters=preset.filters,
+                favorite=preset.id in favorites,
+                created_at=preset.created_at,
+            )
+        )
+
+    return response
+
+
+@app.post("/screener/presets", response_model=ScreenerPresetOut, status_code=status.HTTP_201_CREATED)
+async def create_preset(
+    request: Request,
+    payload: ScreenerPresetCreate,
+    authorization: str = Depends(require_authorization),
+    user_client: UserServiceClient = Depends(get_user_service_client),
+    entitlements: Entitlements = Depends(get_entitlements),
+    db: Session = Depends(get_db),
+) -> ScreenerPresetOut:
+    user_id = require_customer_id(request)
+
+    preset = ScreenerPreset(
+        user_id=user_id,
+        name=payload.name,
+        description=payload.description,
+        filters=payload.filters,
+    )
+    db.add(preset)
+    db.flush()
+
+    preferences = await user_client.get_preferences(authorization)
+    favorites = set(_preferences_favorites(preferences))
+
+    if payload.favorite:
+        favorites.add(preset.id)
+        _ensure_quota(entitlements, len(favorites))
+        updated_preferences = _update_favorites(preferences, sorted(favorites))
+        await user_client.update_preferences(authorization, updated_preferences)
+
+    db.commit()
+
+    return ScreenerPresetOut(
+        id=preset.id,
+        name=preset.name,
+        description=preset.description,
+        filters=preset.filters,
+        favorite=preset.id in favorites,
+        created_at=preset.created_at,
+    )
+
+
+@app.post("/screener/presets/{preset_id}/favorite", response_model=ScreenerPresetOut)
+async def toggle_favorite(
+    request: Request,
+    preset_id: int,
+    payload: ScreenerPresetFavoriteUpdate,
+    authorization: str = Depends(require_authorization),
+    user_client: UserServiceClient = Depends(get_user_service_client),
+    entitlements: Entitlements = Depends(get_entitlements),
+    db: Session = Depends(get_db),
+) -> ScreenerPresetOut:
+    user_id = require_customer_id(request)
+    preset = db.get(ScreenerPreset, preset_id)
+    if preset is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Preset not found")
+    if preset.user_id != user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Preset does not belong to the user")
+
+    preferences = await user_client.get_preferences(authorization)
+    favorites = set(_preferences_favorites(preferences))
+
+    if payload.favorite:
+        favorites.add(preset.id)
+        _ensure_quota(entitlements, len(favorites))
+    else:
+        favorites.discard(preset.id)
+
+    updated_preferences = _update_favorites(preferences, sorted(favorites))
+    await user_client.update_preferences(authorization, updated_preferences)
+
+    return ScreenerPresetOut(
+        id=preset.id,
+        name=preset.name,
+        description=preset.description,
+        filters=preset.filters,
+        favorite=preset.id in favorites,
+        created_at=preset.created_at,
+    )

--- a/services/screener/app/schemas.py
+++ b/services/screener/app/schemas.py
@@ -1,0 +1,44 @@
+"""Pydantic models exposed by the screener API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class ScreenerResultPayload(BaseModel):
+    symbol: str | None = None
+    rank: int
+    score: float | None = None
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ScreenerRunResponse(BaseModel):
+    snapshot_id: int
+    provider: str
+    preset_id: int | None = None
+    filters: dict[str, Any]
+    results: list[dict[str, Any]]
+
+
+class ScreenerPresetOut(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+    filters: dict[str, Any]
+    favorite: bool = False
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ScreenerPresetCreate(BaseModel):
+    name: str
+    filters: dict[str, Any]
+    description: str | None = None
+    favorite: bool = False
+
+
+class ScreenerPresetFavoriteUpdate(BaseModel):
+    favorite: bool

--- a/services/screener/requirements-dev.txt
+++ b/services/screener/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+pytest-asyncio

--- a/services/screener/requirements.txt
+++ b/services/screener/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+SQLAlchemy>=2
+httpx
+pydantic>=2

--- a/services/screener/tests/test_screener_service.py
+++ b/services/screener/tests/test_screener_service.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from infra import ScreenerPreset, ScreenerResult, ScreenerSnapshot
+from libs.db import db
+from libs.entitlements.client import Entitlements
+from services.screener.app.main import (
+    app,
+    get_entitlements,
+    get_fmp_client,
+    get_user_service_client,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def disable_entitlements_middleware() -> None:
+    """Remove the entitlements middleware for isolated unit tests."""
+
+    app.user_middleware = [mw for mw in app.user_middleware if mw.cls.__name__ != "EntitlementsMiddleware"]
+    app.middleware_stack = app.build_middleware_stack()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_db() -> Iterator[None]:
+    """Ensure the screener tables are empty before each test."""
+
+    yield
+    with db.SessionLocal() as session:
+        session.query(ScreenerResult).delete()
+        session.query(ScreenerSnapshot).delete()
+        session.query(ScreenerPreset).delete()
+        session.commit()
+
+
+class DummyProvider:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def screen(self, *, filters: dict[str, Any] | None = None, limit: int = 50) -> list[dict[str, Any]]:
+        payload = {
+            "filters": filters or {},
+            "limit": limit,
+        }
+        self.calls.append(payload)
+        return [
+            {"symbol": "AAPL", "score": 0.91, "sector": "Technology"},
+            {"symbol": "MSFT", "score": 0.87, "sector": "Technology"},
+        ]
+
+
+@dataclass
+class DummyUserService:
+    preferences: dict[str, Any] | None = None
+
+    async def __aenter__(self) -> "DummyUserService":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def get_preferences(self, authorization: str) -> dict[str, Any]:  # noqa: ARG002 - signature compatibility
+        return self.preferences or {}
+
+    async def update_preferences(self, authorization: str, preferences: dict[str, Any]) -> None:  # noqa: ARG002
+        self.preferences = preferences
+
+
+@pytest.fixture
+def dummy_provider() -> DummyProvider:
+    provider = DummyProvider()
+
+    async def dependency_override() -> AsyncGenerator[DummyProvider, None]:
+        yield provider
+
+    app.dependency_overrides[get_fmp_client] = dependency_override
+    yield provider
+    app.dependency_overrides.pop(get_fmp_client, None)
+
+
+@pytest.fixture
+def dummy_user_service() -> DummyUserService:
+    client = DummyUserService()
+
+    async def dependency_override() -> AsyncGenerator[DummyUserService, None]:
+        async with client as session:
+            yield session
+
+    app.dependency_overrides[get_user_service_client] = dependency_override
+    yield client
+    app.dependency_overrides.pop(get_user_service_client, None)
+
+
+@pytest.fixture
+def entitlements_limit_one() -> None:
+    entitlements = Entitlements(customer_id="1", features={}, quotas={"limit.watchlists": 1})
+
+    def dependency_override(request: Request) -> Entitlements:  # noqa: ARG001
+        return entitlements
+
+    app.dependency_overrides[get_entitlements] = dependency_override
+    yield
+    app.dependency_overrides.pop(get_entitlements, None)
+
+
+def _auth_headers() -> dict[str, str]:
+    return {
+        "x-customer-id": "1",
+        "Authorization": "Bearer test-token",
+    }
+
+
+def test_run_screener_creates_snapshot(dummy_provider: DummyProvider, dummy_user_service: DummyUserService) -> None:
+    with TestClient(app) as client:
+        response = client.get("/screener/run", headers={"x-customer-id": "1"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["provider"] == "fmp"
+    assert payload["results"][0]["symbol"] == "AAPL"
+    assert dummy_provider.calls[0]["limit"] == 50
+
+    with db.SessionLocal() as session:
+        snapshot_count = session.query(ScreenerSnapshot).count()
+        results_count = session.query(ScreenerResult).count()
+    assert snapshot_count == 1
+    assert results_count == 2
+
+
+def test_create_preset_with_favorite_enforces_quota(
+    dummy_provider: DummyProvider,
+    dummy_user_service: DummyUserService,
+    entitlements_limit_one: None,
+) -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/screener/presets",
+            json={"name": "Growth", "filters": {"sector": "Technology"}, "favorite": True},
+            headers=_auth_headers(),
+        )
+        assert response.status_code == 201, response.text
+
+        response = client.post(
+            "/screener/presets",
+            json={"name": "Value", "filters": {"sector": "Financial"}, "favorite": True},
+            headers=_auth_headers(),
+        )
+        assert response.status_code == 403
+        assert "quota" in response.json()["detail"].lower()
+
+    assert dummy_user_service.preferences is not None
+    assert dummy_user_service.preferences["screener"]["favorites"]
+
+
+def test_toggle_favorite_updates_preferences(
+    dummy_provider: DummyProvider,
+    dummy_user_service: DummyUserService,
+    entitlements_limit_one: None,
+) -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/screener/presets",
+            json={"name": "Momentum", "filters": {"betaMoreThan": 1.0}},
+            headers=_auth_headers(),
+        )
+        assert response.status_code == 201, response.text
+        preset_id = response.json()["id"]
+
+        response = client.post(
+            f"/screener/presets/{preset_id}/favorite",
+            json={"favorite": True},
+            headers=_auth_headers(),
+        )
+        assert response.status_code == 200
+        assert response.json()["favorite"] is True
+
+        response = client.post(
+            f"/screener/presets/{preset_id}/favorite",
+            json={"favorite": False},
+            headers=_auth_headers(),
+        )
+        assert response.status_code == 200
+        assert response.json()["favorite"] is False
+
+    assert dummy_user_service.preferences is not None
+    assert dummy_user_service.preferences["screener"]["favorites"] == []


### PR DESCRIPTION
## Summary
- add a FastAPI screener service with Financial Modeling Prep integration, user presets, and entitlement-aware favorites
- add shared SQLAlchemy models plus Alembic migrations for screener snapshots, presets, and results
- document the new API surface and cover it with unit tests that mock the provider and user-service

## Testing
- pytest services/screener/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d7ca8298288332ad11263206a0ddd6