### PR TITLE
Add shared observability stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,5 +44,33 @@
     ports:
       - "8012:8000"
 
+  prometheus:
+    image: prom/prometheus:v2.53.1
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    volumes:
+      - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infra/prometheus/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro
+    ports:
+      - "9090:9090"
+    depends_on:
+      - auth-service
+      - user-service
+
+  grafana:
+    image: grafana/grafana:10.4.5
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+    volumes:
+      - ./docs/observability/dashboards:/var/lib/grafana/dashboards:ro
+      - ./infra/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./infra/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+
 volumes:
   pgdata: {}

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,60 @@
+# Observabilité des microservices
+
+Cette section décrit la configuration commune ajoutée à l'ensemble des services FastAPI :
+
+- une journalisation JSON corrélée sur stdout ;
+- un endpoint `/metrics` compatible Prometheus ;
+- le stack de supervision Prometheus + Grafana fourni via `docker-compose`.
+
+## Journalisation JSON corrélée
+
+Chaque service configure désormais automatiquement la journalisation structurée à l'import du module FastAPI. Les logs sont émis au format JSON sur `stdout` et incluent systématiquement les champs suivants :
+
+| Champ | Description |
+| --- | --- |
+| `timestamp` | Horodatage ISO 8601 (UTC, précision milliseconde). |
+| `level` | Niveau de log (`INFO`, `ERROR`, etc.). |
+| `logger` | Nom du logger Python émetteur. |
+| `service` | Identifiant du service (ex. `auth-service`). |
+| `message` | Contenu textuel du log. |
+| `correlation_id` | Identifiant de corrélation propagé via l'en-tête `X-Correlation-ID` (généré si absent). |
+| `request_id` | Identifiant unique généré pour chaque requête HTTP. |
+
+Les erreurs incluent également un champ `exception` avec la trace formatée. Toute donnée supplémentaire transmise via `logging.Logger.extra` est sérialisée (conversion en `str` en dernier recours).
+
+### Propagation
+
+Le middleware `RequestContextMiddleware` recherche les en-têtes `X-Correlation-ID` ou `X-Request-ID`. À défaut, un UUID est créé et ajouté à la réponse. Les identifiants restent disponibles dans le code applicatif via `libs.observability.logging.get_correlation_id()` et `get_request_id()`.
+
+## Endpoint `/metrics`
+
+Tous les services ajoutent automatiquement le middleware Prometheus qui instrumente :
+
+- `http_requests_total{service,method,path,status}` : compteur par statut HTTP ;
+- `http_request_latency_seconds{service,method,path}` : histogramme de latence avec buckets prédéfinis.
+
+L'endpoint `/metrics` est exclu de la documentation OpenAPI mais renvoie les métriques au format exposition Prometheus.
+
+## Prometheus & Grafana
+
+Le fichier `docker-compose.yml` expose deux nouveaux services :
+
+- `prometheus` (port `9090`) chargé avec `infra/prometheus/prometheus.yml` et les règles d'alerte `infra/prometheus/alert_rules.yml` ;
+- `grafana` (port `3000`) pré-provisionné avec une source de données Prometheus et le tableau de bord `docs/observability/dashboards/fastapi-overview.json`.
+
+### Démarrage rapide
+
+```bash
+docker-compose up prometheus grafana
+```
+
+Accédez à Grafana via http://localhost:3000 (login/par défaut `admin`/`admin`). Le tableau de bord **FastAPI - Vue d'ensemble** affiche le débit, la latence P95 et le taux d'erreurs 5xx filtrables par service.
+
+## Alerting
+
+Les règles Prometheus fournies déclenchent :
+
+- **FastAPIHighLatency** : latence moyenne > 500 ms sur 5 minutes (`severity: warning`).
+- **FastAPIHighErrorRate** : taux de 5xx > 5 % sur 10 minutes (`severity: critical`).
+
+La procédure d'escalade associée est détaillée dans `docs/operations/alerting.md`.

--- a/docs/observability/dashboards/fastapi-overview.json
+++ b/docs/observability/dashboards/fastapi-overview.json
@@ -1,0 +1,114 @@
+{
+  "id": null,
+  "uid": "fastapi-overview",
+  "title": "FastAPI - Vue d'ensemble",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        },
+        "query": "label_values(http_requests_total, service)",
+        "refresh": 2,
+        "multi": false,
+        "includeAll": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Débit des requêtes",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"$service\"}[5m])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "req/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latence P95",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_latency_seconds_bucket{service=\"$service\"}[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Taux d'erreur 5xx",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"$service\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{service=\"$service\"}[5m]))",
+          "legendFormat": "Taux 5xx",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      }
+    }
+  ]
+}

