### PR TITLE
feat: add codex automation services

### DIFF
--- a/.github/workflows/codex-run.yml
+++ b/.github/workflows/codex-run.yml
@@ -1,0 +1,51 @@
+name: codex-run
+
+on:
+  workflow_call:
+    inputs:
+      provider:
+        description: Source de l'événement (github|stripe|tradingview)
+        required: true
+        type: string
+      event-type:
+        description: Type d'événement (ex issue_comment)
+        required: true
+        type: string
+      event-payload:
+        description: Payload JSON de l'événement
+        required: true
+        type: string
+    secrets:
+      github-token:
+        description: Token GitHub pour les opérations API
+        required: true
+      codex-github-token:
+        description: Jeton d'installation pour le worker Codex
+        required: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -r services/codex_worker/requirements.txt
+      - name: Persist event payload
+        run: |
+          cat <<'JSON' > event.json
+          ${{ inputs.event-payload }}
+          JSON
+      - name: Execute Codex worker
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+          CODEX_WORKER_GITHUB_TOKEN: ${{ secrets.codex-github-token }}
+        run: |
+          python -m services.codex_worker.app.cli --provider "${{ inputs.provider }}" --event-type "${{ inputs['event-type'] }}" --event-path event.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: codex-lint
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Version de Python utilisée pour le lint
+        required: false
+        default: '3.12'
+        type: string
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run linters
+        run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: codex-test
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Version de Python utilisée pour les tests
+        required: false
+        default: '3.12'
+        type: string
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -r services/codex_gateway/requirements-dev.txt
+          pip install -r services/codex_worker/requirements-dev.txt
+      - name: Run test suite
+        run: make test

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,62 @@
+# Codex Automation Platform
+
+Le projet Codex automatise les interactions GitHub/Stripe/TradingView pour gérer le cycle de vie des contributions ouvertes et la facturation associée.
+
+## Architecture
+
+- **Gateway** (`services/codex_gateway/`, service "codex-gateway") : service FastAPI exposant les webhooks `/webhooks/github`, `/webhooks/stripe` et `/webhooks/tradingview`. Les signatures HMAC des fournisseurs sont vérifiées avant la mise en file des événements dans le broker mémoire.
+- **Worker** (`services/codex_worker/`, service "codex-worker") : consomme les événements, pilote les Checks GitHub, exécute les plans/pytest dans des conteneurs jetables et vérifie les droits via OpenFeature.
+- **Librairie partagée** (`libs/codex/`) : modèles d'événements et broker mémoire permettant les tests unitaires et un usage local.
+
+## Commandes supportées
+
+Les commandes s'exécutent via des commentaires GitHub sur les Pull Requests :
+
+| Commande | Description |
+| --- | --- |
+| `/codex plan` | Crée un check-run, clone le dépôt dans un conteneur (image `ghcr.io/trading-bot/codex-sandbox:latest`), installe les dépendances dev et lance `pytest`. Le résultat est commenté dans la PR avec les logs. |
+| `/codex pr` | Déclenche le workflow de merge automatique (`merge_method = squash`) après validation des entitlements. |
+
+Chaque commande nécessite une capability OpenFeature : `codex.plan` ou `codex.pr`. Les attributs utilisés sont `user` (auteur du commentaire) et `repository`.
+
+## Gouvernance des branches
+
+- Les branches `main` et `release/*` sont protégées et ne peuvent être modifiées que par le workflow `/codex pr` après validation.
+- Les branches de fonctionnalités doivent suivre le préfixe `feature/<ticket>`.
+- Les merges effectués par le worker utilisent systématiquement `merge_method=squash` afin de garantir un historique linéaire.
+
+## Configuration du GitHub App
+
+1. Créer une GitHub App avec les permissions suivantes :
+   - Checks : `Read & write`
+   - Pull requests : `Read & write`
+   - Issues : `Read & write`
+   - Repository contents : `Read`
+   - Webhooks : URL `https://<gateway>/webhooks/github`, secret `CODEX_GATEWAY_GITHUB_WEBHOOK_SECRET`
+2. Installer l'application sur les dépôts cibles et récupérer le token d'installation (stocké dans `CODEX_WORKER_GITHUB_TOKEN`).
+3. Définir les événements webhook obligatoires : `issue_comment`, `pull_request`, `check_suite`.
+
+## Workflows GitHub Actions
+
+Trois workflows réutilisables sont fournis :
+
+- `.github/workflows/lint.yml` : exécute `make lint` sur un environnement Python 3.12.
+- `.github/workflows/test.yml` : installe `requirements-dev.txt`, lance `make test` et publie les rapports pytest.
+- `.github/workflows/codex-run.yml` : workflow déclenché par commentaire `/codex <cmd>` qui appelle le worker via un job réutilisable.
+
+Les workflows sont définis avec `workflow_call` pour être invoqués depuis les pipelines de produit.
+
+## Secrets et déploiement
+
+Les environnements GitHub Actions doivent définir les secrets suivants :
+
+| Secret | Service | Description |
+| --- | --- | --- |
+| `CODEX_GATEWAY_GITHUB_WEBHOOK_SECRET` | Gateway | Signature HMAC GitHub. |
+| `CODEX_GATEWAY_STRIPE_WEBHOOK_SECRET` | Gateway | Signature Stripe. |
+| `CODEX_GATEWAY_TRADINGVIEW_WEBHOOK_SECRET` | Gateway | Signature TradingView. |
+| `CODEX_WORKER_GITHUB_TOKEN` | Worker | Token d'installation de la GitHub App. |
+| `CODEX_WORKER_SANDBOX_IMAGE` | Worker | (Optionnel) Image alternative pour le conteneur sandbox. |
+| `CODEX_OPENFEATURE_PROVIDER` | Worker | (Optionnel) Configuration du provider OpenFeature en production. |
+
+Pour un déploiement sur Kubernetes, les secrets peuvent être provisionnés via `infra/` (Terraform/Helm) et injectés dans les pods `codex-gateway` et `codex-worker`. Les workflows GitHub Actions peuvent utiliser `environment` + `secrets` afin de synchroniser la configuration avec les environnements de staging/production.

