### PR TITLE
Add project evaluation and refresh community docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,54 @@
-# Code of Conduct
-Be excellent to each other. No harassment, discrimination, or abuse. Collaborate with respect.
+# Code de conduite de la communauté Trading Bot Open Source
+
+Nous voulons une communauté inclusive, professionnelle et collaborative. Chaque membre — mainteneur,
+contributeur·rice ou utilisateur·rice — s'engage à respecter les principes suivants :
+
+## 1. Principes fondamentaux
+
+- **Respect** : traitez toutes les personnes avec dignité, indépendamment de leur origine, identité,
+  expérience, religion, handicap ou toute autre caractéristique protégée.
+- **Collaboration** : privilégiez la discussion ouverte, la bienveillance et la recherche de solutions
+  constructives.
+- **Intégrité** : soyez honnête dans vos contributions, vos retours et la manière dont vous représentez
+  le projet.
+
+## 2. Comportements attendus
+
+- Utiliser un langage approprié et non violent.
+- Accueillir les nouveaux membres et partager les connaissances de manière pédagogique.
+- Respecter les processus de revue, la propriété intellectuelle et la confidentialité des informations
+  partagées sous NDA ou non publiques.
+- Signaler rapidement les vulnérabilités de sécurité de manière responsable (voir `SECURITY.md` le cas
+  échéant).
+
+## 3. Comportements inacceptables
+
+- Harcèlement, discrimination, trolling, attaques personnelles ou politiques.
+- Publication de contenus offensants, sexualisés ou violents.
+- Partage de données personnelles ou confidentielles sans consentement explicite.
+- Sabotage, exploitation ou tentatives d'accès non autorisé aux systèmes du projet.
+
+## 4. Signalement et application
+
+- Envoyez un e-mail à `maintainers@trading-bot.dev` ou ouvrez un ticket privé si vous êtes témoin ou
+  victime d'un comportement contraire à ce code.
+- Les mainteneurs analyseront chaque signalement rapidement et prendront des mesures appropriées :
+  avertissement, suspension temporaire ou exclusion définitive du projet.
+- Les décisions disciplinaires peuvent être contestées en contactant un·e mainteneur·e référent·e qui
+  n'a pas participé au premier traitement.
+
+## 5. Responsabilité des mainteneurs
+
+- Donner l'exemple en appliquant et en faisant respecter le code.
+- Documenter les incidents de manière confidentielle et protéger la vie privée des personnes impliquées.
+- Communiquer clairement les décisions prises et les recours possibles.
+
+## 6. Portée
+
+Ce code de conduite s'applique à tous les espaces du projet : dépôts Git, issues, pull requests,
+plateformes de discussion synchrones ou asynchrones, évènements en ligne ou physiques.
+
+---
+
+En participant au projet, vous acceptez de respecter ce code de conduite et de contribuer à une
+communauté accueillante et sûre pour toutes et tous.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,67 @@
-# Contribuer
+# Guide de contribution
 
-## Branching
-- `main`: stable.
-- `develop`: intégrations.
-- feature branches: `feat/<slug>`, `chore/<slug>`, `fix/<slug>`.
+Merci de votre intérêt pour Trading Bot Open Source ! Ce guide résume les attentes pour proposer une
+contribution efficace et agréable.
 
-## Commits
-- Style recommandé: Conventional Commits (ex: `feat: add risk engine`).
-- Lint auto via **pre-commit**.
+## 1. Avant de commencer
 
-## Tests & Lint
+- Lisez le [Code de conduite](CODE_OF_CONDUCT.md) et engagez-vous à le respecter.
+- Parcourez les issues existantes et la feuille de route dans `docs/project-evaluation.md` pour
+  identifier les priorités actuelles.
+- Ouvrez une issue si vous souhaitez discuter d'une nouvelle fonctionnalité ou d'un changement majeur
+  avant de démarrer le développement.
+
+## 2. Préparer votre environnement
+
 ```bash
-pre-commit run -a
-pytest -q
+git clone https://github.com/decarvalhoe/trading-bot-open-source.git
+cd trading-bot-open-source
+make setup           # installe les dépendances de développement
+make dev-up          # lance PostgreSQL, Redis et les services principaux
 ```
 
