### PR TITLE
feat: add marketplace and social services

### DIFF
--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -1,0 +1,74 @@
+# Marketplace Service
+
+The marketplace service exposes APIs to publish algorithmic strategies and to
+manage copy-trading subscriptions. It relies on the shared entitlements service
+for access control and records all actions in the global audit trail.
+
+## Database schema
+
+| Table | Description |
+| --- | --- |
+| `marketplace_listings` | Published strategies (owner, pricing, Stripe Connect account). |
+| `marketplace_versions` | Immutable payloads for each listing version. |
+| `marketplace_subscriptions` | Copy-trading subscriptions referencing listings and versions. |
+| `audit_logs` | Shared audit trail recording marketplace events. |
+
+## Stripe Connect integration
+
+Publishing a listing requires the creator to provide their Stripe Connect
+account identifier (`connect_account_id`). This enables automated revenue
+sharing when investors subscribe to the listing.
+
+## Entitlements
+
+Capabilities are resolved through the entitlements middleware:
+
+- `can.publish_strategy` – required to publish or update listings.
+- `can.copy_trade` – required to subscribe to a listing or view copies.
+
+Requests must include an `X-User-Id` header (or `X-Customer-Id`) so the
+middleware can resolve entitlements.
+
+## REST API
+
+All endpoints are served from the `/marketplace` prefix.
+
+### `POST /marketplace/listings`
+Publish a new listing.
+
+```json
+{
+  "strategy_name": "Momentum Edge",
+  "description": "Breakout strategy",
+  "price_cents": 19900,
+  "currency": "USD",
+  "connect_account_id": "acct_123",
+  "initial_version": {
+    "version": "1.0.0",
+    "configuration": {"risk": 2}
+  }
+}
+```
+
+Returns the created listing with the current versions.
+
+### `GET /marketplace/listings`
+Browse published listings. Returns the latest version metadata for each entry.
+
+### `POST /marketplace/listings/{listing_id}/versions`
+Publish a new version for an existing listing. Only the owner can perform this
+operation.
+
+### `POST /marketplace/copies`
+Create a copy-trading subscription. Optional `payment_reference` allows linking
+to Stripe payment intents.
+
+### `GET /marketplace/copies`
+Return the subscriptions owned by the authenticated investor. Each read
+operation is recorded to the audit trail.
+
+## Audit trail
+
+All state changes (listing publication, version releases, copy subscriptions and
+copy views) are inserted into `audit_logs`. This provides a central trace of
+monetisation events for compliance and revenue reconciliation.

--- a/docs/social.md
+++ b/docs/social.md
@@ -1,0 +1,60 @@
+# Social Service
+
+The social service powers public profiles, follow relationships, activity feeds
+and performance leaderboards. Access is mediated through entitlements and every
+state change is persisted to the shared audit trail.
+
+## Database schema
+
+| Table | Description |
+| --- | --- |
+| `social_profiles` | Public profile for each user (display name, bio, visibility). |
+| `social_follows` | Directed follow relationships between users. |
+| `social_activities` | Activity feed entries (follow events, manual posts, etc.). |
+| `social_leaderboards` | Snapshots of curated leaderboards. |
+| `audit_logs` | Central audit trail storing social events. |
+
+## Entitlements
+
+- `can.publish_strategy` – required to manage your profile, post activities and
+  maintain leaderboards.
+- `can.copy_trade` – required to follow another profile.
+
+The FastAPI app expects an `X-User-Id` (or `X-Customer-Id`) header to map
+requests to entitlements.
+
+## REST API
+
+All endpoints live under the `/social` prefix.
+
+### Profiles
+
+- `PUT /social/profiles/me` — create or update the authenticated user's public
+  profile.
+- `GET /social/profiles/{user_id}` — fetch a public profile. Private profiles are
+  hidden unless requested by their owner.
+
+### Follows
+
+`POST /social/follows` toggles follow status. Set `{"follow": false}` to
+unfollow. Follow actions automatically emit both activity feed entries and audit
+logs.
+
+### Activity feed
+
+- `POST /social/activities` — create a custom activity entry (for example a
+  shared trade or a milestone).
+- `GET /social/activities` — fetch the latest activities for the authenticated
+  user and the profiles they follow. The `limit` query parameter constrains the
+  number of results (default 20).
+
+### Leaderboards
+
+- `PUT /social/leaderboards/{slug}` — create or refresh a leaderboard snapshot.
+- `GET /social/leaderboards/{slug}` — retrieve an existing leaderboard.
+
+## Audit trail
+
+Profile updates, follow/unfollow events, activity posts and leaderboard changes
+write to `audit_logs`. The audit entries capture the service name, action code,
+actors and contextual metadata to make compliance reviews simple.

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -1,5 +1,6 @@
 """Infrastructure helpers for the monorepo."""
 