--- a/libs/codex/__init__.py
+++ b/libs/codex/__init__.py
@@ -1,0 +1,12 @@
+"""Shared Codex utilities used by the gateway and worker services."""
+
+from .events import CodexEvent, CodexEventPayload
+from .messaging import EventConsumer, EventPublisher, MemoryEventBroker
+
+__all__ = [
+    "CodexEvent",
+    "CodexEventPayload",
+    "EventConsumer",
+    "EventPublisher",
+    "MemoryEventBroker",
+]

--- a/libs/codex/events.py
+++ b/libs/codex/events.py
@@ -1,0 +1,53 @@
+"""Pydantic models describing Codex automation events."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+class CodexEventPayload(BaseModel):
+    """Raw payload for an incoming webhook event."""
+
+    content_type: str = Field(default="application/json", alias="contentType")
+    body: bytes = Field(repr=False)
+    encoding: str | None = None
+
+    def json(self) -> Any:
+        """Decode the payload as JSON."""
+
+        if "json" not in self.content_type:
+            msg = "Payload is not JSON encoded"
+            raise ValueError(msg)
+        text = self.body.decode(self.encoding or "utf-8")
+        import json
+
+        return json.loads(text)
+
+
+class CodexEvent(BaseModel):
+    """Representation of a webhook that should be processed by the worker."""
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    provider: Literal["github", "stripe", "tradingview"]
+    event_type: str | None = Field(default=None, alias="eventType")
+    delivery: str | None = None
+    signature: str | None = None
+    payload: CodexEventPayload
+    received_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), alias="receivedAt"
+    )
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+    model_config = {
+        "populate_by_name": True,
+        "arbitrary_types_allowed": True,
+    }
+
+    def body_as_json(self) -> Any:
+        """Helper returning the payload decoded as JSON."""
+
+        return self.payload.json()

--- a/libs/codex/messaging.py
+++ b/libs/codex/messaging.py
@@ -1,0 +1,39 @@
+"""Async messaging primitives shared by Codex services."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+from .events import CodexEvent
+
+
+class EventPublisher(Protocol):
+    """Publisher capable of emitting Codex events."""
+
+    async def publish(self, event: CodexEvent) -> None:
+        """Publish an event to the downstream worker."""
+        raise NotImplementedError
+
+
+class EventConsumer(Protocol):
+    """Consumer interface used by the worker service."""
+
+    async def get(self) -> CodexEvent:
+        """Fetch the next available event, waiting if necessary."""
+        raise NotImplementedError
+
+
+class MemoryEventBroker(EventPublisher, EventConsumer):
+    """In-memory broker used for development and testing."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[CodexEvent] = asyncio.Queue()
+
+    async def publish(self, event: CodexEvent) -> None:
+        await self._queue.put(event)
+
+    async def get(self) -> CodexEvent:
+        event = await self._queue.get()
+        self._queue.task_done()
+        return event

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ detect-secrets>=1.4.0
 pytest>=7.4.0
 pytest-asyncio>=0.24.0
 httpx>=0.24.0
+openfeature-sdk>=0.8.3

--- a/services/codex_gateway/app/__init__.py
+++ b/services/codex_gateway/app/__init__.py
@@ -1,0 +1,1 @@
+"""Codex gateway FastAPI application."""

--- a/services/codex_gateway/app/config.py
+++ b/services/codex_gateway/app/config.py
@@ -1,0 +1,38 @@
+"""Environment configuration for the Codex gateway."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Settings loaded from environment variables."""
+
+    github_webhook_secret: str = Field(
+        "", description="Secret used to validate GitHub webhook signatures", repr=False
+    )
+    stripe_webhook_secret: str = Field(
+        "", description="Secret used to validate Stripe webhook signatures", repr=False
+    )
+    tradingview_webhook_secret: str = Field(
+        "", description="Secret used to validate TradingView webhook signatures", repr=False
+    )
+    broker_backend: str = Field(
+        "memory",
+        description="Messaging backend to publish events (memory|redis|sqs)",
+    )
+    service_name: str = Field("codex-gateway", description="Service identifier used for logging")
+
+    class Config:
+        env_prefix = "CODEX_GATEWAY_"
+        case_sensitive = False
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached settings to avoid re-parsing environment variables."""
+
+    return Settings()

--- a/services/codex_gateway/app/deps.py
+++ b/services/codex_gateway/app/deps.py
@@ -1,0 +1,21 @@
+"""Dependency wiring for the Codex gateway."""
+
+from __future__ import annotations
+
+from fastapi import Depends
+
+from libs.codex import MemoryEventBroker
+
+from .config import Settings, get_settings
+
+
+async def get_broker(settings: Settings = Depends(get_settings)) -> MemoryEventBroker:
+    """Return the in-memory broker used to push events to the worker."""
+
+    if settings.broker_backend != "memory":  # pragma: no cover - placeholder for future backends
+        msg = f"Unsupported broker backend: {settings.broker_backend}"
+        raise RuntimeError(msg)
+
+    if not hasattr(get_broker, "_broker"):
+        get_broker._broker = MemoryEventBroker()  # type: ignore[attr-defined]
+    return get_broker._broker  # type: ignore[attr-defined]

--- a/services/codex_gateway/app/main.py
+++ b/services/codex_gateway/app/main.py
@@ -1,0 +1,112 @@
+"""FastAPI application receiving Codex webhooks."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import Depends, FastAPI, Request, status
+
+from libs.codex import CodexEvent, CodexEventPayload
+
+from .config import Settings, get_settings
+from .deps import get_broker
+from .security import (
+    verify_github_signature,
+    verify_stripe_signature,
+    verify_tradingview_signature,
+)
+
+app = FastAPI(title="Codex Gateway", version="0.1.0")
+
+
+def _extract_event_type(body: bytes) -> str | None:
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    event_type = payload.get("type")
+    if isinstance(event_type, str):
+        return event_type
+    return None
+
+
+@app.post("/webhooks/github", status_code=status.HTTP_202_ACCEPTED)
+async def github_webhook(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    broker=Depends(get_broker),
+) -> dict[str, Any]:
+    body = await request.body()
+    signature = request.headers.get("X-Hub-Signature-256")
+    verify_github_signature(settings.github_webhook_secret, signature, body)
+
+    event = CodexEvent(
+        provider="github",
+        eventType=request.headers.get("X-GitHub-Event"),
+        delivery=request.headers.get("X-GitHub-Delivery"),
+        signature=signature,
+        payload=CodexEventPayload(
+            contentType=request.headers.get("Content-Type", "application/json"),
+            body=body,
+        ),
+        metadata={
+            "user_agent": request.headers.get("User-Agent", ""),
+            "hook_id": request.headers.get("X-GitHub-Hook-ID", ""),
+        },
+    )
+    await broker.publish(event)
+    return {"status": "queued"}
+
+
+@app.post("/webhooks/stripe", status_code=status.HTTP_202_ACCEPTED)
+async def stripe_webhook(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    broker=Depends(get_broker),
+) -> dict[str, Any]:
+    body = await request.body()
+    signature = request.headers.get("stripe-signature")
+    verify_stripe_signature(settings.stripe_webhook_secret, signature, body)
+
+    event = CodexEvent(
+        provider="stripe",
+        eventType=_extract_event_type(body),
+        signature=signature,
+        payload=CodexEventPayload(
+            contentType=request.headers.get("Content-Type", "application/json"),
+            body=body,
+        ),
+        metadata={"stripe_event_id": request.headers.get("Stripe-Signature-Id", "")},
+    )
+    await broker.publish(event)
+    return {"status": "queued"}
+
+
+@app.post("/webhooks/tradingview", status_code=status.HTTP_202_ACCEPTED)
+async def tradingview_webhook(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    broker=Depends(get_broker),
+) -> dict[str, Any]:
+    body = await request.body()
+    signature = request.headers.get("X-Signature")
+    verify_tradingview_signature(settings.tradingview_webhook_secret, signature, body)
+
+    event = CodexEvent(
+        provider="tradingview",
+        eventType=_extract_event_type(body),
+        signature=signature,
+        payload=CodexEventPayload(
+            contentType=request.headers.get("Content-Type", "application/json"),
+            body=body,
+        ),
+        metadata={"user_agent": request.headers.get("User-Agent", "")},
+    )
+    await broker.publish(event)
+    return {"status": "queued"}
+
+
+@app.get("/health", status_code=status.HTTP_200_OK)
+async def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/services/codex_gateway/app/security.py
+++ b/services/codex_gateway/app/security.py
@@ -1,0 +1,67 @@
+"""Signature validation utilities for webhook endpoints."""
+
+from __future__ import annotations
+
+import base64
+import hmac
+from hashlib import sha256
+from time import time
+
+from fastapi import HTTPException, status
+
+
+def verify_github_signature(secret: str, signature_header: str | None, body: bytes) -> None:
+    """Validate a GitHub webhook signature."""
+
+    if not secret:
+        return
+    if not signature_header or not signature_header.startswith("sha256="):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing signature")
+    signature = signature_header.split("=", 1)[1]
+    expected = hmac.new(secret.encode("utf-8"), body, sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid signature")
+
+
+def verify_stripe_signature(secret: str, signature_header: str | None, body: bytes) -> None:
+    """Validate a Stripe webhook signature."""
+
+    if not secret:
+        return
+    if not signature_header:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing signature")
+
+    elements: dict[str, str] = {}
+    for part in signature_header.split(","):
+        try:
+            key, value = part.split("=", 1)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid signature header") from exc
+        elements[key] = value
+
+    timestamp = int(elements.get("t", "0"))
+    transmitted_signature = elements.get("v1")
+    if not transmitted_signature:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing signature")
+
+    if abs(int(time()) - timestamp) > 300:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Expired signature")
+
+    signed_payload = f"{timestamp}.{body.decode('utf-8')}".encode("utf-8")
+    expected = hmac.new(secret.encode("utf-8"), msg=signed_payload, digestmod=sha256).hexdigest()
+    if not hmac.compare_digest(expected, transmitted_signature):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid signature")
+
+
+def verify_tradingview_signature(secret: str, signature_header: str | None, body: bytes) -> None:
+    """Validate a TradingView webhook signature."""
+
+    if not secret:
+        return
+    if not signature_header:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing signature")
+
+    digest = hmac.new(secret.encode("utf-8"), body, sha256).digest()
+    expected = base64.b64encode(digest).decode("utf-8")
+    if not hmac.compare_digest(expected, signature_header):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid signature")

--- a/services/codex_gateway/requirements-dev.txt
+++ b/services/codex_gateway/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest>=8.2
+httpx>=0.27
+pytest-asyncio>=0.24

--- a/services/codex_gateway/requirements.txt
+++ b/services/codex_gateway/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.111
+uvicorn>=0.29
+pydantic>=2.6
+pydantic-settings>=2.3

--- a/services/codex_gateway/tests/test_webhooks.py
+++ b/services/codex_gateway/tests/test_webhooks.py
@@ -1,0 +1,122 @@
+"""Unit tests covering webhook signature validation."""
+
+from __future__ import annotations
+
+import base64
+import hmac
+from hashlib import sha256
+from time import time
+
+import pytest
+from fastapi import status
+from httpx import ASGITransport, AsyncClient
+
+from libs.codex import MemoryEventBroker
+from services.codex_gateway.app import deps
+from services.codex_gateway.app.config import Settings, get_settings
+from services.codex_gateway.app.main import app
+
+
+@pytest.fixture(autouse=True)
+def reset_dependencies() -> None:
+    deps.get_broker.__dict__.pop("_broker", None)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def configured_settings() -> Settings:
+    return Settings(
+        github_webhook_secret="gh-secret",
+        stripe_webhook_secret="stripe-secret",
+        tradingview_webhook_secret="tv-secret",
+    )
+
+
+@pytest.mark.asyncio
+async def test_github_webhook_enqueues_event(configured_settings: Settings) -> None:
+    broker = MemoryEventBroker()
+    app.dependency_overrides[deps.get_broker] = lambda: broker
+    app.dependency_overrides[get_settings] = lambda: configured_settings
+
+    body = b"{\"action\": \"created\"}"
+    signature = hmac.new(b"gh-secret", body, sha256).hexdigest()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/github",
+            content=body,
+            headers={
+                "X-Hub-Signature-256": f"sha256={signature}",
+                "X-GitHub-Event": "issue_comment",
+                "X-GitHub-Delivery": "delivery-1",
+            },
+        )
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    event = await broker.get()
+    assert event.provider == "github"
+    assert event.event_type == "issue_comment"
+    assert event.delivery == "delivery-1"
+    assert event.payload.body == body
+
+
+@pytest.mark.asyncio
+async def test_github_webhook_rejects_invalid_signature(configured_settings: Settings) -> None:
+    app.dependency_overrides[get_settings] = lambda: configured_settings
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/github",
+            content=b"{}",
+            headers={"X-Hub-Signature-256": "sha256=invalid"},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_verifies_signature(configured_settings: Settings) -> None:
+    broker = MemoryEventBroker()
+    app.dependency_overrides[deps.get_broker] = lambda: broker
+    app.dependency_overrides[get_settings] = lambda: configured_settings
+
+    body = b"{\"type\": \"checkout.session.completed\"}"
+    timestamp = int(time())
+    signed_payload = f"{timestamp}.{body.decode('utf-8')}".encode("utf-8")
+    signature = hmac.new(b"stripe-secret", msg=signed_payload, digestmod=sha256).hexdigest()
+    header = f"t={timestamp},v1={signature}"
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/stripe",
+            content=body,
+            headers={"stripe-signature": header},
+        )
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    event = await broker.get()
+    assert event.provider == "stripe"
+    assert event.event_type == "checkout.session.completed"
+
+
+@pytest.mark.asyncio
+async def test_tradingview_webhook_verifies_signature(configured_settings: Settings) -> None:
+    broker = MemoryEventBroker()
+    app.dependency_overrides[deps.get_broker] = lambda: broker
+    app.dependency_overrides[get_settings] = lambda: configured_settings
+
+    body = b"{\"type\": \"alert\"}"
+    digest = hmac.new(b"tv-secret", body, sha256).digest()
+    signature = base64.b64encode(digest).decode("utf-8")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/tradingview",
+            content=body,
+            headers={"X-Signature": signature},
+        )
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    event = await broker.get()
+    assert event.provider == "tradingview"
+    assert event.event_type == "alert"