-## PR
-- Petite, testée, description claire, checklist CI verte.
+Consultez `Makefile` et `docs/` pour d'autres commandes utiles (tests E2E, scripts d'import, etc.).
+
+## 3. Stratégie Git
+
+- Branche par fonctionnalité : `feat/<slug>`, `fix/<slug>`, `chore/<slug>`.
+- `main` : branche stable ; `develop` (si existante) pour les intégrations intermédiaires.
+- Rebase régulièrement sur `main` pour limiter les conflits.
+
+## 4. Style de code et commits
+
+- Suivez les conventions [Conventional Commits](https://www.conventionalcommits.org/fr/v1.0.0/).
+- Le formatage et la qualité sont automatisés via `black`, `isort`, `flake8` et `mypy` (mode strict).
+- Avant de pousser, exécutez :
+
+```bash
+pre-commit run -a
+pytest -q            # ajoutez des tests lorsqu'une fonctionnalité est modifiée ou introduite
+make e2e             # optionnel mais recommandé pour valider le parcours auth
+```
+
+Documentez les nouvelles commandes, variables d'environnement ou schémas dans `docs/`.
+
+## 5. Soumettre une Pull Request
+
+1. Vérifiez que les tests passent localement et que la CI s'exécute sans erreur.
+2. Remplissez la description en expliquant la motivation, l'implémentation et les impacts éventuels.
+3. Ajoutez des captures ou extraits de logs pertinents si votre changement touche l'UI ou l'observabilité.
+4. Mentionnez les issues liées (`Fixes #123`).
+5. Soyez prêt·e à itérer suite aux retours de revue.
+
+## 6. Revue de code
+
+- Les mainteneurs valident la cohérence technique, la sécurité et la documentation.
+- Les retours doivent rester respectueux et constructifs ; n'hésitez pas à poser des questions.
+- Un minimum de deux approbations est recommandé pour les changements significatifs (services,
+  schémas de données, infrastructure).
+
+## 7. Contribution non-code
+
+Les contributions sur la documentation, les traductions, la gestion de projet et les tests sont tout
+autant appréciées. Signalez-les via des issues dédiées ou des discussions.
+
+---
+
+Merci de contribuer à faire de Trading Bot Open Source une plateforme fiable et collaborative !

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,10 @@
+# Licence MIT
+
+La licence officielle du projet est reproduite ci-dessous en anglais, conformément au texte MIT
+original. La traduction est fournie uniquement à titre informatif.
+
+---
+
 MIT License
 
 Copyright (c) 2025 Manus
@@ -19,3 +26,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+## Traduction non officielle (résumé)
+
+- Vous pouvez utiliser, copier, modifier et distribuer le logiciel librement.
+- Vous devez conserver l'avis de copyright et la licence dans toutes les copies.
+- Le logiciel est fourni **sans garantie** ; les auteurs ne sont pas responsables des dommages
+  résultant de son utilisation.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Ce trading bot est une plateforme complète qui permet de :
 - 📋 **Alertes et notifications** : Système d'alertes personnalisables
 - 📋 **Rapports détaillés** : Analyses approfondies des résultats
 
+## 📊 Évaluation 2025 & actions futures
+
+Une revue technique complète du dépôt a été réalisée en septembre 2025. Elle confirme la solidité de
+l'architecture actuelle (microservices FastAPI, middleware d'entitlements partagé) et identifie les
+chantiers prioritaires pour livrer un parcours de trading opérationnel.
+
+- **Points forts** : base d'authentification avancée (MFA TOTP, rôles), CI E2E, Makefile facilitant
+  l'onboarding, documentation structurée.
+- **Points d'attention** : services trading encore embryonnaires, couverture de tests limitée, manque
+  d'observabilité et de gouvernance sécurité.
+- **Priorités recommandées (0-3 mois)** : finaliser le `user-service`, cadrer le MVP trading, étendre
+  les tests (unitaires + E2E TOTP), introduire observabilité et gestion sécurisée des secrets.
+
+Retrouvez le rapport détaillé et la feuille de route moyen terme dans
+[`docs/project-evaluation.md`](docs/project-evaluation.md).
+
 ## 🛠️ Pour les développeurs
 
 ### Démarrage rapide

