### PR TITLE
Define sandbox trading flow contracts and CLI

### DIFF
--- a/docs/mvp-sandbox-flow.md
+++ b/docs/mvp-sandbox-flow.md
@@ -1,0 +1,37 @@
+# Parcours MVP en environnement sandbox
+
+Ce guide décrit le flux cible entre les services `market_data`, `algo-engine` et `order-router`
+pour une exécution spot simplifiée. Il s'appuie sur les nouveaux contrats de données partagés
+(`schemas/market.py`) et sur les limites configurées dans `providers/limits.py`.
+
+## Endpoints exposés
+
+| Service | Endpoint | Description |
+| --- | --- | --- |
+| `market_data` | `GET /spot/{symbol}?venue=binance.spot` | Retourne un `Quote` synthétique (bid/ask/mid) pour le symbole demandé. |
+| `market_data` | `GET /orderbook/{symbol}?venue=binance.spot` | Fournit un `OrderBookSnapshot` cohérent avec les limites sandbox. |
+| `algo-engine` | `POST /mvp/plan` | Construit un `ExecutionPlan` prêt à être routé (quote + book + ordre). |
+| `order-router` | `POST /plans` | Génère la même vue côté routing en s'appuyant sur les règles de risque. |
+| `order-router` | `POST /orders` | Route l'ordre standardisé et renvoie un `ExecutionReport`. |
+| `order-router` | `GET /orders/log` / `GET /executions` | Suivi des reconnaissances et des remplissages en format partagé. |
+
+## Script CLI `scripts/dev/run_mvp_flow.py`
+
+Le script Python `run_mvp_flow.py` orchestre ce parcours sans dépendre de services
+réels : il consomme la configuration sandbox, construit un `OrderRequest` puis
+un `ExecutionPlan`, et affiche la structure complète en JSON.
+
+```bash
+$ scripts/dev/run_mvp_flow.py BTCUSDT 0.5 --side buy --price 30000
+```
+
+La sortie contient :
+
+- la définition normalisée de l'ordre (`order`),
+- le `Quote` et l'`OrderBookSnapshot` synthétiques,
+- la structure `plan` utilisée par les services,
+- les limites associées à la paire (quantité max, fréquence de rafraîchissement, etc.).
+
+Ce script constitue une démonstration reproductible du flux MVP : les mêmes
+structures sont utilisées par les endpoints REST correspondants, garantissant
+l'alignement contractuel entre les services.

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,5 +1,25 @@
-"""External market data providers used across services."""
+"""External market data providers and sandbox configuration helpers."""
+from __future__ import annotations
 
 from .fmp import FinancialModelingPrepClient, FinancialModelingPrepError
+from .limits import (
+    PairLimit,
+    build_orderbook,
+    build_plan,
+    build_quote,
+    get_pair_limit,
+    iter_supported_pairs,
+    universe,
+)
 
-__all__ = ["FinancialModelingPrepClient", "FinancialModelingPrepError"]
+__all__ = [
+    "FinancialModelingPrepClient",
+    "FinancialModelingPrepError",
+    "PairLimit",
+    "build_orderbook",
+    "build_plan",
+    "build_quote",
+    "get_pair_limit",
+    "iter_supported_pairs",
+    "universe",
+]