--- a/services/codex_worker/app/__init__.py
+++ b/services/codex_worker/app/__init__.py
@@ -1,0 +1,1 @@
+"""Codex worker service for automation workflows."""

--- a/services/codex_worker/app/cli.py
+++ b/services/codex_worker/app/cli.py
@@ -1,0 +1,50 @@
+"""Command line entrypoint to execute Codex worker logic from CI."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from libs.codex import CodexEvent, CodexEventPayload, MemoryEventBroker
+
+from .config import get_settings
+from .entitlements import EntitlementChecker
+from .github import GitHubClient
+from .sandbox import SandboxRunner
+from .worker import CodexWorker
+
+
+async def run_once(event: CodexEvent) -> None:
+    settings = get_settings()
+    broker = MemoryEventBroker()
+    github = GitHubClient(settings.github_token)
+    sandbox = SandboxRunner(settings.sandbox_image, settings.checkout_root)
+    entitlements = EntitlementChecker(settings.feature_flag_environment)
+    worker = CodexWorker(broker, github, sandbox, entitlements)
+    await worker._handle_event(event)
+    await github.close()
+
+
+def load_event(provider: str, event_type: str, path: Path) -> CodexEvent:
+    payload = path.read_text(encoding="utf-8")
+    return CodexEvent(
+        provider=provider,
+        eventType=event_type,
+        payload=CodexEventPayload(contentType="application/json", body=payload.encode("utf-8")),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Execute a Codex worker run for a single event")
+    parser.add_argument("--provider", default="github", help="Event provider (github|stripe|tradingview)")
+    parser.add_argument("--event-type", default="issue_comment", help="Type de l'événement")
+    parser.add_argument("--event-path", required=True, help="Chemin vers le payload JSON")
+    args = parser.parse_args()
+
+    event = load_event(args.provider, args.event_type, Path(args.event_path))
+    asyncio.run(run_once(event))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/services/codex_worker/app/config.py
+++ b/services/codex_worker/app/config.py
@@ -1,0 +1,35 @@
+"""Environment configuration for the Codex worker."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Settings loaded from environment variables."""
+
+    github_token: str = Field("", description="GitHub token used to call the REST API", repr=False)
+    sandbox_image: str = Field(
+        "ghcr.io/trading-bot/codex-sandbox:latest",
+        description="Container image used to run plan and test commands",
+    )
+    checkout_root: str = Field(
+        "/tmp/codex",
+        description="Directory where repositories are cloned before running commands",
+    )
+    feature_flag_environment: str = Field(
+        "codex",
+        description="OpenFeature client name used for entitlement checks",
+    )
+
+    class Config:
+        env_prefix = "CODEX_WORKER_"
+        case_sensitive = False
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/services/codex_worker/app/entitlements.py
+++ b/services/codex_worker/app/entitlements.py
@@ -1,0 +1,20 @@
+"""OpenFeature based entitlement checks for Codex commands."""
+
+from __future__ import annotations
+
+from openfeature import api
+from openfeature.evaluation_context import EvaluationContext
+
+
+class EntitlementChecker:
+    """Wrapper around OpenFeature for evaluating entitlements."""
+
+    def __init__(self, environment: str) -> None:
+        self._client = api.get_client(environment)
+
+    def is_allowed(self, capability: str, user: str, repository: str) -> bool:
+        context = EvaluationContext(
+            targeting_key=user,
+            attributes={"repository": repository, "capability": capability},
+        )
+        return self._client.get_boolean_value(capability, False, context)