+from .audit_models import Base as AuditBase, AuditLog
 from .entitlements_models import (
     Base as EntitlementsBase,
     EntitlementsCache,
@@ -8,22 +9,40 @@ from .entitlements_models import (
     PlanFeature,
     Subscription,
 )
+from .marketplace_models import (
+    Base as MarketplaceBase,
+    Listing,
+    ListingVersion,
+    MarketplaceSubscription,
+)
 from .screener_models import (
     ScreenerBase,
     ScreenerPreset,
     ScreenerResult,
     ScreenerSnapshot,
 )
+from .social_models import Base as SocialBase, Activity, Follow, Leaderboard, Profile
 
 __all__ = [
+    "AuditBase",
+    "AuditLog",
     "EntitlementsBase",
     "EntitlementsCache",
     "Feature",
     "Plan",
     "PlanFeature",
     "Subscription",
+    "MarketplaceBase",
+    "Listing",
+    "ListingVersion",
+    "MarketplaceSubscription",
     "ScreenerBase",
     "ScreenerPreset",
     "ScreenerResult",
     "ScreenerSnapshot",
+    "SocialBase",
+    "Activity",
+    "Follow",
+    "Leaderboard",
+    "Profile",
 ]

--- a/infra/audit_models.py
+++ b/infra/audit_models.py
@@ -1,0 +1,28 @@
+"""Reusable audit trail models shared across services."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from sqlalchemy import JSON, Column, DateTime, Integer, String, Text, func
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+
+class AuditLog(Base):
+    """Represents an audit log entry tracking user actions."""
+
+    __tablename__ = "audit_logs"
+
+    id: int = Column(Integer, primary_key=True)
+    service: str = Column(String(64), nullable=False, index=True)
+    action: str = Column(String(64), nullable=False)
+    actor_id: str = Column(String(64), nullable=False, index=True)
+    subject_id: Optional[str] = Column(String(64), nullable=True, index=True)
+    details: Dict[str, object] = Column(JSON, nullable=False, default=dict)
+    message: Optional[str] = Column(Text)
+    created_at: datetime = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+
+__all__ = ["Base", "AuditLog"]

--- a/infra/marketplace_models.py
+++ b/infra/marketplace_models.py
@@ -1,0 +1,113 @@
+"""SQLAlchemy models powering the marketplace service."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class Listing(Base):
+    """A strategy that can be published to the marketplace."""
+
+    __tablename__ = "marketplace_listings"
+
+    id: int = Column(Integer, primary_key=True)
+    owner_id: str = Column(String(64), nullable=False, index=True)
+    strategy_name: str = Column(String(128), nullable=False)
+    description: Optional[str] = Column(Text)
+    price_cents: int = Column(Integer, nullable=False)
+    currency: str = Column(String(3), nullable=False, default="USD")
+    connect_account_id: str = Column(String(64), nullable=False)
+    status: str = Column(String(16), nullable=False, default="published")
+    created_at: datetime = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at: datetime = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    versions = relationship(
+        "ListingVersion",
+        back_populates="listing",
+        cascade="all, delete-orphan",
+        order_by="ListingVersion.created_at.desc()",
+    )
+    subscriptions = relationship(
+        "MarketplaceSubscription",
+        back_populates="listing",
+        cascade="all, delete-orphan",
+    )
+
+
+class ListingVersion(Base):
+    """Immutable payload representing a published version of a listing."""
+
+    __tablename__ = "marketplace_versions"
+
+    id: int = Column(Integer, primary_key=True)
+    listing_id: int = Column(
+        Integer,
+        ForeignKey("marketplace_listings.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    version: str = Column(String(32), nullable=False, default="1.0.0")
+    changelog: Optional[str] = Column(Text)
+    configuration: Dict[str, object] = Column(JSON, nullable=False, default=dict)
+    is_published: bool = Column(Boolean, nullable=False, default=True)
+    created_at: datetime = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    listing = relationship("Listing", back_populates="versions")
+
+    __table_args__ = (
+        UniqueConstraint("listing_id", "version", name="uq_listing_version"),
+    )
+
+
+class MarketplaceSubscription(Base):
+    """Represents an investor copying a strategy from the marketplace."""
+
+    __tablename__ = "marketplace_subscriptions"
+
+    id: int = Column(Integer, primary_key=True)
+    listing_id: int = Column(
+        Integer,
+        ForeignKey("marketplace_listings.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    subscriber_id: str = Column(String(64), nullable=False, index=True)
+    version_id: Optional[int] = Column(
+        Integer,
+        ForeignKey("marketplace_versions.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    payment_reference: Optional[str] = Column(String(128))
+    status: str = Column(String(16), nullable=False, default="active")
+    created_at: datetime = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    listing = relationship("Listing", back_populates="subscriptions")
+    version = relationship("ListingVersion")
+
+    __table_args__ = (
+        UniqueConstraint("listing_id", "subscriber_id", name="uq_listing_subscriber"),
+    )
+
+
+__all__ = ["Base", "Listing", "ListingVersion", "MarketplaceSubscription"]

--- a/infra/social_models.py
+++ b/infra/social_models.py
@@ -1,0 +1,94 @@
+"""SQLAlchemy models for social features (profiles, follows, leaderboards)."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class Profile(Base):
+    """Public profile for a strategy creator or investor."""
+
+    __tablename__ = "social_profiles"
+
+    id: int = Column(Integer, primary_key=True)
+    user_id: str = Column(String(64), nullable=False, unique=True, index=True)
+    display_name: str = Column(String(128), nullable=False)
+    bio: Optional[str] = Column(Text)
+    avatar_url: Optional[str] = Column(String(255))
+    is_public: bool = Column(Boolean, nullable=False, default=True)
+    created_at: datetime = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at: datetime = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    activities = relationship("Activity", back_populates="profile", cascade="all, delete-orphan")
+
+
+class Follow(Base):
+    """Following relationship between two profiles."""
+
+    __tablename__ = "social_follows"
+
+    id: int = Column(Integer, primary_key=True)
+    follower_id: str = Column(String(64), nullable=False, index=True)
+    followee_id: str = Column(String(64), nullable=False, index=True)
+    created_at: datetime = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("follower_id", "followee_id", name="uq_social_follow"),
+    )
+
+
+class Activity(Base):
+    """Activity item displayed in feeds."""
+
+    __tablename__ = "social_activities"
+
+    id: int = Column(Integer, primary_key=True)
+    profile_id: int = Column(
+        Integer,
+        ForeignKey("social_profiles.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    activity_type: str = Column(String(64), nullable=False)
+    data: Dict[str, object] = Column(JSON, nullable=False, default=dict)
+    created_at: datetime = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    profile = relationship("Profile", back_populates="activities")
+
+
+class Leaderboard(Base):
+    """Leaderboard snapshots used for discovery."""
+
+    __tablename__ = "social_leaderboards"
+
+    id: int = Column(Integer, primary_key=True)
+    slug: str = Column(String(64), nullable=False, unique=True)
+    title: str = Column(String(128), nullable=False)
+    metric: str = Column(String(64), nullable=False)
+    period: str = Column(String(32), nullable=False, default="all")
+    data: Dict[str, object] = Column(JSON, nullable=False, default=dict)
+    generated_at: datetime = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+
+__all__ = ["Base", "Profile", "Follow", "Activity", "Leaderboard"]

--- a/libs/audit/__init__.py
+++ b/libs/audit/__init__.py
@@ -1,0 +1,36 @@
+"""Helpers to record audit trail events."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from infra import AuditLog
+
+
+def record_audit(
+    db: Session,
+    *,
+    service: str,
+    action: str,
+    actor_id: str,
+    subject_id: Optional[str] = None,
+    details: Optional[Dict[str, Any]] = None,
+    message: Optional[str] = None,
+) -> AuditLog:
+    """Persist an :class:`AuditLog` entry and return it."""
+
+    entry = AuditLog(
+        service=service,
+        action=action,
+        actor_id=actor_id,
+        subject_id=subject_id,
+        details=details or {},
+        message=message,
+    )
+    db.add(entry)
+    db.flush()
+    return entry
+
+
+__all__ = ["record_audit"]

--- a/services/conftest.py
+++ b/services/conftest.py
@@ -20,8 +20,16 @@ if str(db.engine.url) != os.environ["DATABASE_URL"]:
 if os.environ["DATABASE_URL"].startswith("sqlite"):
     Path(TEST_DB).touch()
 
-from infra import EntitlementsBase  # noqa: E402
-from infra import ScreenerBase  # noqa: E402
+from infra import (  # noqa: E402
+    AuditBase,
+    EntitlementsBase,
+    MarketplaceBase,
+    ScreenerBase,
+    SocialBase,
+)
 
 EntitlementsBase.metadata.create_all(bind=db.engine)
 ScreenerBase.metadata.create_all(bind=db.engine)
+MarketplaceBase.metadata.create_all(bind=db.engine)
+SocialBase.metadata.create_all(bind=db.engine)
+AuditBase.metadata.create_all(bind=db.engine)

--- a/services/marketplace/app/dependencies.py
+++ b/services/marketplace/app/dependencies.py
@@ -1,0 +1,40 @@
+"""Dependency helpers for the marketplace service."""
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request
+
+from libs.entitlements.client import Entitlements
+
+
+def get_entitlements(request: Request) -> Entitlements:
+    entitlements = getattr(request.state, "entitlements", None)
+    if entitlements is None:
+        raise HTTPException(status_code=403, detail="Entitlements are required")
+    return entitlements
+
+
+def require_publish_capability(entitlements: Entitlements = Depends(get_entitlements)) -> Entitlements:
+    if not entitlements.has("can.publish_strategy"):
+        raise HTTPException(status_code=403, detail="Missing capability: can.publish_strategy")
+    return entitlements
+
+
+def require_copy_capability(entitlements: Entitlements = Depends(get_entitlements)) -> Entitlements:
+    if not entitlements.has("can.copy_trade"):
+        raise HTTPException(status_code=403, detail="Missing capability: can.copy_trade")
+    return entitlements
+
+
+def get_actor_id(request: Request) -> str:
+    actor_id = request.headers.get("x-user-id") or request.headers.get("x-customer-id")
+    if not actor_id:
+        raise HTTPException(status_code=400, detail="Missing x-user-id header")
+    return actor_id
+
+
+__all__ = [
+    "get_entitlements",
+    "require_publish_capability",
+    "require_copy_capability",
+    "get_actor_id",
+]

--- a/services/marketplace/app/main.py
+++ b/services/marketplace/app/main.py
@@ -1,0 +1,100 @@
+"""FastAPI application exposing the marketplace service."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, FastAPI
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from infra import AuditBase, MarketplaceBase, MarketplaceSubscription
+from libs.audit import record_audit
+from libs.db.db import engine, get_db
+from libs.entitlements.fastapi import install_entitlements_middleware
+
+from .dependencies import (
+    get_actor_id,
+    get_entitlements,
+    require_copy_capability,
+    require_publish_capability,
+)
+from .schemas import CopyRequest, CopyResponse, ListingCreate, ListingOut, ListingVersionRequest
+from .service import add_version, create_listing, create_subscription, get_listing, list_listings
+
+app = FastAPI(title="Marketplace Service", version="0.1.0")
+
+MarketplaceBase.metadata.create_all(bind=engine)
+AuditBase.metadata.create_all(bind=engine)
+
+install_entitlements_middleware(app)
+
+router = APIRouter(prefix="/marketplace", tags=["marketplace"])
+
+
+@router.post("/listings", response_model=ListingOut, status_code=201)
+def publish_listing(
+    payload: ListingCreate,
+    db: Session = Depends(get_db),
+    actor_id: str = Depends(get_actor_id),
+    _: object = Depends(require_publish_capability),
+):
+    listing = create_listing(db, owner_id=actor_id, payload=payload)
+    return ListingOut.model_validate(listing)
+
+
+@router.get("/listings", response_model=list[ListingOut])
+def browse_listings(db: Session = Depends(get_db)):
+    listings = list_listings(db)
+    return [ListingOut.model_validate(obj) for obj in listings]
+
+
+@router.post("/listings/{listing_id}/versions", response_model=ListingOut)
+def publish_version(
+    listing_id: int,
+    payload: ListingVersionRequest,
+    db: Session = Depends(get_db),
+    actor_id: str = Depends(get_actor_id),
+    _: object = Depends(require_publish_capability),
+):
+    listing = get_listing(db, listing_id)
+    add_version(db, listing=listing, payload=payload, actor_id=actor_id)
+    db.refresh(listing)
+    return ListingOut.model_validate(listing)
+
+
+@router.post("/copies", response_model=CopyResponse, status_code=201)
+def copy_strategy(
+    payload: CopyRequest,
+    db: Session = Depends(get_db),
+    actor_id: str = Depends(get_actor_id),
+    _: object = Depends(require_copy_capability),
+):
+    subscription = create_subscription(db, actor_id=actor_id, payload=payload)
+    return CopyResponse.model_validate(subscription)
+
+
+@router.get("/copies", response_model=list[CopyResponse])
+def my_copies(
+    db: Session = Depends(get_db),
+    actor_id: str = Depends(get_actor_id),
+    _: object = Depends(get_entitlements),
+):
+    stmt = select(MarketplaceSubscription).where(MarketplaceSubscription.subscriber_id == actor_id)
+    subscriptions = db.scalars(stmt).all()
+    for sub in subscriptions:
+        record_audit(
+            db,
+            service="marketplace",
+            action="listing.copy.viewed",
+            actor_id=actor_id,
+            subject_id=str(sub.listing_id),
+            details={"subscription_id": sub.id},
+        )
+    db.commit()
+    return [CopyResponse.model_validate(sub) for sub in subscriptions]
+
+
+app.include_router(router)
+
+
+@app.get("/health")
+def healthcheck():
+    return {"status": "ok"}

--- a/services/marketplace/app/schemas.py
+++ b/services/marketplace/app/schemas.py
@@ -1,0 +1,73 @@
+"""Pydantic models exposed by the marketplace API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ListingVersionCreate(BaseModel):
+    version: str = Field(default="1.0.0", max_length=32)
+    configuration: Dict[str, Any] = Field(default_factory=dict)
+    changelog: Optional[str] = None
+
+
+class ListingCreate(BaseModel):
+    strategy_name: str = Field(max_length=128)
+    description: Optional[str] = None
+    price_cents: int = Field(ge=0)
+    currency: str = Field(default="USD", max_length=3)
+    connect_account_id: str = Field(max_length=64)
+    initial_version: Optional[ListingVersionCreate] = None
+
+
+class ListingVersionOut(BaseModel):
+    id: int
+    version: str
+    changelog: Optional[str]
+    configuration: Dict[str, Any]
+    is_published: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ListingOut(BaseModel):
+    id: int
+    owner_id: str
+    strategy_name: str
+    description: Optional[str]
+    price_cents: int
+    currency: str
+    connect_account_id: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    versions: list[ListingVersionOut] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ListingVersionRequest(BaseModel):
+    version: str = Field(max_length=32)
+    configuration: Dict[str, Any] = Field(default_factory=dict)
+    changelog: Optional[str] = None
+
+
+class CopyRequest(BaseModel):
+    listing_id: int
+    version_id: Optional[int] = None
+    payment_reference: Optional[str] = Field(default=None, max_length=128)
+
+
+class CopyResponse(BaseModel):
+    id: int
+    listing_id: int
+    subscriber_id: str
+    version_id: Optional[int]
+    payment_reference: Optional[str]
+    status: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/services/marketplace/app/service.py
+++ b/services/marketplace/app/service.py
@@ -1,0 +1,148 @@
+"""Domain logic for the marketplace API."""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from infra import Listing, ListingVersion, MarketplaceSubscription
+from libs.audit import record_audit
+
+from .schemas import CopyRequest, ListingCreate, ListingVersionRequest
+
+
+def create_listing(db: Session, *, owner_id: str, payload: ListingCreate) -> Listing:
+    listing = Listing(
+        owner_id=owner_id,
+        strategy_name=payload.strategy_name,
+        description=payload.description,
+        price_cents=payload.price_cents,
+        currency=payload.currency.upper(),
+        connect_account_id=payload.connect_account_id,
+    )
+    db.add(listing)
+    db.flush()
+
+    if payload.initial_version:
+        version_payload = payload.initial_version
+        listing.versions.append(
+            ListingVersion(
+                version=version_payload.version,
+                configuration=version_payload.configuration,
+                changelog=version_payload.changelog,
+            )
+        )
+
+    record_audit(
+        db,
+        service="marketplace",
+        action="listing.created",
+        actor_id=owner_id,
+        subject_id=str(listing.id),
+        details={
+            "strategy_name": listing.strategy_name,
+            "price_cents": listing.price_cents,
+            "currency": listing.currency,
+        },
+    )
+    db.commit()
+    db.refresh(listing)
+    return listing
+
+
+def add_version(db: Session, *, listing: Listing, payload: ListingVersionRequest, actor_id: str) -> ListingVersion:
+    if listing.owner_id != actor_id:
+        raise HTTPException(status_code=403, detail="Only the owner can publish a new version")
+
+    version = ListingVersion(
+        listing=listing,
+        version=payload.version,
+        configuration=payload.configuration,
+        changelog=payload.changelog,
+    )
+    db.add(version)
+    db.flush()
+
+    record_audit(
+        db,
+        service="marketplace",
+        action="listing.version.published",
+        actor_id=actor_id,
+        subject_id=str(listing.id),
+        details={"version": version.version},
+    )
+    db.commit()
+    db.refresh(version)
+    return version
+
+
+def list_listings(db: Session) -> list[Listing]:
+    stmt = select(Listing).options(selectinload(Listing.versions)).order_by(Listing.created_at.desc())
+    return db.scalars(stmt).all()
+
+
+def get_listing(db: Session, listing_id: int) -> Listing:
+    listing = db.scalar(
+        select(Listing)
+        .where(Listing.id == listing_id)
+        .options(selectinload(Listing.versions))
+    )
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    return listing
+
+
+def create_subscription(
+    db: Session,
+    *,
+    actor_id: str,
+    payload: CopyRequest,
+) -> MarketplaceSubscription:
+    listing = get_listing(db, payload.listing_id)
+
+    if listing.owner_id == actor_id:
+        raise HTTPException(status_code=400, detail="Creators cannot subscribe to their own strategy")
+
+    existing = db.scalar(
+        select(MarketplaceSubscription).where(
+            MarketplaceSubscription.listing_id == payload.listing_id,
+            MarketplaceSubscription.subscriber_id == actor_id,
+        )
+    )
+    if existing and existing.status == "active":
+        raise HTTPException(status_code=409, detail="Subscription already active")
+
+    version: Optional[ListingVersion] = None
+    if payload.version_id:
+        version = db.get(ListingVersion, payload.version_id)
+        if not version or version.listing_id != listing.id:
+            raise HTTPException(status_code=400, detail="Version does not belong to listing")
+    else:
+        version = listing.versions[0] if listing.versions else None
+
+    subscription = MarketplaceSubscription(
+        listing=listing,
+        subscriber_id=actor_id,
+        version=version,
+        payment_reference=payload.payment_reference,
+    )
+    db.add(subscription)
+    db.flush()
+
+    record_audit(
+        db,
+        service="marketplace",
+        action="listing.copied",
+        actor_id=actor_id,
+        subject_id=str(listing.id),
+        details={
+            "subscription_id": subscription.id,
+            "version_id": subscription.version_id,
+            "payment_reference": payload.payment_reference,
+        },
+    )
+    db.commit()
+    db.refresh(subscription)
+    return subscription

--- a/services/marketplace/tests/test_marketplace_service.py
+++ b/services/marketplace/tests/test_marketplace_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from infra import AuditLog, Listing, ListingVersion, MarketplaceSubscription
+from libs.db.db import SessionLocal
+from libs.entitlements.client import Entitlements
+
+from services.marketplace.app.dependencies import get_entitlements
+from services.marketplace.app.main import app
+
+client = TestClient(app)
+
+@pytest.fixture(scope="module", autouse=True)
+def disable_entitlements_middleware() -> None:
+    app.user_middleware = [mw for mw in app.user_middleware if mw.cls.__name__ != "EntitlementsMiddleware"]
+    app.middleware_stack = app.build_middleware_stack()
+
+
+
+def _clear_marketplace_tables(db: Session) -> None:
+    db.execute(delete(MarketplaceSubscription))
+    db.execute(delete(ListingVersion))
+    db.execute(delete(Listing))
+    db.execute(delete(AuditLog))
+    db.commit()
+
+
+@pytest.fixture(autouse=True)
+def clean_database() -> None:
+    with SessionLocal() as db:
+        _clear_marketplace_tables(db)
+    yield
+    with SessionLocal() as db:
+        _clear_marketplace_tables(db)
+
+
+@pytest.fixture
+def entitlements_state():
+    state = {"value": None}
+
+    def override_entitlements():
+        if state["value"] is None:
+            raise HTTPException(status_code=403, detail="Entitlements override missing")
+        return state["value"]
+
+    app.dependency_overrides[get_entitlements] = override_entitlements
+    try:
+        yield state
+    finally:
+        app.dependency_overrides.pop(get_entitlements, None)
+
+
+def test_publish_listing_requires_capability():
+    payload = {
+        "strategy_name": "Mean Reversion Alpha",
+        "description": "Daily swing trades",
+        "price_cents": 9900,
+        "currency": "EUR",
+        "connect_account_id": "acct_123",
+    }
+    response = client.post("/marketplace/listings", json=payload, headers={"x-user-id": "creator-1"})
+    assert response.status_code == 403
+
+
+def test_publish_and_copy_flow(entitlements_state):
+    entitlements_state["value"] = Entitlements(
+        customer_id="creator-1",
+        features={"can.publish_strategy": True},
+        quotas={},
+    )
+    payload = {
+        "strategy_name": "Momentum Edge",
+        "description": "1h breakout entries",
+        "price_cents": 19900,
+        "currency": "USD",
+        "connect_account_id": "acct_creator",
+        "initial_version": {"version": "1.0.0", "configuration": {"risk": 2}},
+    }
+    response = client.post("/marketplace/listings", json=payload, headers={"x-user-id": "creator-1"})
+    assert response.status_code == 201, response.text
+    listing_id = response.json()["id"]
+    assert response.json()["versions"][0]["version"] == "1.0.0"
+
+    entitlements_state["value"] = Entitlements(
+        customer_id="investor-9",
+        features={"can.copy_trade": True},
+        quotas={},
+    )
+    copy_payload = {"listing_id": listing_id, "payment_reference": "pi_123"}
+    copy_response = client.post(
+        "/marketplace/copies",
+        json=copy_payload,
+        headers={"x-user-id": "investor-9"},
+    )
+    assert copy_response.status_code == 201, copy_response.text
+    subscription = copy_response.json()
+    assert subscription["listing_id"] == listing_id
+    assert subscription["payment_reference"] == "pi_123"
+
+    copies_response = client.get("/marketplace/copies", headers={"x-user-id": "investor-9"})
+    assert copies_response.status_code == 200
+    assert len(copies_response.json()) == 1
+
+    with SessionLocal() as db:
+        listing = db.get(Listing, listing_id)
+        assert listing is not None
+        assert listing.strategy_name == "Momentum Edge"
+        versions = db.scalars(select(ListingVersion.id)).all()
+        assert versions, "Expected at least one stored version"
+        audit_actions = db.scalars(select(AuditLog.action)).all()
+        assert {"listing.created", "listing.copied"}.issubset(set(audit_actions))
+
+
+def test_only_owner_can_publish_new_version(entitlements_state):
+    entitlements_state["value"] = Entitlements(
+        customer_id="creator-1",
+        features={"can.publish_strategy": True},
+        quotas={},
+    )
+    listing_payload = {
+        "strategy_name": "Scalper",
+        "description": "Fast entries",
+        "price_cents": 5000,
+        "currency": "USD",
+        "connect_account_id": "acct_1",
+    }
+    resp = client.post("/marketplace/listings", json=listing_payload, headers={"x-user-id": "creator-1"})
+    listing_id = resp.json()["id"]
+
+    entitlements_state["value"] = Entitlements(
+        customer_id="intruder",
+        features={"can.publish_strategy": True},
+        quotas={},
+    )
+    version_resp = client.post(
+        f"/marketplace/listings/{listing_id}/versions",
+        json={"version": "2.0.0", "configuration": {}},
+        headers={"x-user-id": "other-user"},
+    )
+    assert version_resp.status_code == 403
+
+    entitlements_state["value"] = Entitlements(
+        customer_id="creator-1",
+        features={"can.publish_strategy": True},
+        quotas={},
+    )
+    ok_resp = client.post(
+        f"/marketplace/listings/{listing_id}/versions",
+        json={"version": "2.0.0", "configuration": {}},
+        headers={"x-user-id": "creator-1"},
+    )
+    assert ok_resp.status_code == 200
+    assert ok_resp.json()["versions"][0]["version"] == "2.0.0"

--- a/services/social/app/dependencies.py
+++ b/services/social/app/dependencies.py
@@ -1,0 +1,46 @@
+"""Dependency helpers for the social API."""
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request
+
+from libs.entitlements.client import Entitlements
+
+
+def get_entitlements(request: Request) -> Entitlements:
+    entitlements = getattr(request.state, "entitlements", None)
+    if entitlements is None:
+        raise HTTPException(status_code=403, detail="Entitlements are required")
+    return entitlements
+
+
+def require_profile_capability(entitlements: Entitlements = Depends(get_entitlements)) -> Entitlements:
+    if not entitlements.has("can.publish_strategy"):
+        raise HTTPException(status_code=403, detail="Missing capability: can.publish_strategy")
+    return entitlements
+
+
+def require_follow_capability(entitlements: Entitlements = Depends(get_entitlements)) -> Entitlements:
+    if not entitlements.has("can.copy_trade"):
+        raise HTTPException(status_code=403, detail="Missing capability: can.copy_trade")
+    return entitlements
+
+
+def get_actor_id(request: Request) -> str:
+    actor_id = request.headers.get("x-user-id") or request.headers.get("x-customer-id")
+    if not actor_id:
+        raise HTTPException(status_code=400, detail="Missing x-user-id header")
+    return actor_id
+
+
+def get_optional_actor_id(request: Request) -> str | None:
+    actor_id = request.headers.get("x-user-id") or request.headers.get("x-customer-id")
+    return actor_id
+
+
+__all__ = [
+    "get_entitlements",
+    "require_profile_capability",
+    "require_follow_capability",
+    "get_actor_id",
+    "get_optional_actor_id",
+]

--- a/services/social/app/main.py
+++ b/services/social/app/main.py
@@ -1,0 +1,124 @@
+"""FastAPI application exposing social features."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from infra import AuditBase, Leaderboard, SocialBase
+from libs.db.db import engine, get_db
+from libs.entitlements.fastapi import install_entitlements_middleware
+
+from .dependencies import (
+    get_actor_id,
+    get_optional_actor_id,
+    require_follow_capability,
+    require_profile_capability,
+)
+from .schemas import (
+    ActivityCreate,
+    ActivityOut,
+    FollowRequest,
+    LeaderboardOut,
+    LeaderboardUpsert,
+    ProfileOut,
+    ProfileUpdate,
+)
+from .service import (
+    create_activity,
+    fetch_activity_feed,
+    fetch_profile,
+    toggle_follow,
+    upsert_leaderboard,
+    upsert_profile,
+)
+
+app = FastAPI(title="Social Service", version="0.1.0")
+
+SocialBase.metadata.create_all(bind=engine)
+AuditBase.metadata.create_all(bind=engine)
+
+install_entitlements_middleware(app)
+
+router = APIRouter(prefix="/social", tags=["social"])
+
+
+@router.put("/profiles/me", response_model=ProfileOut)
+def update_profile(
+    payload: ProfileUpdate,
+    db: Session = Depends(get_db),
+    actor_id: str = Depends(get_actor_id),
+    _: object = Depends(require_profile_capability),
+):
+    profile = upsert_profile(db, actor_id=actor_id, payload=payload)
+    return ProfileOut.model_validate(profile)
+
+
+@router.get("/profiles/{user_id}", response_model=ProfileOut)
+def get_profile(
+    user_id: str,
+    db: Session = Depends(get_db),
+    actor_id: str | None = Depends(get_optional_actor_id),
+):
+    profile = fetch_profile(db, user_id=user_id, viewer_id=actor_id)
+    return ProfileOut.model_validate(profile)
+
+
+@router.post("/follows", response_model=dict)
+def follow_action(
+    payload: FollowRequest,
+    db: Session = Depends(get_db),
+    actor_id: str = Depends(get_actor_id),
+    _: object = Depends(require_follow_capability),
+):
+    changed = toggle_follow(db, actor_id=actor_id, payload=payload)
+    return {"changed": changed}
+
+
+@router.post("/activities", response_model=ActivityOut, status_code=201)
+def log_activity(
+    payload: ActivityCreate,
+    db: Session = Depends(get_db),
+    actor_id: str = Depends(get_actor_id),
+    _: object = Depends(require_profile_capability),
+):
+    activity = create_activity(db, actor_id=actor_id, payload=payload)
+    return ActivityOut.model_validate(activity)
+
+
+@router.get("/activities", response_model=list[ActivityOut])
+def activity_feed(
+    db: Session = Depends(get_db),
+    actor_id: str | None = Depends(get_optional_actor_id),
+    limit: int = Query(20, ge=1, le=100),
+):
+    activities = fetch_activity_feed(db, viewer_id=actor_id, limit=limit)
+    return [ActivityOut.model_validate(act) for act in activities]
+
+
+@router.put("/leaderboards/{slug}", response_model=LeaderboardOut)
+def upsert_board(
+    slug: str,
+    payload: LeaderboardUpsert,
+    db: Session = Depends(get_db),
+    actor_id: str = Depends(get_actor_id),
+    _: object = Depends(require_profile_capability),
+):
+    board = upsert_leaderboard(db, slug=slug, payload=payload, actor_id=actor_id)
+    return LeaderboardOut.model_validate(board)
+
+
+@router.get("/leaderboards/{slug}", response_model=LeaderboardOut)
+def get_board(slug: str, db: Session = Depends(get_db)):
+    board = db.scalar(select(Leaderboard).where(Leaderboard.slug == slug))
+    if not board:
+        raise HTTPException(status_code=404, detail="Leaderboard not found")
+    return LeaderboardOut.model_validate(board)
+
+
+app.include_router(router)
+
+
+@app.get("/health")
+def healthcheck():
+    return {"status": "ok"}

--- a/services/social/app/schemas.py
+++ b/services/social/app/schemas.py
@@ -1,0 +1,64 @@
+"""Pydantic schemas for the social service."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProfileUpdate(BaseModel):
+    display_name: str = Field(max_length=128)
+    bio: Optional[str] = None
+    avatar_url: Optional[str] = Field(default=None, max_length=255)
+    is_public: bool = True
+
+
+class ProfileOut(BaseModel):
+    user_id: str
+    display_name: str
+    bio: Optional[str]
+    avatar_url: Optional[str]
+    is_public: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FollowRequest(BaseModel):
+    target_user_id: str = Field(max_length=64)
+    follow: bool = True
+
+
+class ActivityCreate(BaseModel):
+    activity_type: str = Field(max_length=64)
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ActivityOut(BaseModel):
+    id: int
+    profile_id: int
+    activity_type: str
+    data: Dict[str, Any]
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LeaderboardUpsert(BaseModel):
+    title: str = Field(max_length=128)
+    metric: str = Field(max_length=64)
+    period: str = Field(default="all", max_length=32)
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LeaderboardOut(BaseModel):
+    slug: str
+    title: str
+    metric: str
+    period: str
+    data: Dict[str, Any]
+    generated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/services/social/app/service.py
+++ b/services/social/app/service.py
@@ -1,0 +1,181 @@
+"""Domain services for the social API."""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from infra import Activity, Follow, Leaderboard, Profile
+from libs.audit import record_audit
+
+from .schemas import ActivityCreate, FollowRequest, LeaderboardUpsert, ProfileUpdate
+
+
+
+def upsert_profile(db: Session, *, actor_id: str, payload: ProfileUpdate) -> Profile:
+    profile = db.scalar(select(Profile).where(Profile.user_id == actor_id))
+    created = False
+    if not profile:
+        profile = Profile(
+            user_id=actor_id,
+            display_name=payload.display_name,
+            bio=payload.bio,
+            avatar_url=payload.avatar_url,
+            is_public=payload.is_public,
+        )
+        db.add(profile)
+        created = True
+    else:
+        profile.display_name = payload.display_name
+        profile.bio = payload.bio
+        profile.avatar_url = payload.avatar_url
+        profile.is_public = payload.is_public
+
+    record_audit(
+        db,
+        service="social",
+        action="profile.created" if created else "profile.updated",
+        actor_id=actor_id,
+        subject_id=actor_id,
+        details={"is_public": profile.is_public},
+    )
+    db.commit()
+    db.refresh(profile)
+    return profile
+
+
+def fetch_profile(db: Session, *, user_id: str, viewer_id: Optional[str] = None) -> Profile:
+    profile = db.scalar(select(Profile).where(Profile.user_id == user_id))
+    if not profile or (not profile.is_public and profile.user_id != viewer_id):
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+
+def toggle_follow(db: Session, *, actor_id: str, payload: FollowRequest) -> bool:
+    if actor_id == payload.target_user_id:
+        raise HTTPException(status_code=400, detail="Cannot follow yourself")
+
+    target = db.scalar(select(Profile).where(Profile.user_id == payload.target_user_id))
+    if not target:
+        raise HTTPException(status_code=404, detail="Target profile not found")
+
+    follow = db.scalar(
+        select(Follow).where(
+            Follow.follower_id == actor_id,
+            Follow.followee_id == payload.target_user_id,
+        )
+    )
+    if payload.follow:
+        if follow:
+            return False
+        follow = Follow(follower_id=actor_id, followee_id=payload.target_user_id)
+        db.add(follow)
+        record_audit(
+            db,
+            service="social",
+            action="profile.followed",
+            actor_id=actor_id,
+            subject_id=payload.target_user_id,
+        )
+        create_activity(
+            db,
+            actor_id=actor_id,
+            payload=ActivityCreate(
+                activity_type="follow",
+                data={"target_user_id": payload.target_user_id},
+            ),
+        )
+        db.commit()
+        return True
+
+    if follow:
+        db.delete(follow)
+        record_audit(
+            db,
+            service="social",
+            action="profile.unfollowed",
+            actor_id=actor_id,
+            subject_id=payload.target_user_id,
+        )
+        db.commit()
+        return True
+
+    return False
+
+
+def create_activity(db: Session, *, actor_id: str, payload: ActivityCreate) -> Activity:
+    profile = db.scalar(select(Profile).where(Profile.user_id == actor_id))
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found for activity")
+
+    activity = Activity(profile=profile, activity_type=payload.activity_type, data=payload.data)
+    db.add(activity)
+    record_audit(
+        db,
+        service="social",
+        action="activity.logged",
+        actor_id=actor_id,
+        subject_id=str(profile.id),
+        details={"activity_type": payload.activity_type},
+    )
+    db.commit()
+    db.refresh(activity)
+    return activity
+
+
+def fetch_activity_feed(
+    db: Session,
+    *,
+    viewer_id: Optional[str] = None,
+    limit: int = 20,
+) -> list[Activity]:
+    stmt = select(Activity).join(Profile).order_by(Activity.created_at.desc()).limit(limit)
+    if viewer_id:
+        followee_ids = db.scalars(
+            select(Follow.followee_id).where(Follow.follower_id == viewer_id)
+        ).all()
+        user_ids = set(followee_ids + [viewer_id])
+        if user_ids:
+            stmt = stmt.where(Profile.user_id.in_(user_ids))
+    return db.scalars(stmt).all()
+
+
+def upsert_leaderboard(db: Session, *, slug: str, payload: LeaderboardUpsert, actor_id: str) -> Leaderboard:
+    board = db.scalar(select(Leaderboard).where(Leaderboard.slug == slug))
+    created = False
+    if not board:
+        board = Leaderboard(
+            slug=slug,
+            title=payload.title,
+            metric=payload.metric,
+            period=payload.period,
+            data=payload.data,
+        )
+        db.add(board)
+        created = True
+    else:
+        board.title = payload.title
+        board.metric = payload.metric
+        board.period = payload.period
+        board.data = payload.data
+
+    record_audit(
+        db,
+        service="social",
+        action="leaderboard.created" if created else "leaderboard.updated",
+        actor_id=actor_id,
+        subject_id=slug,
+        details={"metric": board.metric, "period": board.period},
+    )
+    db.commit()
+    db.refresh(board)
+    return board
+
+
+def clear_profile_data(db: Session, *, user_id: str) -> None:
+    db.execute(delete(Follow).where((Follow.follower_id == user_id) | (Follow.followee_id == user_id)))
+    db.execute(delete(Activity).where(Activity.profile_id.in_(select(Profile.id).where(Profile.user_id == user_id))))
+    db.execute(delete(Profile).where(Profile.user_id == user_id))
+    db.commit()

--- a/services/social/tests/test_social_service.py
+++ b/services/social/tests/test_social_service.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from infra import Activity, AuditLog, Follow, Leaderboard, Profile
+from libs.db.db import SessionLocal
+from libs.entitlements.client import Entitlements
+
+from services.social.app.dependencies import get_entitlements
+from services.social.app.main import app
+
+client = TestClient(app)
+
+@pytest.fixture(scope="module", autouse=True)
+def disable_entitlements_middleware() -> None:
+    app.user_middleware = [mw for mw in app.user_middleware if mw.cls.__name__ != "EntitlementsMiddleware"]
+    app.middleware_stack = app.build_middleware_stack()
+
+
+
+def _clear_social_tables(db: Session) -> None:
+    db.execute(delete(Follow))
+    db.execute(delete(Activity))
+    db.execute(delete(Profile))
+    db.execute(delete(Leaderboard))
+    db.execute(delete(AuditLog))
+    db.commit()
+
+
+@pytest.fixture(autouse=True)
+def clean_database() -> None:
+    with SessionLocal() as db:
+        _clear_social_tables(db)
+    yield
+    with SessionLocal() as db:
+        _clear_social_tables(db)
+
+
+@pytest.fixture
+def entitlements_state():
+    state = {"value": None}
+
+    def override_entitlements():
+        if state["value"] is None:
+            raise HTTPException(status_code=403, detail="Entitlements override missing")
+        return state["value"]
+
+    app.dependency_overrides[get_entitlements] = override_entitlements
+    try:
+        yield state
+    finally:
+        app.dependency_overrides.pop(get_entitlements, None)
+
+
+def test_profile_update_requires_capability():
+    payload = {
+        "display_name": "Alpha Trader",
+        "bio": "Loves market micro-structure",
+        "avatar_url": None,
+        "is_public": True,
+    }
+    response = client.put("/social/profiles/me", json=payload, headers={"x-user-id": "creator-1"})
+    assert response.status_code == 403
+
+
+def test_social_flow(entitlements_state):
+    entitlements_state["value"] = Entitlements(
+        customer_id="creator-1",
+        features={"can.publish_strategy": True},
+        quotas={},
+    )
+    profile_payload = {
+        "display_name": "Creator One",
+        "bio": "Trend following",
+        "avatar_url": "https://example.com/avatar.png",
+        "is_public": True,
+    }
+    profile_resp = client.put(
+        "/social/profiles/me",
+        json=profile_payload,
+        headers={"x-user-id": "creator-1"},
+    )
+    assert profile_resp.status_code == 200
+    assert profile_resp.json()["display_name"] == "Creator One"
+
+    entitlements_state["value"] = Entitlements(
+        customer_id="follower-9",
+        features={"can.publish_strategy": True},
+        quotas={},
+    )
+    follower_profile = {
+        "display_name": "Follower Nine",
+        "bio": "Copy trading fan",
+        "avatar_url": None,
+        "is_public": True,
+    }
+    client.put(
+        "/social/profiles/me",
+        json=follower_profile,
+        headers={"x-user-id": "follower-9"},
+    )
+
+    entitlements_state["value"] = Entitlements(
+        customer_id="follower-9",
+        features={"can.copy_trade": True},
+        quotas={},
+    )
+    follow_resp = client.post(
+        "/social/follows",
+        json={"target_user_id": "creator-1", "follow": True},
+        headers={"x-user-id": "follower-9"},
+    )
+    assert follow_resp.status_code == 200
+    assert follow_resp.json()["changed"] is True
+
+    entitlements_state["value"] = Entitlements(
+        customer_id="follower-9",
+        features={"can.publish_strategy": True},
+        quotas={},
+    )
+    activity_resp = client.post(
+        "/social/activities",
+        json={"activity_type": "shared_trade", "data": {"symbol": "BTCUSDT"}},
+        headers={"x-user-id": "follower-9"},
+    )
+    assert activity_resp.status_code == 201
+
+    feed_resp = client.get("/social/activities", headers={"x-user-id": "follower-9"})
+    assert feed_resp.status_code == 200
+    assert len(feed_resp.json()) >= 1
+
+    board_payload = {
+        "title": "Top Sharpe",
+        "metric": "sharpe",
+        "period": "weekly",
+        "data": {"creator-1": 2.1},
+    }
+    entitlements_state["value"] = Entitlements(
+        customer_id="creator-1",
+        features={"can.publish_strategy": True},
+        quotas={},
+    )
+    board_resp = client.put(
+        "/social/leaderboards/top-creators",
+        json=board_payload,
+        headers={"x-user-id": "creator-1"},
+    )
+    assert board_resp.status_code == 200
+    assert board_resp.json()["metric"] == "sharpe"
+
+    with SessionLocal() as db:
+        profiles = db.scalars(select(Profile.user_id)).all()
+        assert set(profiles) == {"creator-1", "follower-9"}
+        follows = db.scalars(select(Follow.followee_id)).all()
+        assert follows == ["creator-1"]
+        activities = db.scalars(select(Activity.activity_type)).all()
+        assert "follow" in activities
+        audits = db.scalars(select(AuditLog.action)).all()
+        assert {"profile.created", "profile.followed", "activity.logged", "leaderboard.created"}.issubset(set(audits))


### PR DESCRIPTION
## Summary
- add reusable audit log models and wire new bases into the shared infrastructure setup
- implement marketplace APIs for publishing strategies and copy-trading with entitlement checks, Stripe Connect metadata, and audit logging
- implement social APIs for public profiles, follows, activities, and leaderboards with entitlements plus audit trail coverage, and document both services

## Testing
- pytest services/marketplace/tests/test_marketplace_service.py services/social/tests/test_social_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d94e39fc048332a5a6a3f70ca81396