--- a/providers/limits.py
+++ b/providers/limits.py
@@ -1,0 +1,182 @@
+"""Shared sandbox trading limits and helper factories."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterable
+
+from schemas.market import (
+    ExecutionPlan,
+    ExecutionVenue,
+    OrderBookLevel,
+    OrderBookSnapshot,
+    OrderRequest,
+    Quote,
+)
+
+
+@dataclass(frozen=True)
+class PairLimit:
+    """Constraints and reference values for a trading pair."""
+
+    symbol: str
+    venue: ExecutionVenue
+    max_position: float
+    max_order_size: float
+    quote_refresh_seconds: float
+    orderbook_refresh_seconds: float
+    reference_price: float
+    tick_size: float
+    depth_levels: int
+
+    def notional_limit(self) -> float:
+        return self.max_position * self.reference_price
+
+
+_SANDBOX_LIMITS: Dict[ExecutionVenue, Dict[str, PairLimit]] = {
+    ExecutionVenue.BINANCE_SPOT: {
+        "BTCUSDT": PairLimit(
+            symbol="BTCUSDT",
+            venue=ExecutionVenue.BINANCE_SPOT,
+            max_position=2.0,
+            max_order_size=0.75,
+            quote_refresh_seconds=1.0,
+            orderbook_refresh_seconds=0.5,
+            reference_price=30_000.0,
+            tick_size=5.0,
+            depth_levels=5,
+        ),
+        "ETHUSDT": PairLimit(
+            symbol="ETHUSDT",
+            venue=ExecutionVenue.BINANCE_SPOT,
+            max_position=50.0,
+            max_order_size=10.0,
+            quote_refresh_seconds=1.0,
+            orderbook_refresh_seconds=0.5,
+            reference_price=2_000.0,
+            tick_size=1.0,
+            depth_levels=5,
+        ),
+    },
+    ExecutionVenue.IBKR_PAPER: {
+        "AAPL": PairLimit(
+            symbol="AAPL",
+            venue=ExecutionVenue.IBKR_PAPER,
+            max_position=5_000.0,
+            max_order_size=1_000.0,
+            quote_refresh_seconds=2.0,
+            orderbook_refresh_seconds=1.0,
+            reference_price=180.0,
+            tick_size=0.05,
+            depth_levels=5,
+        ),
+        "MSFT": PairLimit(
+            symbol="MSFT",
+            venue=ExecutionVenue.IBKR_PAPER,
+            max_position=4_000.0,
+            max_order_size=800.0,
+            quote_refresh_seconds=2.0,
+            orderbook_refresh_seconds=1.0,
+            reference_price=320.0,
+            tick_size=0.05,
+            depth_levels=5,
+        ),
+    },
+}
+
+
+def universe() -> Dict[ExecutionVenue, Dict[str, PairLimit]]:
+    """Return the immutable sandbox limits universe."""
+
+    return _SANDBOX_LIMITS
+
+
+def get_pair_limit(venue: ExecutionVenue, symbol: str) -> PairLimit | None:
+    """Retrieve the configured limits for a symbol."""
+
+    return _SANDBOX_LIMITS.get(venue, {}).get(symbol.upper())
+
+
+def iter_supported_pairs() -> Iterable[PairLimit]:
+    """Iterate over the configured pair limits."""
+
+    for venue_limits in _SANDBOX_LIMITS.values():
+        yield from venue_limits.values()
+
+
+def build_quote(limit: PairLimit) -> Quote:
+    """Construct a synthetic quote snapshot in sandbox mode."""
+
+    bid = limit.reference_price - (limit.tick_size / 2)
+    ask = limit.reference_price + (limit.tick_size / 2)
+    mid = (bid + ask) / 2
+    spread_bps = (ask - bid) / mid * 10_000
+    return Quote(
+        symbol=limit.symbol,
+        venue=limit.venue,
+        bid=bid,
+        ask=ask,
+        mid=mid,
+        spread_bps=spread_bps,
+        timestamp=datetime.now(timezone.utc),
+    )
+
+
+def build_orderbook(limit: PairLimit) -> OrderBookSnapshot:
+    """Generate a deterministic sandbox order book."""
+
+    bids = [
+        OrderBookLevel(
+            price=limit.reference_price - limit.tick_size * (index + 1),
+            size=limit.max_order_size,
+        )
+        for index in range(limit.depth_levels)
+    ]
+    asks = [
+        OrderBookLevel(
+            price=limit.reference_price + limit.tick_size * (index + 1),
+            size=limit.max_order_size,
+        )
+        for index in range(limit.depth_levels)
+    ]
+    return OrderBookSnapshot(
+        symbol=limit.symbol,
+        venue=limit.venue,
+        bids=bids,
+        asks=asks,
+        depth=limit.depth_levels,
+        last_update=datetime.now(timezone.utc),
+    )
+
+
+def build_plan(order: OrderRequest) -> ExecutionPlan:
+    """Compose a sandbox execution plan for the provided order request."""
+
+    limit = get_pair_limit(order.venue, order.symbol)
+    if limit is None:
+        raise ValueError(f"Pair {order.symbol} is not configured for {order.venue}")
+    quote = build_quote(limit)
+    book = build_orderbook(limit)
+    rationale = (
+        f"Sandbox plan for {order.side} {order.quantity} {order.symbol} on {order.venue}."
+        " Risk controls sourced from providers.limits."
+    )
+    return ExecutionPlan(
+        venue=order.venue,
+        symbol=order.symbol,
+        quote=quote,
+        orderbook=book,
+        order=order,
+        rationale=rationale,
+    )
+
+
+__all__ = [
+    "PairLimit",
+    "build_orderbook",
+    "build_plan",
+    "build_quote",
+    "get_pair_limit",
+    "iter_supported_pairs",
+    "universe",
+]

--- a/schemas/market.py
+++ b/schemas/market.py
@@ -1,0 +1,176 @@
+"""Shared market data and order execution contracts."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import List, Self
+
+from pydantic import BaseModel, Field, RootModel, model_validator
+
+
+class ExecutionVenue(str, Enum):
+    """Identifier for the execution venue or liquidity source."""
+
+    BINANCE_SPOT = "binance.spot"
+    IBKR_PAPER = "ibkr.paper"
+    SANDBOX_INTERNAL = "sandbox.internal"
+
+
+class Quote(BaseModel):
+    """Best bid/ask snapshot for a trading symbol."""
+
+    symbol: str
+    venue: ExecutionVenue
+    bid: float = Field(..., gt=0)
+    ask: float = Field(..., gt=0)
+    mid: float = Field(..., gt=0)
+    spread_bps: float = Field(..., ge=0)
+    timestamp: datetime
+
+    @model_validator(mode="after")
+    def _validate_mid(self) -> Self:
+        if self.bid > self.ask:
+            raise ValueError("bid must be lower than ask")
+        implied_mid = (self.bid + self.ask) / 2
+        if abs(self.mid - implied_mid) > 1e-9:
+            object.__setattr__(self, "mid", implied_mid)
+        if self.timestamp.tzinfo is None:
+            object.__setattr__(self, "timestamp", self.timestamp.replace(tzinfo=timezone.utc))
+        return self
+
+
+class OrderBookLevel(BaseModel):
+    price: float = Field(..., gt=0)
+    size: float = Field(..., ge=0)
+
+
+class OrderBookSnapshot(BaseModel):
+    """Aggregated order book levels for a symbol."""
+
+    symbol: str
+    venue: ExecutionVenue
+    bids: List[OrderBookLevel]
+    asks: List[OrderBookLevel]
+    depth: int = Field(..., ge=0)
+    last_update: datetime
+
+    @model_validator(mode="after")
+    def _ensure_depth(self) -> Self:
+        depth = min(len(self.bids), len(self.asks))
+        object.__setattr__(self, "depth", depth)
+        if self.last_update.tzinfo is None:
+            object.__setattr__(self, "last_update", self.last_update.replace(tzinfo=timezone.utc))
+        return self
+
+
+class OrderSide(str, Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+class OrderType(str, Enum):
+    MARKET = "market"
+    LIMIT = "limit"
+
+
+class TimeInForce(str, Enum):
+    GTC = "GTC"
+    IOC = "IOC"
+    FOK = "FOK"
+
+
+class OrderRequest(BaseModel):
+    """Standardised order placement contract."""
+
+    broker: str
+    venue: ExecutionVenue
+    symbol: str
+    side: OrderSide
+    quantity: float = Field(..., gt=0)
+    order_type: OrderType
+    price: float | None = Field(default=None, gt=0)
+    time_in_force: TimeInForce = TimeInForce.GTC
+    estimated_loss: float | None = None
+    client_order_id: str | None = Field(default=None, max_length=36)
+    tags: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_price(self) -> Self:
+        if self.order_type == OrderType.LIMIT and self.price is None:
+            raise ValueError("price is required for limit orders")
+        if self.order_type == OrderType.MARKET:
+            object.__setattr__(self, "price", None)
+        return self
+
+
+class ExecutionStatus(str, Enum):
+    ACCEPTED = "accepted"
+    PARTIALLY_FILLED = "partially_filled"
+    FILLED = "filled"
+    REJECTED = "rejected"
+    CANCELLED = "cancelled"
+
+
+class ExecutionFill(BaseModel):
+    quantity: float = Field(..., ge=0)
+    price: float = Field(..., gt=0)
+    timestamp: datetime
+
+    @model_validator(mode="after")
+    def _ensure_timestamp(self) -> Self:
+        if self.timestamp.tzinfo is None:
+            object.__setattr__(self, "timestamp", self.timestamp.replace(tzinfo=timezone.utc))
+        return self
+
+
+class ExecutionReport(BaseModel):
+    order_id: str
+    status: ExecutionStatus
+    broker: str
+    venue: ExecutionVenue
+    symbol: str
+    side: OrderSide
+    quantity: float
+    filled_quantity: float
+    avg_price: float | None = None
+    submitted_at: datetime
+    fills: list[ExecutionFill] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _timestamps(self) -> Self:
+        if self.submitted_at.tzinfo is None:
+            object.__setattr__(self, "submitted_at", self.submitted_at.replace(tzinfo=timezone.utc))
+        return self
+
+
+class ExecutionPlan(BaseModel):
+    """Aggregate payload linking quote, order book and order intent."""
+
+    venue: ExecutionVenue
+    symbol: str
+    quote: Quote
+    orderbook: OrderBookSnapshot
+    order: OrderRequest
+    rationale: str | None = None
+
+
+class ExecutionPlanList(RootModel[list[ExecutionPlan]]):
+    """Container used by orchestrator endpoints returning multiple plans."""
+
+
+__all__ = [
+    "ExecutionFill",
+    "ExecutionPlan",
+    "ExecutionPlanList",
+    "ExecutionReport",
+    "ExecutionStatus",
+    "ExecutionVenue",
+    "OrderBookLevel",
+    "OrderBookSnapshot",
+    "OrderRequest",
+    "OrderSide",
+    "OrderType",
+    "Quote",
+    "TimeInForce",
+]

--- a/scripts/dev/run_mvp_flow.py
+++ b/scripts/dev/run_mvp_flow.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Trigger the sandbox MVP flow without relying on running services."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from typing import Any
+
+from providers.limits import build_plan, get_pair_limit
+from schemas.market import ExecutionVenue, OrderRequest, OrderSide, OrderType
+
+
+def _parse_order_type(value: str) -> OrderType:
+    try:
+        return OrderType(value.lower())  # type: ignore[arg-type]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Unsupported order type: {value}") from exc
+
+
+def _parse_side(value: str) -> OrderSide:
+    try:
+        return OrderSide(value.lower())  # type: ignore[arg-type]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Unsupported order side: {value}") from exc
+
+
+def _parse_venue(value: str) -> ExecutionVenue:
+    try:
+        return ExecutionVenue(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Unsupported venue: {value}") from exc
+
+
+def _order_dump(order: OrderRequest) -> dict[str, Any]:
+    data = order.model_dump()
+    data["venue"] = order.venue.value
+    data["side"] = order.side.value
+    data["order_type"] = order.order_type.value
+    data["time_in_force"] = order.time_in_force.value
+    return data
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sandbox orchestration for the MVP trading flow")
+    parser.add_argument("symbol", help="Trading symbol to use (e.g. BTCUSDT)")
+    parser.add_argument("quantity", type=float, help="Order quantity to route")
+    parser.add_argument(
+        "--broker",
+        default="binance",
+        help="Broker identifier compatible with the order-router service",
+    )
+    parser.add_argument(
+        "--venue",
+        type=_parse_venue,
+        default=ExecutionVenue.BINANCE_SPOT,
+        help="Execution venue key (default: binance.spot)",
+    )
+    parser.add_argument(
+        "--side",
+        type=_parse_side,
+        default=OrderSide.BUY,
+        help="Order side: buy or sell",
+    )
+    parser.add_argument(
+        "--type",
+        dest="order_type",
+        type=_parse_order_type,
+        default=OrderType.LIMIT,
+        help="Order type: limit or market",
+    )
+    parser.add_argument("--price", type=float, default=None, help="Limit price (ignored for market orders)")
+
+    args = parser.parse_args()
+    limit = get_pair_limit(args.venue, args.symbol)
+    if limit is None:
+        raise SystemExit(f"Symbol {args.symbol} is not configured for venue {args.venue.value}.")
+    if args.quantity > limit.max_order_size:
+        raise SystemExit(
+            f"Requested quantity {args.quantity} exceeds sandbox limit {limit.max_order_size} for {args.symbol}."
+        )
+
+    order = OrderRequest(
+        broker=args.broker,
+        venue=args.venue,
+        symbol=args.symbol,
+        side=args.side,
+        order_type=args.order_type,
+        quantity=args.quantity,
+        price=args.price,
+    )
+    plan = build_plan(order)
+    payload = {
+        "order": _order_dump(order),
+        "quote": plan.quote.model_dump(),
+        "orderbook": plan.orderbook.model_dump(),
+        "plan": plan.model_dump(),
+        "limits": asdict(limit),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/algo-engine/tests/test_strategies.py
+++ b/services/algo-engine/tests/test_strategies.py
@@ -119,3 +119,21 @@ def test_enforce_entitlements_respects_limit():
     with pytest.raises(Exception) as exc:
         _enforce_entitlements(dummy_request, True)
     assert "limit" in str(exc.value)
+
+def test_build_execution_plan():
+    client = TestClient(app)
+    response = client.post(
+        "/mvp/plan",
+        json={
+            "broker": "binance",
+            "symbol": "BTCUSDT",
+            "side": "buy",
+            "order_type": "limit",
+            "quantity": 0.5,
+            "price": 30_000,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["order"]["broker"] == "binance"
+    assert body["orderbook"]["symbol"] == "BTCUSDT"

--- a/services/order-router/app/brokers/binance.py
+++ b/services/order-router/app/brokers/binance.py
@@ -1,7 +1,9 @@
-"""Simplified Binance broker adapter."""
+"""Sandbox Binance adapter returning deterministic execution reports."""
 from __future__ import annotations
 
-from typing import Dict
+from datetime import datetime, timezone
+
+from schemas.market import ExecutionFill, ExecutionReport, ExecutionStatus, OrderRequest
 
 from .base import BrokerAdapter
 
@@ -9,14 +11,29 @@ from .base import BrokerAdapter
 class BinanceAdapter(BrokerAdapter):
     name = "binance"
 
-    def place_order(self, order: Dict[str, float]) -> Dict[str, float]:
-        order_id = f"BN-{len(self.orders) + 1}"
-        enriched = {**order, "order_id": order_id, "status": "accepted"}
-        self.orders.append(enriched)
-        if order.get("quantity", 0) > 0:
-            execution = {"order_id": order_id, "filled_qty": order["quantity"], "price": order.get("price", 0.0)}
-            self.executions.append(execution)
-        return enriched
+    def place_order(self, order: OrderRequest, *, reference_price: float) -> ExecutionReport:
+        price = reference_price if reference_price > 0 else 1.0
+        order_id = f"BN-{len(self.reports()) + 1}"
+        fill = ExecutionFill(
+            quantity=order.quantity,
+            price=price,
+            timestamp=datetime.now(timezone.utc),
+        )
+        report = ExecutionReport(
+            order_id=order_id,
+            status=ExecutionStatus.FILLED,
+            broker=self.name,
+            venue=order.venue,
+            symbol=order.symbol,
+            side=order.side,
+            quantity=order.quantity,
+            filled_quantity=order.quantity,
+            avg_price=price,
+            submitted_at=datetime.now(timezone.utc),
+            fills=[fill],
+            tags=order.tags,
+        )
+        return self._store_report(report)
 
 
 __all__ = ["BinanceAdapter"]

--- a/services/order-router/app/brokers/ibkr.py
+++ b/services/order-router/app/brokers/ibkr.py
@@ -1,7 +1,9 @@
-"""Interactive Brokers adapter."""
+"""Paper IBKR broker adapter used by the sandbox order router."""
 from __future__ import annotations
 
-from typing import Dict
+from datetime import datetime, timezone
+
+from schemas.market import ExecutionFill, ExecutionReport, ExecutionStatus, OrderRequest
 
 from .base import BrokerAdapter
 
@@ -9,18 +11,31 @@ from .base import BrokerAdapter
 class IBKRAdapter(BrokerAdapter):
     name = "ibkr"
 
-    def place_order(self, order: Dict[str, float]) -> Dict[str, float]:
-        order_id = f"IB-{len(self.orders) + 1}"
-        enriched = {**order, "order_id": order_id, "status": "accepted"}
-        self.orders.append(enriched)
-        if order.get("quantity", 0) != 0:
-            execution = {
-                "order_id": order_id,
-                "filled_qty": order["quantity"] * 0.95,
-                "price": order.get("price", 0.0),
-            }
-            self.executions.append(execution)
-        return enriched
+    def place_order(self, order: OrderRequest, *, reference_price: float) -> ExecutionReport:
+        order_id = f"IB-{len(self.reports()) + 1}"
+        fill_price = reference_price if reference_price > 0 else 1.0
+        filled_quantity = order.quantity * 0.95
+        fill = ExecutionFill(
+            quantity=filled_quantity,
+            price=fill_price,
+            timestamp=datetime.now(timezone.utc),
+        )
+        status = ExecutionStatus.PARTIALLY_FILLED if filled_quantity < order.quantity else ExecutionStatus.FILLED
+        report = ExecutionReport(
+            order_id=order_id,
+            status=status,
+            broker=self.name,
+            venue=order.venue,
+            symbol=order.symbol,
+            side=order.side,
+            quantity=order.quantity,
+            filled_quantity=filled_quantity,
+            avg_price=fill_price,
+            submitted_at=datetime.now(timezone.utc),
+            fills=[fill],
+            tags=order.tags,
+        )
+        return self._store_report(report)
 
 
 __all__ = ["IBKRAdapter"]

--- a/services/order-router/app/risk_rules.py
+++ b/services/order-router/app/risk_rules.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Protocol
 
+from schemas.market import OrderRequest
+
 
 class RiskRule(Protocol):
     """Protocol describing a risk validation rule."""
 
-    def validate(self, order: Dict[str, float], context: Dict[str, float]) -> None:
+    def validate(self, order: OrderRequest, context: Dict[str, float]) -> None:
         """Raise :class:`ValueError` when the order violates the rule."""
 
 
@@ -16,22 +18,20 @@ class RiskRule(Protocol):
 class MaxNotionalRule:
     symbol_limits: Dict[str, float]
 
-    def validate(self, order: Dict[str, float], context: Dict[str, float]) -> None:
-        symbol = order["symbol"]
-        qty = order["quantity"]
-        price = order.get("price") or context.get("last_price", 0.0)
-        notional = qty * price
-        limit = self.symbol_limits.get(symbol)
+    def validate(self, order: OrderRequest, context: Dict[str, float]) -> None:
+        price_reference = order.price or context.get("last_price", 0.0)
+        notional = order.quantity * price_reference
+        limit = self.symbol_limits.get(order.symbol)
         if limit is not None and notional > limit:
-            raise ValueError(f"Notional {notional} exceeds limit {limit} for {symbol}")
+            raise ValueError(f"Notional {notional} exceeds limit {limit} for {order.symbol}")
 
 
 @dataclass
 class MaxDailyLossRule:
     max_loss: float
 
-    def validate(self, order: Dict[str, float], context: Dict[str, float]) -> None:
-        estimated = order.get("estimated_loss") or 0.0
+    def validate(self, order: OrderRequest, context: Dict[str, float]) -> None:
+        estimated = order.estimated_loss or 0.0
         projected = context.get("daily_loss", 0.0) + estimated
         if projected < -abs(self.max_loss):
             raise ValueError("Daily loss limit breached")
@@ -43,7 +43,7 @@ class RiskEngine:
     def __init__(self, rules: Iterable[RiskRule]) -> None:
         self._rules: List[RiskRule] = list(rules)
 
-    def validate(self, order: Dict[str, float], context: Dict[str, float]) -> None:
+    def validate(self, order: OrderRequest, context: Dict[str, float]) -> None:
         for rule in self._rules:
             rule.validate(order, context)
 


### PR DESCRIPTION
## Summary
- add shared market data and execution schemas plus sandbox limits for supported pairs
- expose quote, order book and execution planning endpoints across market_data, algo-engine and order-router services
- provide a CLI script and documentation to trigger the MVP sandbox flow end-to-end

## Testing
- pytest services/order-router/tests/test_order_router.py
- pytest services/algo-engine/tests/test_strategies.py

------
https://chatgpt.com/codex/tasks/task_e_68d98a601c7c833282e3e45a004ddd57