--- a/docs/operations/alerting.md
+++ b/docs/operations/alerting.md
@@ -1,0 +1,38 @@
+# Procédure d'escalade des alertes FastAPI
+
+Cette procédure couvre les deux alertes Prometheus livrées par défaut :
+
+- **FastAPIHighLatency** (warning) : latence moyenne > 500 ms pendant 5 minutes.
+- **FastAPIHighErrorRate** (critical) : taux de réponses 5xx > 5 % pendant 10 minutes.
+
+## 1. Détection
+
+1. Prometheus évalue les règles toutes les 15 s.
+2. En cas de déclenchement, un webhook Alertmanager (à configurer selon l'environnement) doit notifier le canal `#trading-alerts` et ouvrir un ticket dans l'outil ITSM.
+
+## 2. Triage initial
+
+| Rôle | Action |
+| --- | --- |
+| Support N1 | Confirme la réalité de l'alerte via Grafana (dashboard *FastAPI - Vue d'ensemble*). |
+| Support N1 | Identifie le service impacté (`labels.service`). |
+| Support N1 | Notifie l'astreinte produit (mail + Slack). |
+
+Si la latence diminue et repasse sous le seuil en moins de 5 minutes supplémentaires, clore l'incident en documentant le ticket.
+
+## 3. Escalade
+
+1. **Astreinte Produit (N2)** – délai de réponse attendu : 15 minutes.
+   - Analyse les métriques détaillées, compare avec les déploiements récents.
+   - Peut déclencher un rollback si une release vient d'avoir lieu.
+2. **Equipe SRE (N3)** – à contacter si :
+   - l'alerte `FastAPIHighErrorRate` reste active > 15 minutes ;
+   - plusieurs services sont impactés simultanément ;
+   - le support N2 demande un support infrastructure.
+   - Contact : téléphone d'astreinte + e-mail `sre@trading-bot.local`.
+
+## 4. Résolution & post-mortem
+
+- Documenter la cause racine et les actions correctives dans le ticket.
+- Programmer un post-mortem si l'alerte critical a duré > 30 minutes ou a généré un impact client.
+- Mettre à jour ce document en cas de changement de contacts ou de seuils.

--- a/infra/grafana/provisioning/dashboards/dashboard.yml
+++ b/infra/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: default
+    orgId: 1
+    folder: Observability
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards
+    updateIntervalSeconds: 30
+    allowUiUpdates: true

--- a/infra/grafana/provisioning/datasources/datasource.yml
+++ b/infra/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/infra/prometheus/alert_rules.yml
+++ b/infra/prometheus/alert_rules.yml
@@ -1,0 +1,21 @@
+groups:
+  - name: fastapi.rules
+    rules:
+      - alert: FastAPIHighLatency
+        expr: sum(rate(http_request_latency_seconds_sum[5m])) / sum(rate(http_request_latency_seconds_count[5m])) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Latence moyenne élevée"
+          description: |
+            La latence moyenne sur 5 minutes dépasse 500 ms (valeur actuelle: {{ printf "%.2f" $value }} s).
+      - alert: FastAPIHighErrorRate
+        expr: sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Taux de réponses 5xx élevé"
+          description: |
+            Plus de 5 % des requêtes retournent un statut 5xx sur 10 minutes (valeur actuelle: {{ printf "%.2f" ($value * 100) }} %).

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alert_rules.yml
+
+scrape_configs:
+  - job_name: fastapi-services
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["auth-service:8000"]
+        labels:
+          service: auth-service
+      - targets: ["user-service:8000"]
+        labels:
+          service: user-service

--- a/libs/observability/__init__.py
+++ b/libs/observability/__init__.py
@@ -1,0 +1,12 @@
+"""Utilities shared across services to standardise observability."""
+
+from .logging import RequestContextMiddleware, configure_logging, get_correlation_id, get_request_id
+from .metrics import setup_metrics
+
+__all__ = [
+    "RequestContextMiddleware",
+    "configure_logging",
+    "get_correlation_id",
+    "get_request_id",
+    "setup_metrics",
+]