--- a/docs/project-evaluation.md
+++ b/docs/project-evaluation.md
@@ -1,0 +1,95 @@
+# Évaluation du projet Trading Bot Open Source
+
+_Date de l'évaluation : septembre 2025_
+
+## 1. Résumé exécutif
+
+Le projet **Trading Bot Open Source** est une plateforme multi-services orientée vers l'automatisation
+stratégique du trading. L'infrastructure et les premières capacités d'authentification sont bien
+avancées, avec une base technique moderne (FastAPI, SQLAlchemy, architecture microservices) et des
+librairies partagées déjà factorisées pour la configuration et les droits d'usage. Les fonctionnalités
+clés d'orchestration de stratégies, d'intégration marchés et d'observabilité restent à implémenter.
+
+## 2. Architecture et code
+
+- **Microservices FastAPI** : les services `auth-service` et `config-service` exposent des API REST
+  claires avec gestion centralisée des entitlements via un middleware commun.【F:services/auth-service/app/main.py†L1-L76】【F:services/config-service/app/main.py†L1-L32】
+- **Sécurité** : l'authentification prend en charge l'inscription, la connexion, la MFA TOTP et une
+  gestion basique des rôles/quotas.【F:services/auth-service/app/main.py†L12-L72】
+- **Librairies partagées** : le module `libs/entitlements` fournit un client et des helpers pour
+  harmoniser les contrôles d'accès dans toute la plateforme.【F:libs/entitlements/__init__.py†L1-L10】
+- **Qualité du code** : la configuration `pyproject.toml` impose Black, isort, Flake8 strict, et Mypy
+  en mode strict, ce qui prépare une base maintenable à long terme.【F:pyproject.toml†L1-L21】
+
+## 3. Infrastructure et opérations
+
+- **Conteneurisation** : chaque service dispose de son `Dockerfile` et le `docker-compose.yml`
+  orchestre PostgreSQL, Redis et les services applicatifs (auth/user) pour le développement local.
+- **CI/CD** : un workflow GitHub Actions dédié aux tests E2E vérifie l'enregistrement et la connexion,
+  assurant un filet de sécurité fonctionnel minimal.【F:codex.plan.yaml†L1-L109】
+- **Gestion de la configuration** : un service centralisé permet de charger et de mettre à jour les
+  paramètres applicatifs via API.【F:services/config-service/app/main.py†L13-L32】
+
+## 4. Tests et qualité
+
+- **Tests E2E** : scripts Bash et PowerShell exécutent un parcours complet d'inscription/connexion
+  contre l'`auth-service` pour prévenir les régressions critiques.【F:codex.plan.yaml†L45-L92】
+- **Tests unitaires** : la structure `services/.../tests` existe mais la couverture reste limitée, en
+  particulier pour les services autres que l'authentification (tests à compléter).
+- **Automatisation locale** : le `Makefile` expose des cibles pour monter l'environnement et lancer les
+  scénarios E2E, facilitant l'onboarding développeur.【F:codex.plan.yaml†L24-L44】
+
+## 5. Documentation et communauté
+
+- **README** : fournit un aperçu détaillé, un plan de livraison par phases et des instructions de
+  démarrage rapide.【F:README.md†L1-L99】
+- **Guides communautaires** : des documents dédiés au code de conduite, aux contributions et à la
+  licence existent mais nécessitaient un enrichissement (mis à jour dans cette itération).
+
+## 6. Risques et points d'attention
+
+1. **Fonctionnalités trading incomplètes** : les services de marché, d'ordonnancement et d'algo sont
+   présents mais peu implémentés. Priorité à définir les MVP pour éviter la dérive de périmètre.
+2. **Couverture de tests partielle** : absence de tests unitaires/intégrés sur la majorité des services.
+   Risque de régressions lors de l'ajout des fonctionnalités de trading.
+3. **Observabilité** : pas encore de stratégie de logs centralisés, métriques ou alerting documentés.
+4. **Sécurité opérationnelle** : secrets et gestion des clés (JWT, TOTP) doivent être alignés avec des
+   pratiques de rotation et de stockage sécurisé en production.
+
+## 7. Recommandations à court terme (0-3 mois)
+
+1. **Livrer un parcours utilisateur complet** : finaliser le `user-service`, relier les entitlements et
+   exposer une API cohérente pour la gestion des profils.
+2. **Définir le MVP trading** : cadrer les services `algo-engine`, `market_data` et `order-router`
+   autour d'un cas d'usage prioritaire (ex. exécution spot sur un exchange supporté).
+3. **Renforcer les tests** : ajouter des tests unitaires sur les modèles et services auth/config,
+   intégrer des tests contractuels pour les API publiques et étendre l'E2E au TOTP.
+4. **Mettre en place l'observabilité** : standardiser la journalisation (structurée), exposer `/metrics`
+   et ajouter une stack de monitoring (ex. Prometheus + Grafana) dans `docker-compose`.
+5. **Sécuriser la configuration** : introduire un gestionnaire de secrets (Vault, Doppler, AWS SM) et
+   documenter la rotation des clés JWT/TOTP.
+
+## 8. Feuille de route moyen terme (3-9 mois)
+
+- **Automatisation de stratégies** : implémenter un moteur de stratégies scriptables avec backtesting
+  basique et sandbox de simulation.
+- **Connecteurs marchés** : prioriser 1-2 brokers/exchanges, établir des abstractions communes et des
+  tests d'intégration isolés.
+- **Gestion des risques** : ajouter limites d'exposition, stop-loss automatiques et reporting quotidien.
+- **Expérience utilisateur** : prévoir une interface web minimale pour visualiser portefeuilles et
+  alertes.
+- **Gouvernance open-source** : instaurer un calendrier de releases, un backlog public et des sessions
+  communautaires régulières.
+
+## 9. Indicateurs de succès
+
+- Temps moyen d'onboarding développeur < 1 journée (Makefile + docs).
+- Taux de succès des tests E2E > 95 % sur les branches principales.
+- Première stratégie de trading exécutée en sandbox d'ici 3 mois.
+- Couverture de tests unitaires > 60 % sur les services critiques d'ici 6 mois.
+- Communauté active : au moins 5 contributeurs externes ayant merge une PR sur 9 mois.
+
+---
+
+_Pour toute question ou pour planifier un audit technique approfondi, contactez l'équipe de
+mainteneurs via les issues GitHub._


### PR DESCRIPTION
## Summary
- add a comprehensive project evaluation report with recommendations
- surface the evaluation highlights and next actions in the main README
- expand the code of conduct, contributing guide, and license summary for contributors

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9710fb2b88332ba1d3195720c2aa7