### PR TITLE
Add unit test for read_config_for_env JSON loading

### DIFF
--- a/services/config-service/tests/test_config_service.py
+++ b/services/config-service/tests/test_config_service.py
@@ -61,3 +61,18 @@ def test_update_config(tmp_path):
 
     del os.environ["ENVIRONMENT"]
     del os.environ["CONFIG_DATA_DIR"]
+
+
+def test_read_config_for_env_reads_json(tmp_path):
+    config_path = tmp_path / "config.custom.json"
+    config_path.write_text("{\"APP_NAME\": \"Custom-Bot\"}", encoding="utf-8")
+
+    original_config_files = dict(_persistence.CONFIG_FILES)
+    _persistence.CONFIG_FILES["custom"] = str(config_path)
+
+    try:
+        data = _persistence.read_config_for_env("custom")
+        assert data == {"APP_NAME": "Custom-Bot"}
+    finally:
+        _persistence.CONFIG_FILES.clear()
+        _persistence.CONFIG_FILES.update(original_config_files)


### PR DESCRIPTION
## Summary
- add a regression test that ensures `read_config_for_env` successfully loads JSON content from disk

## Testing
- pytest services/config-service/tests/test_config_service.py::test_read_config_for_env_reads_json

------
https://chatgpt.com/codex/tasks/task_e_68d98296f7008332a46dfa0b70447beb