--- a/libs/observability/logging.py
+++ b/libs/observability/logging.py
@@ -1,0 +1,173 @@
+"""Structured logging helpers shared by FastAPI services."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+_CORRELATION_ID_CTX: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "correlation_id", default=None
+)
+_REQUEST_ID_CTX: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "request_id", default=None
+)
+_CONFIGURED_SERVICES: set[str] = set()
+
+
+class CorrelationIdFilter(logging.Filter):
+    """Inject correlation identifiers into log records."""
+
+    def __init__(self, service_name: str) -> None:
+        super().__init__()
+        self._service_name = service_name
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - logging side effect
+        record.service = self._service_name
+        record.correlation_id = _CORRELATION_ID_CTX.get()
+        record.request_id = _REQUEST_ID_CTX.get()
+        return True
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Format log records as JSON with a consistent schema."""
+
+    def __init__(self, service_name: str) -> None:
+        super().__init__()
+        self._service_name = service_name
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting side effect
+        payload: dict[str, Any] = {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(timespec="milliseconds"),
+            "level": record.levelname,
+            "logger": record.name,
+            "service": getattr(record, "service", self._service_name),
+            "message": record.getMessage(),
+        }
+        correlation_id = getattr(record, "correlation_id", None)
+        if correlation_id:
+            payload["correlation_id"] = correlation_id
+        request_id = getattr(record, "request_id", None)
+        if request_id:
+            payload["request_id"] = request_id
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = record.stack_info
+
+        reserved = _reserved_log_keys()
+        for key, value in record.__dict__.items():
+            if key in reserved or key in payload:
+                continue
+            try:
+                json.dumps(value)
+                payload[key] = value
+            except TypeError:
+                payload[key] = str(value)
+        return json.dumps(payload, default=str)
+
+
+def _reserved_log_keys() -> set[str]:
+    return {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "message",
+    }
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Populate correlation identifiers for each request."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        service_name: str,
+        correlation_header: str = "X-Correlation-ID",
+    ) -> None:
+        super().__init__(app)
+        self._service_name = service_name
+        self._correlation_header = correlation_header
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        incoming = request.headers.get(self._correlation_header) or request.headers.get(
+            "X-Request-ID"
+        )
+        correlation_id = incoming or uuid.uuid4().hex
+        request_id = uuid.uuid4().hex
+
+        token_corr = _CORRELATION_ID_CTX.set(correlation_id)
+        token_req = _REQUEST_ID_CTX.set(request_id)
+        request.state.correlation_id = correlation_id
+        request.state.request_id = request_id
+
+        response = None
+        try:
+            response = await call_next(request)
+            response.headers.setdefault(self._correlation_header, correlation_id)
+            response.headers.setdefault("X-Request-ID", request_id)
+            return response
+        finally:
+            _CORRELATION_ID_CTX.reset(token_corr)
+            _REQUEST_ID_CTX.reset(token_req)
+
+
+def configure_logging(service_name: str) -> None:
+    """Configure structured logging for the current service."""
+
+    if service_name in _CONFIGURED_SERVICES:
+        return
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonLogFormatter(service_name))
+    handler.addFilter(CorrelationIdFilter(service_name))
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    root_logger.handlers = [handler]
+
+    for logger_name in ("uvicorn", "uvicorn.error", "uvicorn.access", "fastapi"):
+        logger = logging.getLogger(logger_name)
+        logger.handlers = [handler]
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+        logger.addFilter(CorrelationIdFilter(service_name))
+
+    _CONFIGURED_SERVICES.add(service_name)
+
+
+def get_correlation_id() -> Optional[str]:
+    """Return the correlation identifier for the active request context."""
+
+    return _CORRELATION_ID_CTX.get()
+
+
+def get_request_id() -> Optional[str]:
+    """Return the unique request identifier for the active request context."""
+
+    return _REQUEST_ID_CTX.get()

