### PR TITLE
Update MIT license text to canonical wording

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,8 +6,8 @@ Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to do so, subject to the following
-conditions:
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.


### PR DESCRIPTION
## Summary
- update the MIT license grant clause to match the canonical wording
- ensure the English MIT License text aligns with the standard template while leaving the French summary untouched

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d97bb406048332962bd82a3c3f12b9