### PR TITLE
Add contract tests, TOTP E2E coverage, and coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source =
+    services/auth-service/app
+    services/config-service/app
+    libs
+    scripts
+
+[report]
+omit =
+    */tests/*
+    */migrations/*
+show_missing = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,12 @@ jobs:
           pip install -r services/codex_worker/requirements-dev.txt
       - name: Run test suite
         run: make test
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            htmlcov
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,18 @@
-﻿# Python
+# Python
 __pycache__/
 *.py[cod]
 *.egg-info/
 .venv/
 .env
+
+# Coverage
+.coverage
+htmlcov/
+coverage.xml
+
 # Docker
 *.log
+
 # OS
 .DS_Store
 Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,13 @@ lint:
 	pre-commit run -a
 
 test:
+	python -m pip install -r requirements-dev.txt
+	python -m pip install -r services/auth-service/requirements-dev.txt
 	python -m pip install -r services/config-service/requirements-dev.txt
-	pytest
+	python -m coverage erase
+	python -m coverage run -m pytest
+	python -m coverage xml
+	python -m coverage html
 
 e2e:
 	pwsh -NoProfile -File ./scripts/e2e/auth_e2e.ps1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,5 @@ pytest>=7.4.0
 pytest-asyncio>=0.24.0
 httpx>=0.24.0
 openfeature-sdk>=0.8.3
+schemathesis>=4.1.0
+coverage>=7.6

--- a/scripts/e2e/auth_e2e.sh
+++ b/scripts/e2e/auth_e2e.sh
@@ -11,11 +11,106 @@ curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/register \
   -H "Content-Type: application/json" \
   -d "{\"email\":\"$email\",\"password\":\"$password\"}" >/dev/null
 
-token=$(curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/login \
+login_response=$(curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/login \
   -H "Content-Type: application/json" \
-  -d "{\"email\":\"$email\",\"password\":\"$password\"}" | python -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+  -d "{\"email\":\"$email\",\"password\":\"$password\"}")
+
+token=$(python -c "import sys,json; print(json.load(sys.stdin)['access_token'])" <<<"$login_response")
+refresh=$(python -c "import sys,json; print(json.load(sys.stdin)['refresh_token'])" <<<"$login_response")
 
 curl --noproxy "*" -sS -H "Authorization: Bearer $token" http://127.0.0.1:8011/auth/me >/dev/null
+
+setup_response=$(curl --noproxy "*" -sS -H "Authorization: Bearer $token" http://127.0.0.1:8011/auth/totp/setup)
+secret=$(python -c "import sys,json; print(json.load(sys.stdin)['secret'])" <<<"$setup_response")
+
+invalid_status=$(curl --noproxy "*" -sS -o /tmp/totp-invalid.json -w "%{http_code}" \
+  -H "Authorization: Bearer $token" \
+  "http://127.0.0.1:8011/auth/totp/enable?code=000000")
+if [ "$invalid_status" -ne 400 ]; then
+  echo "Expected 400 when enabling TOTP with an invalid code" >&2
+  exit 1
+fi
+
+valid_code=$(python - <<PY
+import sys
+import pyotp
+print(pyotp.TOTP(sys.argv[1]).now())
+PY
+"$secret")
+
+curl --noproxy "*" -sS -H "Authorization: Bearer $token" \
+  "http://127.0.0.1:8011/auth/totp/enable?code=$valid_code" >/dev/null
+
+missing_status=$(curl --noproxy "*" -sS -o /tmp/totp-login-missing.json -w "%{http_code}" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$email\",\"password\":\"$password\"}" \
+  -X POST http://127.0.0.1:8011/auth/login)
+if [ "$missing_status" -ne 401 ]; then
+  echo "Login without TOTP should be rejected" >&2
+  exit 1
+fi
+
+totp_code=$(python - <<PY
+import sys
+import pyotp
+print(pyotp.TOTP(sys.argv[1]).now())
+PY
+"$secret")
+
+login_with_totp=$(curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$email\",\"password\":\"$password\",\"totp\":\"$totp_code\"}")
+
+token=$(python -c "import sys,json; print(json.load(sys.stdin)['access_token'])" <<<"$login_with_totp")
+
+regen_response=$(curl --noproxy "*" -sS -H "Authorization: Bearer $token" http://127.0.0.1:8011/auth/totp/setup)
+new_secret=$(python -c "import sys,json; print(json.load(sys.stdin)['secret'])" <<<"$regen_response")
+
+if [ "$new_secret" = "$secret" ]; then
+  echo "TOTP regeneration did not issue a new secret" >&2
+  exit 1
+fi
+
+old_code=$(python - <<PY
+import sys
+import pyotp
+print(pyotp.TOTP(sys.argv[1]).now())
+PY
+"$secret")
+
+old_login_status=$(curl --noproxy "*" -sS -o /tmp/totp-login-old.json -w "%{http_code}" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$email\",\"password\":\"$password\",\"totp\":\"$old_code\"}" \
+  -X POST http://127.0.0.1:8011/auth/login)
+if [ "$old_login_status" -ne 401 ]; then
+  echo "Login with stale TOTP should fail" >&2
+  exit 1
+fi
+
+new_code=$(python - <<PY
+import sys
+import pyotp
+print(pyotp.TOTP(sys.argv[1]).now())
+PY
+"$new_secret")
+
+curl --noproxy "*" -sS -H "Authorization: Bearer $token" \
+  "http://127.0.0.1:8011/auth/totp/enable?code=$new_code" >/dev/null
+
+final_code=$(python - <<PY
+import sys
+import pyotp
+print(pyotp.TOTP(sys.argv[1]).now())
+PY
+"$new_secret")
+
+final_login=$(curl --noproxy "*" -sS -X POST http://127.0.0.1:8011/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$email\",\"password\":\"$password\",\"totp\":\"$final_code\"}")
+
+python -c "import sys,json; json.load(sys.stdin)" <<<"$final_login" >/dev/null
+
+token=$(python -c "import sys,json; print(json.load(sys.stdin)['access_token'])" <<<"$final_login")
 
 user_payload=$(cat <<JSON
 {

--- a/services/auth-service/requirements-dev.txt
+++ b/services/auth-service/requirements-dev.txt
@@ -1,5 +1,6 @@
-﻿-r requirements.txt
+-r requirements.txt
 pytest>=8.2
 httpx>=0.27
 fastapi[all]>=0.115
 alembic>=1.13
+schemathesis>=4.1.0

--- a/services/auth-service/tests/_helpers.py
+++ b/services/auth-service/tests/_helpers.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+from sqlalchemy import select
+
+_service_root = Path(__file__).resolve().parents[1]
+_package_name = "auth_service_app"
+_repo_root = _service_root.parents[1]
+
+if str(_repo_root) not in sys.path:
+    sys.path.append(str(_repo_root))
+
+if _package_name not in sys.modules:
+    _package_spec = importlib.util.spec_from_file_location(
+        _package_name,
+        _service_root / "app" / "__init__.py",
+        submodule_search_locations=[str(_service_root / "app")],
+    )
+    assert _package_spec and _package_spec.loader
+    _package_module = importlib.util.module_from_spec(_package_spec)
+    sys.modules[_package_name] = _package_module
+    _package_spec.loader.exec_module(_package_module)  # type: ignore[arg-type]
+
+main = importlib.import_module(f"{_package_name}.main")
+models = importlib.import_module(f"{_package_name}.models")
+schemas = importlib.import_module(f"{_package_name}.schemas")
+security = importlib.import_module(f"{_package_name}.security")
+get_db = importlib.import_module("libs.db.db").get_db
+
+app = main.app  # type: ignore[attr-defined]
+Base = models.Base
+MFATotp = models.MFATotp
+Role = models.Role
+User = models.User
+UserRole = models.UserRole
+
+totp_now = security.totp_now
+TokenPair = schemas.TokenPair
+LoginRequest = schemas.LoginRequest
+RegisterRequest = schemas.RegisterRequest
+TOTPSetup = schemas.TOTPSetup
+Me = schemas.Me
+
+
+def create_user_with_role(session, email: str = "user@example.com", password: str = "secret") -> User:
+    user = User(email=email, password_hash=main.hash_password(password))
+    session.add(user)
+
+    role = session.scalar(select(Role).where(Role.name == "user"))
+    if not role:
+        role = Role(name="user")
+        session.add(role)
+        session.flush()
+
+    session.add(UserRole(user_id=user.id, role_id=role.id))
+    session.commit()
+    session.refresh(user)
+    return user

--- a/services/auth-service/tests/conftest.py
+++ b/services/auth-service/tests/conftest.py
@@ -1,0 +1,76 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+CURRENT_DIR = Path(__file__).resolve().parent
+
+HELPERS_NAME = "auth_service_test_helpers"
+HELPERS_PATH = CURRENT_DIR / "_helpers.py"
+
+
+def _load_helpers(name: str, path: Path) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+helpers = _load_helpers(HELPERS_NAME, HELPERS_PATH)
+
+Base = helpers.Base
+app = helpers.app
+get_db = helpers.get_db
+main = helpers.main
+
+
+@pytest.fixture()
+def session_factory():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    yield TestingSessionLocal
+    Base.metadata.drop_all(engine)
+
+
+@pytest.fixture()
+def client(session_factory):
+    def override_get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def mock_password_hashing(monkeypatch):
+    def _hash(password: str) -> str:
+        return f"hashed::{password}"
+
+    def _verify(password: str, hashed: str) -> bool:
+        return hashed == f"hashed::{password}"
+
+    monkeypatch.setattr(main, "hash_password", _hash)
+    monkeypatch.setattr(main, "verify_password", _verify)

--- a/services/auth-service/tests/test_contract_auth.py
+++ b/services/auth-service/tests/test_contract_auth.py
@@ -1,0 +1,152 @@
+import importlib.util
+import secrets
+import sys
+import time
+from pathlib import Path
+from typing import Generator
+from types import ModuleType
+
+import pyotp
+import pytest
+from schemathesis import openapi
+from sqlalchemy import select
+
+CURRENT_DIR = Path(__file__).resolve().parent
+
+HELPERS_NAME = "auth_service_test_helpers"
+HELPERS_PATH = CURRENT_DIR / "_helpers.py"
+
+
+def _load_helpers(name: str, path: Path) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+helpers = _load_helpers(HELPERS_NAME, HELPERS_PATH)
+
+MFATotp = helpers.MFATotp
+TokenPair = helpers.TokenPair
+TOTPSetup = helpers.TOTPSetup
+User = helpers.User
+app = helpers.app
+get_db = helpers.get_db
+totp_now = helpers.totp_now
+
+
+@pytest.fixture()
+def api_schema(session_factory) -> Generator:
+    def override_get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    schema = openapi.from_asgi("/openapi.json", app)
+    try:
+        yield schema
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_openapi_document_is_valid(api_schema):
+    api_schema.validate()
+    paths = api_schema.raw_schema.get("paths", {})
+    assert "/auth/register" in paths
+    assert "/auth/login" in paths
+    assert "/auth/totp/enable" in paths
+
+
+def test_contract_flows_cover_totp_cycle(client, session_factory, api_schema):
+    email = f"contract-{secrets.token_hex(4)}@example.com"
+    password = "Passw0rd!"
+
+    register_payload = {"email": email, "password": password}
+    register_response = client.post("/auth/register", json=register_payload)
+    assert register_response.status_code == 201
+
+    login_payload = {"email": email, "password": password}
+    first_login = client.post("/auth/login", json=login_payload)
+    assert first_login.status_code == 200
+    tokens = TokenPair.model_validate(first_login.json())
+
+    setup_response = client.post(
+        "/auth/totp/setup",
+        headers={"Authorization": f"Bearer {tokens.access_token}"},
+    )
+    assert setup_response.status_code == 200
+    totp_setup = TOTPSetup.model_validate(setup_response.json())
+
+    invalid_enable = client.post(
+        "/auth/totp/enable",
+        headers={"Authorization": f"Bearer {tokens.access_token}"},
+        params={"code": "000000"},
+    )
+    assert invalid_enable.status_code == 400
+
+    valid_code = pyotp.TOTP(totp_setup.secret).now()
+    enable_response = client.post(
+        "/auth/totp/enable",
+        headers={"Authorization": f"Bearer {tokens.access_token}"},
+        params={"code": valid_code},
+    )
+    assert enable_response.status_code == 200
+
+    missing_totp = client.post("/auth/login", json=login_payload)
+    assert missing_totp.status_code == 401
+
+    timed_code = pyotp.TOTP(totp_setup.secret).now()
+    login_with_totp = client.post(
+        "/auth/login",
+        json={"email": email, "password": password, "totp": timed_code},
+    )
+    assert login_with_totp.status_code == 200
+    tokens = TokenPair.model_validate(login_with_totp.json())
+
+    regenerate = client.post(
+        "/auth/totp/setup",
+        headers={"Authorization": f"Bearer {tokens.access_token}"},
+    )
+    assert regenerate.status_code == 200
+    regenerated = TOTPSetup.model_validate(regenerate.json())
+    assert regenerated.secret != totp_setup.secret
+
+    stale_code = pyotp.TOTP(totp_setup.secret).now()
+    login_with_old_secret = client.post(
+        "/auth/login",
+        json={"email": email, "password": password, "totp": stale_code},
+    )
+    assert login_with_old_secret.status_code == 401
+
+    fresh_code = pyotp.TOTP(regenerated.secret).now()
+    reenable = client.post(
+        "/auth/totp/enable",
+        headers={"Authorization": f"Bearer {tokens.access_token}"},
+        params={"code": fresh_code},
+    )
+    assert reenable.status_code == 200
+
+    time.sleep(0.1)
+    final_code = totp_now(regenerated.secret).now()
+    final_login = client.post(
+        "/auth/login",
+        json={"email": email, "password": password, "totp": final_code},
+    )
+    assert final_login.status_code == 200
+    TokenPair.model_validate(final_login.json())
+
+    with session_factory() as session:
+        user = session.scalar(select(User).where(User.email == email))
+        assert user is not None
+        totp_row = session.get(MFATotp, user.id)
+        assert totp_row is not None
+        assert totp_row.enabled is True
+        assert totp_row.secret == regenerated.secret

--- a/services/config-service/requirements-dev.txt
+++ b/services/config-service/requirements-dev.txt
@@ -1,3 +1,4 @@
-﻿-r requirements.txt
+-r requirements.txt
 pytest>=8.2
 httpx>=0.27
+schemathesis>=4.1.0

--- a/services/config-service/tests/_helpers.py
+++ b/services/config-service/tests/_helpers.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+_service_root = Path(__file__).resolve().parents[1]
+_package_name = "config_service_app"
+_repo_root = _service_root.parents[1]
+
+if str(_repo_root) not in sys.path:
+    sys.path.append(str(_repo_root))
+
+if _package_name not in sys.modules:
+    _package_spec = importlib.util.spec_from_file_location(
+        _package_name,
+        _service_root / "app" / "__init__.py",
+        submodule_search_locations=[str(_service_root / "app")],
+    )
+    assert _package_spec and _package_spec.loader
+    _package_module = importlib.util.module_from_spec(_package_spec)
+    sys.modules[_package_name] = _package_module
+    _package_spec.loader.exec_module(_package_module)  # type: ignore[arg-type]
+
+main = importlib.import_module(f"{_package_name}.main")
+persistence = importlib.import_module(f"{_package_name}.persistence")
+schemas = importlib.import_module(f"{_package_name}.schemas")
+settings_module = importlib.import_module(f"{_package_name}.settings")
+
+app = main.app  # type: ignore[attr-defined]
+ConfigUpdate = schemas.ConfigUpdate
+Settings = settings_module.Settings
+load_settings = settings_module.load_settings
+read_config_for_env = persistence.read_config_for_env
+CONFIG_FILES = persistence.CONFIG_FILES

--- a/services/config-service/tests/conftest.py
+++ b/services/config-service/tests/conftest.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from fastapi.testclient import TestClient
+
+CURRENT_DIR = Path(__file__).resolve().parent
+
+HELPERS_NAME = "config_service_test_helpers"
+HELPERS_PATH = CURRENT_DIR / "_helpers.py"
+
+
+def _load_helpers(name: str, path: Path) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+helpers = _load_helpers(HELPERS_NAME, HELPERS_PATH)
+
+CONFIG_FILES = helpers.CONFIG_FILES
+app = helpers.app
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def config_env(tmp_path) -> Generator[str, None, None]:
+    original_env = os.environ.get("ENVIRONMENT")
+    original_dir = os.environ.get("CONFIG_DATA_DIR")
+    original_mapping = dict(CONFIG_FILES)
+
+    os.environ["ENVIRONMENT"] = "test"
+    os.environ["CONFIG_DATA_DIR"] = str(tmp_path)
+
+    CONFIG_FILES.clear()
+    for env in ("dev", "test", "prod"):
+        CONFIG_FILES[env] = os.path.join(str(tmp_path), f"config.{env}.json")
+
+    try:
+        yield str(tmp_path)
+    finally:
+        CONFIG_FILES.clear()
+        CONFIG_FILES.update(original_mapping)
+
+        if original_env is None:
+            os.environ.pop("ENVIRONMENT", None)
+        else:
+            os.environ["ENVIRONMENT"] = original_env
+        if original_dir is None:
+            os.environ.pop("CONFIG_DATA_DIR", None)
+        else:
+            os.environ["CONFIG_DATA_DIR"] = original_dir

--- a/services/config-service/tests/test_config_service.py
+++ b/services/config-service/tests/test_config_service.py
@@ -1,78 +1,106 @@
-import importlib
 import importlib.util
-import os
 import sys
 from pathlib import Path
+from types import ModuleType
 
-from fastapi.testclient import TestClient
+import pytest
+from pydantic import ValidationError
 
-_service_root = Path(__file__).resolve().parents[1]
-_package_name = "config_service_app"
+CURRENT_DIR = Path(__file__).resolve().parent
 
-if str(_service_root.parents[1]) not in sys.path:
-    sys.path.append(str(_service_root.parents[1]))
-
-if _package_name not in sys.modules:
-    _package_spec = importlib.util.spec_from_file_location(
-        _package_name,
-        _service_root / "app" / "__init__.py",
-        submodule_search_locations=[str(_service_root / "app")],
-    )
-    assert _package_spec and _package_spec.loader
-    _package_module = importlib.util.module_from_spec(_package_spec)
-    sys.modules[_package_name] = _package_module
-    _package_spec.loader.exec_module(_package_module)  # type: ignore[arg-type]
-
-main = importlib.import_module(f"{_package_name}.main")
-_persistence = importlib.import_module(f"{_package_name}.persistence")
-app = main.app  # type: ignore[attr-defined]
-
-client = TestClient(app)
+HELPERS_NAME = "config_service_test_helpers"
+HELPERS_PATH = CURRENT_DIR / "_helpers.py"
 
 
-def test_health_check():
+def _load_helpers(name: str, path: Path) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+helpers = _load_helpers(HELPERS_NAME, HELPERS_PATH)
+
+CONFIG_FILES = helpers.CONFIG_FILES
+ConfigUpdate = helpers.ConfigUpdate
+Settings = helpers.Settings
+load_settings = helpers.load_settings
+read_config_for_env = helpers.read_config_for_env
+
+
+def test_health_check(client):
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
 
-def test_get_current_config():
+def test_get_current_config(client):
     response = client.get("/config/current")
     assert response.status_code == 200
-    data = response.json()
-    assert data["APP_NAME"] == "trading-bot-config"
+    data = Settings.model_validate(response.json())
+    assert data.APP_NAME == "trading-bot-config"
 
 
-def test_update_config(tmp_path):
-    os.environ["ENVIRONMENT"] = "test"
-    os.environ["CONFIG_DATA_DIR"] = str(tmp_path)
-    _persistence.CONFIG_FILES["test"] = os.path.join(str(tmp_path), "config.test.json")
+def test_update_config(client, config_env):
+    config_path = Path(config_env) / "config.test.json"
+    CONFIG_FILES["test"] = str(config_path)
 
-    update_payload = {"APP_NAME": "My-Awesome-Trading-Bot"}
-    response = client.post("/config/update", json=update_payload)
+    update_payload = ConfigUpdate(APP_NAME="My-Awesome-Trading-Bot")
+    response = client.post("/config/update", json=update_payload.model_dump(exclude_none=True))
     assert response.status_code == 200
-    data = response.json()
-    assert data["APP_NAME"] == "My-Awesome-Trading-Bot"
-    assert data["ENVIRONMENT"] == "test"
+    data = Settings.model_validate(response.json())
+    assert data.APP_NAME == "My-Awesome-Trading-Bot"
+    assert data.ENVIRONMENT == "test"
 
-    test_config_path = tmp_path / "config.test.json"
-    assert test_config_path.exists()
-    assert "My-Awesome-Trading-Bot" in test_config_path.read_text(encoding="utf-8")
+    assert config_path.exists()
+    assert "My-Awesome-Trading-Bot" in config_path.read_text(encoding="utf-8")
 
-    del os.environ["ENVIRONMENT"]
-    del os.environ["CONFIG_DATA_DIR"]
+    CONFIG_FILES.pop("test", None)
 
 
 def test_read_config_for_env_reads_json(tmp_path):
     config_path = tmp_path / "config.custom.json"
     config_path.write_text("{\"APP_NAME\": \"Custom-Bot\"}", encoding="utf-8")
 
-    original_config_files = dict(_persistence.CONFIG_FILES)
-    _persistence.CONFIG_FILES["custom"] = str(config_path)
+    original_config_files = dict(CONFIG_FILES)
+    CONFIG_FILES["custom"] = str(config_path)
 
     try:
-        data = _persistence.read_config_for_env("custom")
+        data = read_config_for_env("custom")
         assert data == {"APP_NAME": "Custom-Bot"}
     finally:
-        _persistence.CONFIG_FILES.clear()
-        _persistence.CONFIG_FILES.update(original_config_files)
+        CONFIG_FILES.clear()
+        CONFIG_FILES.update(original_config_files)
+
+
+def test_settings_environment_validation():
+    with pytest.raises(ValidationError):
+        Settings(ENVIRONMENT="invalid")
+
+
+def test_config_update_rejects_incorrect_types():
+    with pytest.raises(ValidationError):
+        ConfigUpdate(APP_NAME=123)  # type: ignore[arg-type]
+
+
+def test_load_settings_merges_environment_file(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.test.json"
+    config_path.write_text("{\"APP_NAME\": \"Merged\", \"ENVIRONMENT\": \"test\"}", encoding="utf-8")
+
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("CONFIG_DATA_DIR", str(tmp_path))
+    CONFIG_FILES["test"] = str(config_path)
+
+    try:
+        merged = load_settings()
+        assert merged.APP_NAME == "Merged"
+        assert merged.ENVIRONMENT == "test"
+    finally:
+        CONFIG_FILES.pop("test", None)
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("CONFIG_DATA_DIR", raising=False)

--- a/services/config-service/tests/test_contract_config.py
+++ b/services/config-service/tests/test_contract_config.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from schemathesis import openapi
+
+CURRENT_DIR = Path(__file__).resolve().parent
+
+HELPERS_NAME = "config_service_test_helpers"
+HELPERS_PATH = CURRENT_DIR / "_helpers.py"
+
+
+def _load_helpers(name: str, path: Path) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+helpers = _load_helpers(HELPERS_NAME, HELPERS_PATH)
+
+ConfigUpdate = helpers.ConfigUpdate
+Settings = helpers.Settings
+app = helpers.app
+
+
+def test_openapi_contract_validates_structure():
+    schema = openapi.from_asgi("/openapi.json", app)
+    schema.validate()
+    assert "/config/current" in schema.raw_schema.get("paths", {})
+    assert "/config/update" in schema.raw_schema.get("paths", {})
+
+
+def test_contract_endpoints_return_declared_models(client, config_env):
+    schema = openapi.from_asgi("/openapi.json", app)
+    current_operation = schema["/config/current"]["get"]
+    current_response = client.get("/config/current")
+    current_operation.validate_response(current_response)
+
+    payload = ConfigUpdate(APP_NAME="Contract-Bot").model_dump(exclude_none=True)
+    update_operation = schema["/config/update"]["post"]
+    response = client.post("/config/update", json=payload)
+    Settings.model_validate(response.json())
+    update_operation.validate_response(response)
+
+    error_response = client.post("/config/update", json={"ENVIRONMENT": "invalid"})
+    assert error_response.status_code == 400

--- a/services/inplay/app/config.py
+++ b/services/inplay/app/config.py
@@ -4,10 +4,16 @@ import functools
 from typing import Dict, List
 
 from pydantic import Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=False,
+        populate_by_name=True,
+    )
+
     redis_url: str = Field("redis://redis:6379/0", alias="INPLAY_REDIS_URL")
     watchlists: Dict[str, List[str]] = Field(
         default_factory=lambda: {
@@ -16,10 +22,6 @@ class Settings(BaseSettings):
         },
         alias="INPLAY_WATCHLISTS",
     )
-
-    class Config:
-        env_file = ".env"
-        case_sensitive = False
 
 
 @functools.lru_cache

--- a/services/reports/tests/test_reports_api.py
+++ b/services/reports/tests/test_reports_api.py
@@ -103,5 +103,8 @@ def test_refresh_reports_creates_snapshots(tmp_path: Path) -> None:
 
     with session_scope() as session:
         snapshots = session.query(ReportSnapshot).all()
-    assert snapshots
-    assert {snapshot.strategy for snapshot in snapshots} == {StrategyName.ORB, StrategyName.IB}
+        strategies = {snapshot.strategy for snapshot in snapshots}
+        count = len(snapshots)
+
+    assert count
+    assert strategies == {StrategyName.ORB, StrategyName.IB}


### PR DESCRIPTION
## Summary
- add helper modules and fixtures for the auth and config services, including new unit tests and schemathesis-backed contract suites
- extend the auth E2E scripts to cover TOTP enrolment, validation, regeneration, and error paths
- configure coverage.py reporting and update the CI workflow to publish the generated artifacts

## Testing
- pytest services/auth-service/tests/test_auth.py -q
- pytest services/auth-service/tests/test_contract_auth.py -q
- pytest services/config-service/tests/test_config_service.py -q
- pytest services/config-service/tests/test_contract_config.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d99016ded883329e3bb77eacad7ecc