--- a/libs/observability/metrics.py
+++ b/libs/observability/metrics.py
@@ -1,0 +1,85 @@
+"""Prometheus metrics helpers for FastAPI services."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import FastAPI
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+_REQUEST_COUNTER = Counter(
+    "http_requests_total",
+    "Total number of HTTP requests",
+    labelnames=("service", "method", "path", "status"),
+)
+_REQUEST_LATENCY = Histogram(
+    "http_request_latency_seconds",
+    "Latency of HTTP requests in seconds",
+    labelnames=("service", "method", "path"),
+    buckets=(
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+    ),
+)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Collect basic request metrics for Prometheus."""
+
+    def __init__(self, app: ASGIApp, *, service_name: str) -> None:
+        super().__init__(app)
+        self._service_name = service_name
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        route = request.scope.get("route")
+        path_template: str = getattr(route, "path", request.url.path)
+        method = request.method.upper()
+        start = time.perf_counter()
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration = time.perf_counter() - start
+            _REQUEST_COUNTER.labels(self._service_name, method, path_template, "500").inc()
+            _REQUEST_LATENCY.labels(self._service_name, method, path_template).observe(duration)
+            raise
+        duration = time.perf_counter() - start
+        status_code = getattr(response, "status_code", 500)
+        _REQUEST_COUNTER.labels(
+            self._service_name, method, path_template, str(status_code)
+        ).inc()
+        _REQUEST_LATENCY.labels(self._service_name, method, path_template).observe(duration)
+        return response
+
+
+def setup_metrics(app: FastAPI, *, service_name: str) -> None:
+    """Attach Prometheus metrics middleware and endpoint."""
+
+    if getattr(app.state, "_metrics_configured", False):
+        return
+
+    app.add_middleware(MetricsMiddleware, service_name=service_name)
+
+    async def metrics_endpoint() -> Response:
+        payload = generate_latest()
+        return Response(content=payload, media_type=CONTENT_TYPE_LATEST)
+
+    app.add_api_route(
+        "/metrics",
+        metrics_endpoint,
+        methods=["GET"],
+        include_in_schema=False,
+        name="metrics",
+    )
+    app.state._metrics_configured = True

--- a/libs/requirements.common.txt
+++ b/libs/requirements.common.txt
@@ -10,3 +10,4 @@ SQLAlchemy>=2.0
 psycopg2-binary>=2.9
 email-validator
 alembic
+prometheus-client>=0.20

--- a/services/auth-service/requirements.txt
+++ b/services/auth-service/requirements.txt
@@ -6,3 +6,4 @@ passlib[bcrypt]
 python-jose[cryptography]
 pyotp
 pydantic[email]>=2
+prometheus-client>=0.20

--- a/services/billing-service/app/main.py
+++ b/services/billing-service/app/main.py
@@ -6,13 +6,19 @@ from sqlalchemy.orm import Session
 
 from infra import EntitlementsBase
 from libs.db.db import engine, get_db
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 
 from .config import settings
 from .schemas import FeatureIn, PlanFeatureIn, PlanIn
 from .service import attach_features, upsert_feature, upsert_plan
 from .stripe_utils import handle_stripe_event, parse_stripe_payload, verify_webhook_signature
 
+configure_logging("billing-service")
+
 app = FastAPI(title="Billing Service", version="0.1.0")
+app.add_middleware(RequestContextMiddleware, service_name="billing-service")
+setup_metrics(app, service_name="billing-service")
 
 EntitlementsBase.metadata.create_all(bind=engine)
 

--- a/services/billing-service/requirements.txt
+++ b/services/billing-service/requirements.txt
@@ -5,3 +5,4 @@ httpx
 stripe
 psycopg2-binary
 pydantic>=2
+prometheus-client>=0.20

--- a/services/codex_gateway/app/main.py
+++ b/services/codex_gateway/app/main.py
@@ -8,6 +8,8 @@ from typing import Any
 from fastapi import Depends, FastAPI, Request, status
 
 from libs.codex import CodexEvent, CodexEventPayload
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 
 from .config import Settings, get_settings
 from .deps import get_broker
@@ -17,7 +19,11 @@ from .security import (
     verify_tradingview_signature,
 )
 
+configure_logging("codex-gateway")
+
 app = FastAPI(title="Codex Gateway", version="0.1.0")
+app.add_middleware(RequestContextMiddleware, service_name="codex-gateway")
+setup_metrics(app, service_name="codex-gateway")
 
 
 def _extract_event_type(body: bytes) -> str | None:

--- a/services/codex_gateway/requirements.txt
+++ b/services/codex_gateway/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.111
 uvicorn>=0.29
 pydantic>=2.6
 pydantic-settings>=2.3
+prometheus-client>=0.20

--- a/services/config-service/app/main.py
+++ b/services/config-service/app/main.py
@@ -1,12 +1,20 @@
 from fastapi import FastAPI, HTTPException
 
+from fastapi import FastAPI, HTTPException
+
 from .persistence import persist_config
 from .schemas import ConfigUpdate
 from .settings import Settings, load_settings
 from libs.entitlements import install_entitlements_middleware
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
+
+configure_logging("config-service")
 
 app = FastAPI(title="Config Service", version="1.0.0")
 install_entitlements_middleware(app, required_capabilities=["can.use_config"], required_quotas={})