--- a/services/codex_worker/app/github.py
+++ b/services/codex_worker/app/github.py
@@ -1,0 +1,65 @@
+"""Client for interacting with the GitHub REST API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class GitHubClient:
+    """Minimal GitHub REST client supporting Checks and PR interactions."""
+
+    def __init__(
+        self,
+        token: str,
+        base_url: str = "https://api.github.com",
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._token = token
+        self._base_url = base_url.rstrip("/")
+        self._client = client or httpx.AsyncClient(
+            base_url=self._base_url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "codex-worker",
+            },
+        )
+        self._owns_client = client is None
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def create_check_run(self, repository: str, payload: dict[str, Any]) -> dict[str, Any]:
+        response = await self._client.post(f"/repos/{repository}/check-runs", json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    async def update_check_run(
+        self, repository: str, check_run_id: int, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        response = await self._client.patch(
+            f"/repos/{repository}/check-runs/{check_run_id}", json=payload
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def post_pr_comment(
+        self, repository: str, pull_number: int, body: str
+    ) -> dict[str, Any]:
+        response = await self._client.post(
+            f"/repos/{repository}/issues/{pull_number}/comments", json={"body": body}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def merge_pull_request(
+        self, repository: str, pull_number: int, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        response = await self._client.put(
+            f"/repos/{repository}/pulls/{pull_number}/merge", json=payload or {}
+        )
+        response.raise_for_status()
+        return response.json()

--- a/services/codex_worker/app/sandbox.py
+++ b/services/codex_worker/app/sandbox.py
@@ -1,0 +1,52 @@
+"""Run commands inside isolated containers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(slots=True)
+class SandboxResult:
+    """Result returned by a sandbox execution."""
+
+    success: bool
+    logs: str
+    exit_code: int
+
+
+class SandboxRunner:
+    """Execute commands inside an ephemeral container."""
+
+    def __init__(self, image: str, checkout_root: str) -> None:
+        self._image = image
+        self._checkout_root = Path(checkout_root)
+        self._checkout_root.mkdir(parents=True, exist_ok=True)
+
+    async def run(self, repository: str, commands: Sequence[str]) -> SandboxResult:
+        """Execute the provided commands in an isolated container."""
+
+        joined_commands = " && ".join(commands)
+        docker_cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{self._checkout_root}:/workspace",
+            "-e",
+            f"CODEX_REPOSITORY={repository}",
+            self._image,
+            "bash",
+            "-lc",
+            joined_commands,
+        ]
+        process = await asyncio.create_subprocess_exec(
+            *docker_cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await process.communicate()
+        output = stdout.decode("utf-8", errors="ignore")
+        return SandboxResult(success=process.returncode == 0, logs=output, exit_code=process.returncode)

--- a/services/codex_worker/app/worker.py
+++ b/services/codex_worker/app/worker.py
@@ -1,0 +1,169 @@
+"""Asynchronous worker consuming Codex automation events."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from libs.codex import CodexEvent, EventConsumer
+
+from .entitlements import EntitlementChecker
+from .github import GitHubClient
+from .sandbox import SandboxResult, SandboxRunner
+
+LOGGER = logging.getLogger("codex.worker")
+
+
+class CodexWorker:
+    """Consume events and orchestrate automation tasks."""
+
+    def __init__(
+        self,
+        consumer: EventConsumer,
+        github: GitHubClient,
+        sandbox: SandboxRunner,
+        entitlements: EntitlementChecker,
+    ) -> None:
+        self._consumer = consumer
+        self._github = github
+        self._sandbox = sandbox
+        self._entitlements = entitlements
+
+    async def run_forever(self) -> None:
+        """Continuously consume events from the broker."""
+
+        while True:
+            event = await self._consumer.get()
+            try:
+                await self._handle_event(event)
+            except Exception as exc:  # pragma: no cover - best effort logging
+                LOGGER.exception("Failed to process event %s: %s", event.id, exc)
+
+    async def _handle_event(self, event: CodexEvent) -> None:
+        if event.provider == "github":
+            await self._handle_github_event(event)
+        else:
+            LOGGER.info("Ignoring event from provider %s", event.provider)
+
+    async def _handle_github_event(self, event: CodexEvent) -> None:
+        try:
+            payload = event.body_as_json()
+        except ValueError:
+            LOGGER.warning("Received non JSON GitHub payload")
+            return
+
+        event_type = event.event_type or payload.get("action")
+        if event_type != "issue_comment":
+            LOGGER.debug("Unsupported GitHub event type: %s", event_type)
+            return
+
+        if payload.get("action") != "created":
+            LOGGER.debug("Ignoring non creation comment event")
+            return
+
+        comment_body = payload.get("comment", {}).get("body", "")
+        command = self._parse_command(comment_body)
+        if not command:
+            return
+
+        repository = payload.get("repository", {}).get("full_name")
+        pull_number = payload.get("issue", {}).get("number")
+        user = payload.get("comment", {}).get("user", {}).get("login", "")
+        if not repository or not pull_number:
+            LOGGER.warning("Missing repository context in GitHub event")
+            return
+
+        capability = f"codex.{command}"
+        if not self._entitlements.is_allowed(capability, user or "anonymous", repository):
+            await self._github.post_pr_comment(
+                repository,
+                pull_number,
+                "🚫 Vous n'avez pas les droits nécessaires pour exécuter cette commande.",
+            )
+            return
+
+        if command == "plan":
+            await self._execute_plan(repository, pull_number, payload)
+        elif command == "pr":
+            await self._execute_pr(repository, pull_number, payload)
+
+    async def _execute_plan(self, repository: str, pull_number: int, payload: dict[str, Any]) -> None:
+        head_sha = payload.get("issue", {}).get("pull_request", {}).get("head", {}).get("sha")
+        if not head_sha:
+            LOGGER.warning("Unable to determine head SHA for PR #%s", pull_number)
+            return
+
+        check_run = await self._github.create_check_run(
+            repository,
+            {
+                "name": "codex-plan",
+                "head_sha": head_sha,
+                "status": "in_progress",
+            },
+        )
+
+        commands = [
+            "set -e",
+            "mkdir -p /workspace/src",
+            "cd /workspace/src",
+            f"if [ ! -d {repository.split('/')[-1]} ]; then git clone https://github.com/{repository}.git; fi",
+            f"cd {repository.split('/')[-1]}",
+            "git fetch origin",
+            f"git checkout {head_sha}",
+            "pip install -r requirements-dev.txt || true",
+            "pytest",
+        ]
+        result = await self._sandbox.run(repository, commands)
+        await self._finalize_check_run(repository, check_run, result)
+
+        summary = "✅ Plan réussi" if result.success else "❌ Plan en erreur"
+        body = f"{summary}\n\n```\n{result.logs[-4000:]}\n```"
+        await self._github.post_pr_comment(repository, pull_number, body)
+
+    async def _execute_pr(self, repository: str, pull_number: int, payload: dict[str, Any]) -> None:
+        await self._github.post_pr_comment(
+            repository,
+            pull_number,
+            "▶️ Déclenchement du workflow PR...",
+        )
+        await self._github.merge_pull_request(
+            repository,
+            pull_number,
+            payload={"merge_method": "squash"},
+        )
+
+    async def _finalize_check_run(
+        self, repository: str, check_run: dict[str, Any], result: SandboxResult
+    ) -> None:
+        check_run_id = check_run.get("id")
+        if not isinstance(check_run_id, int):
+            LOGGER.warning("Invalid check run identifier returned by GitHub")
+            return
+
+        conclusion = "success" if result.success else "failure"
+        output = {
+            "title": "Codex plan",
+            "summary": result.logs[:1024],
+            "text": result.logs[:65535],
+        }
+        await self._github.update_check_run(
+            repository,
+            check_run_id,
+            {
+                "status": "completed",
+                "conclusion": conclusion,
+                "output": output,
+            },
+        )
+
+    @staticmethod
+    def _parse_command(comment: str) -> str | None:
+        for line in comment.splitlines():
+            line = line.strip()
+            if not line.startswith("/codex"):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                return None
+            return parts[1]
+        return None

--- a/services/codex_worker/requirements-dev.txt
+++ b/services/codex_worker/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.2
+pytest-asyncio>=0.24

--- a/services/codex_worker/requirements.txt
+++ b/services/codex_worker/requirements.txt
@@ -1,0 +1,3 @@
+httpx>=0.27
+openfeature-sdk>=0.8.3
+pydantic>=2.6

--- a/services/codex_worker/tests/test_worker.py
+++ b/services/codex_worker/tests/test_worker.py
@@ -1,0 +1,94 @@
+"""Unit tests for the Codex worker."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from openfeature import api
+from openfeature.provider.in_memory_provider import InMemoryFlag, InMemoryProvider
+
+from libs.codex import CodexEvent, CodexEventPayload
+from services.codex_worker.app.entitlements import EntitlementChecker
+from services.codex_worker.app.worker import CodexWorker
+from services.codex_worker.app.sandbox import SandboxResult
+
+
+@pytest.fixture(autouse=True)
+def configure_openfeature() -> None:
+    flags = {
+        "codex.plan": InMemoryFlag(default_variant="on", variants={"on": True}),
+        "codex.pr": InMemoryFlag(default_variant="on", variants={"on": True}),
+    }
+    api.set_provider(InMemoryProvider(flags))
+    yield
+    api.clear_providers()
+
+
+def make_github_payload(command: str) -> dict[str, object]:
+    return {
+        "action": "created",
+        "comment": {"body": f"/codex {command}", "user": {"login": "alice"}},
+        "issue": {"number": 7, "pull_request": {"head": {"sha": "abc123"}}},
+        "repository": {"full_name": "octo/repo"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_worker_runs_plan() -> None:
+    consumer = AsyncMock()
+    github = AsyncMock()
+    github.create_check_run.return_value = {"id": 42}
+    sandbox = AsyncMock()
+    sandbox.run.return_value = SandboxResult(success=True, logs="tests passed", exit_code=0)
+
+    checker = EntitlementChecker("codex")
+    worker = CodexWorker(consumer, github, sandbox, checker)
+
+    payload = make_github_payload("plan")
+    event = CodexEvent(
+        provider="github",
+        eventType="issue_comment",
+        payload=CodexEventPayload(
+            contentType="application/json",
+            body=json.dumps(payload).encode("utf-8"),
+        ),
+    )
+
+    await worker._handle_event(event)
+
+    github.create_check_run.assert_awaited_once()
+    sandbox.run.assert_awaited_once()
+    github.update_check_run.assert_awaited_once()
+    github.post_pr_comment.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_worker_denies_command_without_entitlement() -> None:
+    flags = {
+        "codex.plan": InMemoryFlag(default_variant="off", variants={"off": False}),
+    }
+    api.set_provider(InMemoryProvider(flags))
+
+    consumer = AsyncMock()
+    github = AsyncMock()
+    sandbox = AsyncMock()
+    checker = EntitlementChecker("codex")
+    worker = CodexWorker(consumer, github, sandbox, checker)
+
+    payload = make_github_payload("plan")
+    event = CodexEvent(
+        provider="github",
+        eventType="issue_comment",
+        payload=CodexEventPayload(
+            contentType="application/json",
+            body=json.dumps(payload).encode("utf-8"),
+        ),
+    )
+
+    await worker._handle_event(event)
+
+    github.post_pr_comment.assert_awaited_once()
+    sandbox.run.assert_not_called()
+    github.create_check_run.assert_not_called()


### PR DESCRIPTION
## Summary
- add a Codex FastAPI gateway that validates GitHub, Stripe, and TradingView webhooks before queueing events
- implement the Codex worker with GitHub Checks/PR integrations, sandbox execution, and OpenFeature entitlement checks
- document Codex operations and provide reusable lint/test/codex-run GitHub workflows

## Testing
- pytest services/codex_gateway/tests services/codex_worker/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d965e7dfa48332b8eceec1f20b115f