### PR TITLE
Fix health checks bypassing entitlements middleware

### DIFF
--- a/libs/entitlements/fastapi.py
+++ b/libs/entitlements/fastapi.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional, Set
 
 from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -22,15 +22,29 @@ class EntitlementsMiddleware(BaseHTTPMiddleware):
         *,
         required_capabilities: Optional[Iterable[str]] = None,
         required_quotas: Optional[Dict[str, int]] = None,
+        skip_paths: Optional[Iterable[str]] = None,
     ) -> None:
         super().__init__(app)
         self._client = client
         self._required_capabilities = list(required_capabilities or [])
         self._required_quotas = dict(required_quotas or {})
         self._bypass = os.getenv("ENTITLEMENTS_BYPASS", "0") == "1"
+        self._skip_paths: Set[str] = {
+            _normalise_path(path) for path in (skip_paths or [])
+        }
 
     async def dispatch(self, request: Request, call_next):
         customer_id = request.headers.get("x-customer-id") or request.headers.get("x-user-id")
+        path = _normalise_path(request.url.path)
+
+        if path in self._skip_paths:
+            request.state.entitlements = Entitlements(
+                customer_id="anonymous",
+                features={},
+                quotas={},
+            )
+            return await call_next(request)
+
         if not customer_id:
             if self._bypass:
                 request.state.entitlements = Entitlements(customer_id="anonymous", features={}, quotas={})
@@ -56,7 +70,11 @@ def install_entitlements_middleware(
     *,
     required_capabilities: Optional[Iterable[str]] = None,
     required_quotas: Optional[Dict[str, int]] = None,
+    skip_paths: Optional[Iterable[str]] = None,
 ) -> None:
+    default_skip_paths = {"/health", "/metrics"}
+    if skip_paths:
+        default_skip_paths.update(_normalise_path(path) for path in skip_paths)
     base_url = os.getenv("ENTITLEMENTS_SERVICE_URL", "http://entitlements-service:8000")
     api_key = os.getenv("ENTITLEMENTS_SERVICE_API_KEY")
     client = EntitlementsClient(base_url, api_key=api_key)
@@ -65,7 +83,20 @@ def install_entitlements_middleware(
         client=client,
         required_capabilities=required_capabilities,
         required_quotas=required_quotas,
+        skip_paths=default_skip_paths,
     )
 
 
 __all__ = ["EntitlementsMiddleware", "install_entitlements_middleware"]
+
+
+def _normalise_path(path: str) -> str:
+    """Return a canonical representation of a URL path for comparisons."""
+
+    if not path:
+        return "/"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+    return path

--- a/services/tests/test_entitlements_middleware.py
+++ b/services/tests/test_entitlements_middleware.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from libs.entitlements.fastapi import install_entitlements_middleware
+
+
+def test_health_endpoint_does_not_require_entitlements(monkeypatch):
+    calls = []
+
+    class DummyClient:
+        async def require(self, *args, **kwargs):  # pragma: no cover - should not be called
+            calls.append((args, kwargs))
+            raise AssertionError("entitlements client should not be invoked")
+
+    monkeypatch.setattr(
+        "libs.entitlements.fastapi.EntitlementsClient",
+        lambda *args, **kwargs: DummyClient(),
+    )
+
+    app = FastAPI()
+    install_entitlements_middleware(app)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert not calls


### PR DESCRIPTION
## Summary
- allow the entitlements middleware to ignore health and metrics routes when evaluating headers
- expose a helper to normalise skip paths and ensure health checks succeed without entitlements
- add a regression test covering the public health endpoint behaviour

## Testing
- pytest services/tests/test_entitlements_middleware.py
- pytest services/auth-service/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a9641e848332b6d321b816fd81dd