+app.add_middleware(RequestContextMiddleware, service_name="config-service")
+setup_metrics(app, service_name="config-service")
 
 
 @app.get("/health", tags=["Monitoring"])

--- a/services/config-service/requirements.txt
+++ b/services/config-service/requirements.txt
@@ -5,3 +5,4 @@ pydantic-settings>=2.3
 python-dotenv>=1.0
 psycopg2-binary>=2.9
 redis>=5.0
+prometheus-client>=0.20

--- a/services/entitlements-service/app/main.py
+++ b/services/entitlements-service/app/main.py
@@ -5,11 +5,17 @@ from sqlalchemy.orm import Session
 
 from infra import EntitlementsBase
 from libs.db.db import engine, get_db
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 
 from .resolver import resolve_entitlements
 from .schemas import ResolveResponse
 
+configure_logging("entitlements-service")
+
 app = FastAPI(title="Entitlements Service", version="0.1.0")
+app.add_middleware(RequestContextMiddleware, service_name="entitlements-service")
+setup_metrics(app, service_name="entitlements-service")
 
 EntitlementsBase.metadata.create_all(bind=engine)
 

--- a/services/entitlements-service/requirements.txt
+++ b/services/entitlements-service/requirements.txt
@@ -4,3 +4,4 @@ SQLAlchemy>=2
 httpx
 psycopg2-binary
 pydantic>=2
+prometheus-client>=0.20

--- a/services/market_data/app/main.py
+++ b/services/market_data/app/main.py
@@ -21,8 +21,14 @@ from .persistence import persist_ticks
 from .schemas import PersistedTick, TradingViewSignal
 from providers.limits import build_orderbook, build_quote, get_pair_limit
 from schemas.market import ExecutionVenue, OrderBookSnapshot, Quote
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
+
+configure_logging("market-data")
 
 app = FastAPI(title="Market Data Service", version="0.1.0")
+app.add_middleware(RequestContextMiddleware, service_name="market-data")
+setup_metrics(app, service_name="market-data")
 
 
 def get_binance_adapter(settings: Settings = Depends(get_settings)) -> BinanceMarketDataAdapter:

--- a/services/market_data/requirements.txt
+++ b/services/market_data/requirements.txt
@@ -6,3 +6,4 @@ binance-connector>=3.12.0
 ib-async>=2.0.1
 pydantic>=1.10,<3
 pydantic-settings>=2.2
+prometheus-client>=0.20

--- a/services/order-router/app/main.py
+++ b/services/order-router/app/main.py
@@ -9,6 +9,8 @@ from fastapi import FastAPI, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from libs.entitlements import install_entitlements_middleware
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 from providers.limits import build_plan, get_pair_limit, iter_supported_pairs
 from schemas.market import ExecutionPlan, ExecutionReport, OrderRequest
 
@@ -110,8 +112,12 @@ router = OrderRouter(
     ),
 )
 
+configure_logging("order-router")
+
 app = FastAPI(title="Order Router", version="0.1.0")
 install_entitlements_middleware(app, required_capabilities=["can.route_orders"])
+app.add_middleware(RequestContextMiddleware, service_name="order-router")
+setup_metrics(app, service_name="order-router")
 
 
 class OrderPayload(OrderRequest):

--- a/services/reports/app/main.py
+++ b/services/reports/app/main.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from fastapi import Depends, FastAPI, HTTPException
+
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 from sqlalchemy.orm import Session
 
 from schemas.report import ReportResponse
@@ -9,7 +12,11 @@ from .calculations import ReportCalculator, load_report_from_snapshots
 from .database import get_engine, get_session
 from .tables import Base
 
+configure_logging("reports")
+
 app = FastAPI(title="Reports Service", version="0.1.0")
+app.add_middleware(RequestContextMiddleware, service_name="reports")
+setup_metrics(app, service_name="reports")
 
 
 @app.on_event("startup")

--- a/services/screener/app/main.py
+++ b/services/screener/app/main.py
@@ -13,6 +13,8 @@ from infra import ScreenerPreset, ScreenerResult, ScreenerSnapshot
 from libs.db.db import get_db
 from libs.entitlements import install_entitlements_middleware
 from libs.entitlements.client import Entitlements
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 from providers import FinancialModelingPrepClient, FinancialModelingPrepError
 
 from .schemas import (
@@ -22,12 +24,16 @@ from .schemas import (
     ScreenerRunResponse,
 )
 
+configure_logging("screener")
+
 app = FastAPI(title="Screener Service", version="0.1.0")
 install_entitlements_middleware(
     app,
     required_capabilities=["can.use_screener"],
     required_quotas={},
 )
+app.add_middleware(RequestContextMiddleware, service_name="screener")
+setup_metrics(app, service_name="screener")
 
 
 async def get_fmp_client() -> FinancialModelingPrepClient:

--- a/services/screener/requirements.txt
+++ b/services/screener/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 SQLAlchemy>=2
 httpx
 pydantic>=2
+prometheus-client>=0.20

--- a/services/social/app/main.py
+++ b/services/social/app/main.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session
 from infra import AuditBase, Leaderboard, SocialBase
 from libs.db.db import engine, get_db
 from libs.entitlements.fastapi import install_entitlements_middleware
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 
 from .dependencies import (
     get_actor_id,
@@ -33,12 +35,16 @@ from .service import (
     upsert_profile,
 )
 
+configure_logging("social")
+
 app = FastAPI(title="Social Service", version="0.1.0")
 
 SocialBase.metadata.create_all(bind=engine)
 AuditBase.metadata.create_all(bind=engine)
 
 install_entitlements_middleware(app)
+app.add_middleware(RequestContextMiddleware, service_name="social")
+setup_metrics(app, service_name="social")
 
 router = APIRouter(prefix="/social", tags=["social"])
 

--- a/services/streaming/requirements.txt
+++ b/services/streaming/requirements.txt
@@ -5,3 +5,4 @@ pydantic-settings
 # Dépendances optionnelles pour les pipelines externes
 redis>=4.6.0
 nats-py>=2.3.0
+prometheus-client>=0.20

--- a/services/streaming_gateway/app/main.py
+++ b/services/streaming_gateway/app/main.py
@@ -6,15 +6,21 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from libs.entitlements import install_entitlements_middleware
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 
 from .config import get_settings
 from .rate_limit import RateLimiter, rate_limit_middleware
 from .routers import oauth, overlays, sessions, tradingview, websocket
 
+configure_logging("streaming-gateway")
+
 settings = get_settings()
 
 app = FastAPI(title="Streaming Gateway", version="0.1.0")
 install_entitlements_middleware(app, required_capabilities=["can.stream"])
+app.add_middleware(RequestContextMiddleware, service_name="streaming-gateway")
+setup_metrics(app, service_name="streaming-gateway")
 
 app.add_middleware(
     CORSMiddleware,

--- a/services/streaming_gateway/requirements.txt
+++ b/services/streaming_gateway/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 cryptography
+prometheus-client>=0.20

--- a/services/user-service/app/main.py
+++ b/services/user-service/app/main.py
@@ -21,6 +21,8 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 from libs.db.db import get_db
 from libs.entitlements import install_entitlements_middleware
 from libs.entitlements.client import Entitlements
+from libs.observability.logging import RequestContextMiddleware, configure_logging
+from libs.observability.metrics import setup_metrics
 
 from .schemas import (
     PreferencesResponse,
@@ -79,6 +81,8 @@ class UserPreferences(Base):
     )
 
 
+configure_logging("user-service")
+
 app = FastAPI(title="User Service", version="0.1.0")
 install_entitlements_middleware(
     app,
@@ -86,6 +90,8 @@ install_entitlements_middleware(
     required_quotas={},
     skip_paths=["/users/register"],
 )
+app.add_middleware(RequestContextMiddleware, service_name="user-service")
+setup_metrics(app, service_name="user-service")
 
 SENSITIVE_FIELDS = {"email", "full_name", "marketing_opt_in"}
 

--- a/services/user-service/requirements.txt
+++ b/services/user-service/requirements.txt
@@ -4,3 +4,4 @@ pydantic>=2
 SQLAlchemy>=2
 psycopg2-binary
 python-jose[cryptography]
+prometheus-client>=0.20


### PR DESCRIPTION
## Summary
- add shared observability utilities that provide JSON logging with correlation IDs and Prometheus middleware
- instrument all FastAPI services with the common logging middleware and `/metrics` endpoint
- extend docker-compose with Prometheus and Grafana plus provisioning files, dashboards, and alert documentation

## Testing
- python -m compileall libs/observability

------
https://chatgpt.com/codex/tasks/task_e_68d99d5c47b88332ab47385386cbfa26