### PR TITLE
feat: centralize secret management and security hardening

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,17 @@ Document new commands, environment variables, or schemas in `docs/`.
 - Feedback must remain respectful and constructive; feel free to ask for clarifications.
 - At least two approvals are recommended for significant changes (services, data schemas, infrastructure).
 
-### 7. Non-Code Contributions
+### 7. Security Review Checklist
+
+Before merging or approving a pull request, ensure that:
+
+- [ ] Secrets and credentials are retrieved via `libs.secrets` (no secrets in git diffs or plaintext `.env`).
+- [ ] New environment variables or secret keys are documented in `docs/` or service READMEs.
+- [ ] JWT/TOTP changes follow the [rotation guide](docs/security/jwt-totp-key-rotation.md).
+- [ ] External dependencies introduced are vetted for licenses and minimum versions.
+- [ ] Logs or metrics added do not leak sensitive data (PII, secrets, access tokens).
+
+### 8. Non-Code Contributions
 
 Documentation, translations, project management, and testing are equally appreciated. Please surface them via dedicated issues or discussions.
 
@@ -120,7 +130,17 @@ Documentez les nouvelles commandes, variables d'environnement ou schémas dans `
 - Les retours doivent rester respectueux et constructifs ; n'hésitez pas à poser des questions.
 - Un minimum de deux approbations est recommandé pour les changements significatifs (services, schémas de données, infrastructure).
 
-### 7. Contribution non-code
+### 7. Checklist de revue sécurité
+
+Avant de fusionner ou d'approuver une pull request, vérifiez :
+
+- [ ] Les secrets et identifiants sont récupérés via `libs.secrets` (pas de secret en clair dans Git ou `.env`).
+- [ ] Les nouvelles variables d'environnement ou clés secrètes sont documentées dans `docs/` ou les READMEs de service.
+- [ ] Les modifications JWT/TOTP respectent le [guide de rotation](docs/security/jwt-totp-key-rotation.md).
+- [ ] Les dépendances externes ajoutées sont auditées (licence, version minimale, maintenance).
+- [ ] Les logs/metrics n'exposent aucune donnée sensible (PII, secrets, tokens).
+
+### 8. Contribution non-code
 
 Les contributions sur la documentation, les traductions, la gestion de projet et les tests sont tout autant appréciées. Signalez-les via des issues dédiées ou des discussions.
 

--- a/docs/security/jwt-totp-key-rotation.md
+++ b/docs/security/jwt-totp-key-rotation.md
@@ -1,0 +1,44 @@
+# Guide de rotation des clés JWT et TOTP
+
+Ce guide décrit la procédure opérationnelle pour renouveler régulièrement les secrets utilisés par les services `auth-service` et `user-service` afin de signer les JSON Web Tokens (JWT) et générer les graines TOTP. Les rotations fréquentes réduisent la fenêtre d'exploitation en cas d'exposition accidentelle d'un secret.
+
+## Fréquence recommandée
+
+| Secret                         | Fréquence cible | Notes |
+| ------------------------------ | --------------- | ----- |
+| Clé de signature JWT principale | Tous les 30 jours | Synchroniser la rotation avec les déploiements planifiés. |
+| Clé JWT de secours             | Tous les 90 jours | Conserver au moins deux clés actives pour assurer une transition sans coupure. |
+| Graines TOTP utilisateur       | Tous les 180 jours | Lancer la régénération lors des campagnes de sécurité ou des ré-initialisations volontaires.
+
+## Préparation
+
+1. Créer une nouvelle clé dans le gestionnaire de secrets (Vault/Doppler/AWS Secrets Manager) sous un identifiant distinct (`JWT_SECRET_v<date>` par exemple).
+2. Mettre à jour le mappage `SECRET_MANAGER_KEY_MAPPING` si nécessaire pour que les services puissent récupérer la nouvelle clé.
+3. Déployer le secret dans un environnement de pré-production et valider les parcours d'authentification.
+
+## Exécution de la rotation JWT
+
+1. **Phase de chevauchement (24h minimum)**
+   - Ajouter la nouvelle clé JWT en tant que clé secondaire dans `auth-service`. Conserver l'ancienne clé comme clé de vérification.
+   - Déployer en production et confirmer que les nouveaux tokens utilisent la nouvelle clé.
+2. **Phase de retrait**
+   - Après expiration du délai d'overlap (>= 24h ou temps de vie maximal des refresh tokens), retirer la clé sortante du gestionnaire de secrets.
+   - Invalider les refresh tokens encore actifs si un incident est suspecté.
+
+## Rotation des graines TOTP
+
+1. Préparer une communication aux utilisateurs expliquant la nécessité de regénérer leur double authentification.
+2. Activer un flag côté API pour déclencher la régénération (ex: forcer un `reset_required` dans la base).
+3. Les utilisateurs enregistrent un nouveau QR code. Anciennes graines désactivées dès que la nouvelle est confirmée.
+
+## Rollback
+
+- **Échec fonctionnel** : remettre le mappage du secret sur la valeur précédente et redéployer. Les tokens signés avec la nouvelle clé deviendront invalides ; communiquer aux clients qu'une reconnexion est nécessaire.
+- **Incident utilisateur TOTP** : réactiver temporairement la graine précédente (valable < 24h) puis assister l'utilisateur à regénérer une nouvelle graine.
+- Conserver un historique horodaté des clés rotationnées pour permettre une analyse post-mortem.
+
+## Automatisation & audit
+
+- Mettre en place une alerte qui déclenche un ticket si une clé approche sa date d'expiration sans plan de rotation.
+- Journaliser chaque accès de lecture aux secrets dans le gestionnaire de secrets et rapprocher ces logs des déploiements.
+- Documenter chaque rotation dans le runbook d'exploitation avec la date, l'opérateur et le résultat.

--- a/libs/requirements.common.txt
+++ b/libs/requirements.common.txt
@@ -11,3 +11,7 @@ psycopg2-binary>=2.9
 email-validator
 alembic
 prometheus-client>=0.20
+requests>=2.31
+hvac>=1.2
+boto3>=1.34
+cryptography>=42.0

--- a/libs/secrets/__init__.py
+++ b/libs/secrets/__init__.py
@@ -1,0 +1,132 @@
+"""Unified interface for loading application secrets."""
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from typing import Callable, Mapping
+
+from .base import SecretProvider, SecretResolution
+from .providers import (
+    AWSSecretsManagerProvider,
+    DopplerSecretProvider,
+    EnvironmentSecretProvider,
+    VaultSecretProvider,
+)
+
+SecretResolver = Callable[[str, str | None], str | None]
+
+
+class SecretManager:
+    """Resolve secrets from configured providers with optional caching."""
+
+    def __init__(self, provider: SecretProvider, *, cache_enabled: bool = True) -> None:
+        self._provider = provider
+        self._cache_enabled = cache_enabled
+        self._cache: dict[str, str | None] = {}
+
+    @property
+    def provider(self) -> SecretProvider:
+        return self._provider
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        if self._cache_enabled and key in self._cache:
+            return self._cache[key] if self._cache[key] is not None else default
+
+        value = None
+        try:
+            value = self._provider.get_secret(key)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise RuntimeError(
+                f"Unable to resolve secret '{key}' using provider '{self._provider.name}'"
+            ) from exc
+
+        if self._cache_enabled:
+            self._cache[key] = value
+
+        return value if value is not None else default
+
+    def resolve(self, key: str, default: str | None = None) -> SecretResolution:
+        value = self.get(key, default=default)
+        return SecretResolution(key=key, provider=self._provider.name, value=value)
+
+
+def _load_key_mapping() -> Mapping[str, str]:
+    raw_mapping = os.environ.get("SECRET_MANAGER_KEY_MAPPING")
+    if not raw_mapping:
+        return {}
+    try:
+        parsed = json.loads(raw_mapping)
+    except json.JSONDecodeError as exc:  # pragma: no cover - configuration error
+        raise RuntimeError("SECRET_MANAGER_KEY_MAPPING must be valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError("SECRET_MANAGER_KEY_MAPPING must be a JSON object")
+    return parsed
+
+
+def _build_provider() -> SecretProvider:
+    provider = os.environ.get("SECRET_MANAGER_PROVIDER", "environment").strip().lower()
+    mapping = _load_key_mapping()
+
+    if provider in {"env", "environment", "local"}:
+        prefix = os.environ.get("SECRET_MANAGER_ENV_PREFIX")
+        return EnvironmentSecretProvider(prefix=prefix)
+    if provider == "vault":
+        url = os.environ.get("VAULT_ADDR")
+        token = os.environ.get("VAULT_TOKEN")
+        if not url or not token:
+            raise RuntimeError("VAULT_ADDR and VAULT_TOKEN must be set for Vault provider")
+        mount_point = os.environ.get("VAULT_KV_MOUNT", "secret")
+        base_path = os.environ.get("VAULT_SECRET_BASE_PATH", "trading-bot")
+        return VaultSecretProvider(
+            url=url,
+            token=token,
+            mount_point=mount_point,
+            base_path=base_path,
+            key_mapping=mapping,
+        )
+    if provider in {"doppler", "doppler.com"}:
+        token = os.environ.get("DOPPLER_TOKEN")
+        config = os.environ.get("DOPPLER_CONFIG")
+        project = os.environ.get("DOPPLER_PROJECT")
+        if not token or not config or not project:
+            raise RuntimeError(
+                "DOPPLER_TOKEN, DOPPLER_CONFIG and DOPPLER_PROJECT must be set for the Doppler provider"
+            )
+        base_url = os.environ.get("DOPPLER_API_URL", "https://api.doppler.com")
+        return DopplerSecretProvider(
+            token=token,
+            config=config,
+            project=project,
+            base_url=base_url,
+            key_mapping=mapping,
+        )
+    if provider in {"aws", "aws-secrets-manager", "secretsmanager"}:
+        region_name = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+        if not region_name:
+            raise RuntimeError("AWS_REGION or AWS_DEFAULT_REGION must be set for AWS Secrets Manager")
+        prefix = os.environ.get("AWS_SECRETS_PREFIX", "")
+        profile_name = os.environ.get("AWS_PROFILE")
+        return AWSSecretsManagerProvider(
+            region_name=region_name,
+            prefix=prefix,
+            profile_name=profile_name,
+            key_mapping=mapping,
+        )
+
+    raise RuntimeError(f"Unknown secret manager provider: {provider}")
+
+
+@lru_cache(maxsize=1)
+def get_secret_manager() -> SecretManager:
+    return SecretManager(_build_provider())
+
+
+def get_secret(key: str, default: str | None = None) -> str | None:
+    """Convenience wrapper used by services to access secrets."""
+
+    manager = get_secret_manager()
+    return manager.get(key, default=default)
+
+
+__all__ = ["SecretManager", "get_secret_manager", "get_secret"]

--- a/libs/secrets/base.py
+++ b/libs/secrets/base.py
@@ -1,0 +1,32 @@
+"""Common types for secret management providers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Protocol
+
+
+class SecretProvider(Protocol):
+    """Interface implemented by all secret providers."""
+
+    name: str
+
+    def get_secret(self, key: str) -> str | None:
+        """Return the secret value for ``key``.
+
+        Providers should return ``None`` when the secret cannot be located
+        instead of raising an exception. Transient errors can still bubble up to
+        help callers troubleshoot configuration issues.
+        """
+
+
+@dataclass(slots=True)
+class SecretResolution:
+    """Represents how a secret was resolved."""
+
+    key: str
+    provider: str
+    value: str | None
+    metadata: Mapping[str, str] | None = None
+
+
+__all__ = ["SecretProvider", "SecretResolution"]

--- a/libs/secrets/providers.py
+++ b/libs/secrets/providers.py
@@ -1,0 +1,157 @@
+"""Providers for retrieving secrets from various backends."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Mapping
+
+from .base import SecretProvider
+
+
+class EnvironmentSecretProvider:
+    """Load secrets directly from environment variables."""
+
+    name = "environment"
+
+    def __init__(self, prefix: str | None = None) -> None:
+        self._prefix = prefix or ""
+
+    def get_secret(self, key: str) -> str | None:
+        env_key = f"{self._prefix}{key}" if self._prefix else key
+        return os.environ.get(env_key)
+
+
+class VaultSecretProvider:
+    """Retrieve secrets from HashiCorp Vault using the KV v2 engine."""
+
+    name = "vault"
+
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        *,
+        mount_point: str = "secret",
+        base_path: str = "trading-bot",
+        key_mapping: Mapping[str, str] | None = None,
+    ) -> None:
+        try:  # Import lazily to avoid making hvac a hard dependency.
+            import hvac  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "hvac must be installed to use the Vault secret provider"
+            ) from exc
+
+        self._client = hvac.Client(url=url, token=token)
+        self._exceptions = hvac.exceptions
+        self._mount_point = mount_point
+        self._base_path = base_path.strip("/")
+        self._mapping = dict(key_mapping or {})
+
+    def _resolve_path(self, key: str) -> str:
+        return self._mapping.get(key, f"{self._base_path}/{key.lower()}").strip("/")
+
+    def get_secret(self, key: str) -> str | None:
+        path = self._resolve_path(key)
+        try:
+            response = self._client.secrets.kv.v2.read_secret_version(
+                mount_point=self._mount_point,
+                path=path,
+            )
+        except self._exceptions.InvalidPath:
+            return None
+        data = response.get("data", {}).get("data", {})
+        if "value" in data:
+            return data["value"]
+        return data.get(key)
+
+
+class DopplerSecretProvider:
+    """Retrieve secrets from Doppler via its HTTP API."""
+
+    name = "doppler"
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        config: str,
+        project: str,
+        base_url: str = "https://api.doppler.com",
+        key_mapping: Mapping[str, str] | None = None,
+    ) -> None:
+        import requests
+
+        self._requests = requests
+        self._token = token
+        self._config = config
+        self._project = project
+        self._base_url = base_url.rstrip("/")
+        self._mapping = dict(key_mapping or {})
+
+    def _resolve_key(self, key: str) -> str:
+        return self._mapping.get(key, key)
+
+    def get_secret(self, key: str) -> str | None:
+        api_key = self._resolve_key(key)
+        response = self._requests.get(
+            f"{self._base_url}/v3/configs/config/secret",
+            params={"project": self._project, "config": self._config, "name": api_key},
+            headers={"Authorization": f"Bearer {self._token}"},
+            timeout=5,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        payload = response.json()
+        return payload.get("secret", {}).get("raw")
+
+
+class AWSSecretsManagerProvider:
+    """Retrieve secrets from AWS Secrets Manager."""
+
+    name = "aws-secrets-manager"
+
+    def __init__(
+        self,
+        *,
+        region_name: str,
+        prefix: str = "",
+        key_mapping: Mapping[str, str] | None = None,
+        profile_name: str | None = None,
+    ) -> None:
+        try:  # pragma: no cover - optional dependency
+            import boto3  # type: ignore
+            session = boto3.Session(profile_name=profile_name) if profile_name else boto3.Session()
+            self._client = session.client("secretsmanager", region_name=region_name)
+        except Exception as exc:  # pragma: no cover - requires AWS SDK
+            raise RuntimeError(
+                "boto3 must be installed and configured to use AWS Secrets Manager"
+            ) from exc
+        self._prefix = prefix
+        self._mapping = dict(key_mapping or {})
+
+    def _resolve_secret_id(self, key: str) -> str:
+        if key in self._mapping:
+            return self._mapping[key]
+        return f"{self._prefix}{key}" if self._prefix else key
+
+    def get_secret(self, key: str) -> str | None:
+        secret_id = self._resolve_secret_id(key)
+        response = self._client.get_secret_value(SecretId=secret_id)
+        secret_string = response.get("SecretString")
+        if secret_string is None:
+            return None
+        try:
+            data = json.loads(secret_string)
+        except json.JSONDecodeError:
+            return secret_string
+        return data.get(key) or data.get("value")
+
+
+__all__ = [
+    "EnvironmentSecretProvider",
+    "VaultSecretProvider",
+    "DopplerSecretProvider",
+    "AWSSecretsManagerProvider",
+]

--- a/scripts/dev/env_crypto.py
+++ b/scripts/dev/env_crypto.py
@@ -1,0 +1,151 @@
+"""Utilities to encrypt and decrypt local .env files."""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+DEFAULT_PASSPHRASE_ENV = "LOCAL_ENV_PASSPHRASE"
+DEFAULT_SALT_LENGTH = 16
+
+
+class EnvCryptoError(RuntimeError):
+    """Raised when encryption or decryption fails."""
+
+
+def _derive_key(passphrase: str, *, salt: bytes) -> bytes:
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=390000,
+    )
+    return base64.urlsafe_b64encode(kdf.derive(passphrase.encode("utf-8")))
+
+
+def _encrypt(raw: bytes, passphrase: str) -> dict[str, str]:
+    salt = secrets.token_bytes(DEFAULT_SALT_LENGTH)
+    key = _derive_key(passphrase, salt=salt)
+    cipher = Fernet(key)
+    token = cipher.encrypt(raw)
+    return {
+        "salt": base64.b64encode(salt).decode("ascii"),
+        "ciphertext": base64.b64encode(token).decode("ascii"),
+        "version": 1,
+    }
+
+
+def _decrypt(payload: dict[str, Any], passphrase: str) -> bytes:
+    try:
+        salt = base64.b64decode(payload["salt"])
+        ciphertext = base64.b64decode(payload["ciphertext"])
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise EnvCryptoError("Encrypted payload is corrupted") from exc
+    key = _derive_key(passphrase, salt=salt)
+    cipher = Fernet(key)
+    return cipher.decrypt(ciphertext)
+
+
+def _resolve_passphrase(value: str | None, *, env_var: str) -> str:
+    if value:
+        return value
+    env_value = os.getenv(env_var)
+    if env_value:
+        return env_value
+    raise EnvCryptoError(
+        f"Passphrase is required. Provide --passphrase or set the {env_var} environment variable."
+    )
+
+
+def _load_file(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise EnvCryptoError(f"Encrypted file '{path}' not found") from exc
+
+
+def cmd_encrypt(args: argparse.Namespace) -> None:
+    passphrase = _resolve_passphrase(args.passphrase, env_var=args.passphrase_env)
+    source = Path(args.input)
+    if not source.exists():
+        raise EnvCryptoError(f"Input file '{source}' not found")
+    payload = _encrypt(source.read_bytes(), passphrase)
+    Path(args.output).write_text(json.dumps(payload, indent=2))
+
+
+def cmd_decrypt(args: argparse.Namespace) -> None:
+    passphrase = _resolve_passphrase(args.passphrase, env_var=args.passphrase_env)
+    payload = _load_file(Path(args.input))
+    raw = _decrypt(payload, passphrase)
+    output_path = Path(args.output)
+    output_path.write_bytes(raw)
+    if args.print_env:
+        print(raw.decode("utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Encrypt or decrypt local environment files")
+    parser.set_defaults(func=None)
+
+    sub = parser.add_subparsers(dest="command")
+
+    encrypt_parser = sub.add_parser("encrypt", help="Encrypt a plain-text .env file")
+    encrypt_parser.add_argument("--input", default=".env", help="Path to the plain-text file to encrypt")
+    encrypt_parser.add_argument(
+        "--output",
+        default=".env.enc",
+        help="Path where the encrypted payload should be written",
+    )
+    encrypt_parser.add_argument("--passphrase", help="Passphrase used to derive the encryption key")
+    encrypt_parser.add_argument(
+        "--passphrase-env",
+        default=DEFAULT_PASSPHRASE_ENV,
+        help="Environment variable containing the passphrase",
+    )
+    encrypt_parser.set_defaults(func=cmd_encrypt)
+
+    decrypt_parser = sub.add_parser("decrypt", help="Decrypt an encrypted .env payload")
+    decrypt_parser.add_argument("--input", default=".env.enc", help="Encrypted payload to decrypt")
+    decrypt_parser.add_argument(
+        "--output",
+        default=".env.runtime",
+        help="Location where the decrypted file should be written",
+    )
+    decrypt_parser.add_argument("--passphrase", help="Passphrase used to derive the encryption key")
+    decrypt_parser.add_argument(
+        "--passphrase-env",
+        default=DEFAULT_PASSPHRASE_ENV,
+        help="Environment variable containing the passphrase",
+    )
+    decrypt_parser.add_argument(
+        "--print-env",
+        action="store_true",
+        help="Echo the decrypted content to stdout (useful for piping into other tools)",
+    )
+    decrypt_parser.set_defaults(func=cmd_decrypt)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "func", None):
+        parser.print_help()
+        return
+    try:
+        args.func(args)
+    except EnvCryptoError as exc:  # pragma: no cover - CLI guard
+        parser.error(str(exc))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry-point
+    main()

--- a/scripts/dev/start.sh
+++ b/scripts/dev/start.sh
@@ -1,4 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${PROJECT_ROOT}" >/dev/null 2>&1
+
+ENCRYPTED_ENV_FILE="${ENCRYPTED_ENV_FILE:-.env.enc}"
+TEMP_ENV_FILE=""
+
+if [[ -f "${ENCRYPTED_ENV_FILE}" ]]; then
+    echo "-> decrypting ${ENCRYPTED_ENV_FILE}"
+    TEMP_ENV_FILE="$(mktemp)"
+    python -m scripts.dev.env_crypto decrypt --input "${ENCRYPTED_ENV_FILE}" --output "${TEMP_ENV_FILE}"
+    set -a
+    # shellcheck source=/dev/null
+    source "${TEMP_ENV_FILE}"
+    set +a
+    cleanup() {
+        if [[ -f "${TEMP_ENV_FILE}" ]]; then
+            rm -f "${TEMP_ENV_FILE}"
+        fi
+    }
+    trap cleanup EXIT
+fi
+
 docker compose up -d --build
 echo "-> dev up. config-service: http://localhost:8000"

--- a/services/auth-service/app/security.py
+++ b/services/auth-service/app/security.py
@@ -1,41 +1,73 @@
-﻿import os, pyotp
-from jose import jwt
-from passlib.context import CryptContext
+"""Security helpers for the auth service."""
+from __future__ import annotations
+
+import os
 from datetime import datetime, timedelta, timezone
 
-JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret-change-me")
+import pyotp
+from jose import jwt
+from passlib.context import CryptContext
+
+from libs.secrets import get_secret
+
+JWT_SECRET = get_secret("JWT_SECRET", default="dev-secret-change-me")
 JWT_ALG = "HS256"
 ACCESS_MIN = int(os.getenv("ACCESS_MIN", "15"))
 REFRESH_DAYS = int(os.getenv("REFRESH_DAYS", "7"))
 
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-def hash_password(p: str) -> str:
-    return pwd.hash(p)
 
-def verify_password(p: str, hashed: str) -> bool:
-    return pwd.verify(p, hashed)
+def hash_password(password: str) -> str:
+    return pwd.hash(password)
 
-def create_token_pair(sub: str, roles: list[str]):
+
+def verify_password(password: str, hashed: str) -> bool:
+    return pwd.verify(password, hashed)
+
+
+def create_token_pair(sub: str, roles: list[str]) -> tuple[str, str]:
     now = datetime.now(timezone.utc)
     access = jwt.encode(
-        {"sub": sub, "roles": roles, "iat": int(now.timestamp()), "exp": int((now + timedelta(minutes=ACCESS_MIN)).timestamp())},
+        {
+            "sub": sub,
+            "roles": roles,
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(minutes=ACCESS_MIN)).timestamp()),
+        },
         JWT_SECRET,
         algorithm=JWT_ALG,
     )
     refresh = jwt.encode(
-        {"sub": sub, "type": "refresh", "iat": int(now.timestamp()), "exp": int((now + timedelta(days=REFRESH_DAYS)).timestamp())},
+        {
+            "sub": sub,
+            "type": "refresh",
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(days=REFRESH_DAYS)).timestamp()),
+        },
         JWT_SECRET,
         algorithm=JWT_ALG,
     )
     return access, refresh
 
-def verify_token(token: str):
+
+def verify_token(token: str) -> dict:
     return jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALG])
+
 
 def generate_totp_secret() -> str:
     return pyotp.random_base32()
 
+
 def totp_now(secret: str) -> pyotp.TOTP:
     return pyotp.TOTP(secret)
 
+
+__all__ = [
+    "hash_password",
+    "verify_password",
+    "create_token_pair",
+    "verify_token",
+    "generate_totp_secret",
+    "totp_now",
+]

--- a/services/billing-service/app/config.py
+++ b/services/billing-service/app/config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+from libs.secrets import get_secret
+
 
 @dataclass(slots=True)
 class Settings:
@@ -12,9 +14,11 @@ class Settings:
 
     @classmethod
     def load(cls) -> "Settings":
-        api_key = os.getenv("STRIPE_API_KEY", "test_stripe_api_key")
-        webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET", "whsec_test")
-        return cls(stripe_api_key=api_key, stripe_webhook_secret=webhook_secret)
+        api_key = get_secret("STRIPE_API_KEY", default=os.getenv("STRIPE_API_KEY", "test_stripe_api_key"))
+        webhook_secret = get_secret(
+            "STRIPE_WEBHOOK_SECRET", default=os.getenv("STRIPE_WEBHOOK_SECRET", "whsec_test")
+        )
+        return cls(stripe_api_key=api_key or "", stripe_webhook_secret=webhook_secret or "")
 
 
 settings = Settings.load()

--- a/services/market_data/app/config.py
+++ b/services/market_data/app/config.py
@@ -5,6 +5,8 @@ import functools
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
+from libs.secrets import get_secret
+
 
 class Settings(BaseSettings):
     database_url: str = Field(
@@ -23,6 +25,23 @@ class Settings(BaseSettings):
         case_sensitive = False
 
 
+_SECRET_KEYS = [
+    "MARKET_DATA_DATABASE_URL",
+    "TRADINGVIEW_HMAC_SECRET",
+    "BINANCE_API_KEY",
+    "BINANCE_API_SECRET",
+]
+
+
+def _secret_overrides() -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for key in _SECRET_KEYS:
+        value = get_secret(key)
+        if value is not None:
+            overrides[key] = value
+    return overrides
+
+
 @functools.lru_cache
 def get_settings() -> Settings:
-    return Settings()
+    return Settings(**_secret_overrides())

--- a/services/screener/app/main.py
+++ b/services/screener/app/main.py
@@ -15,6 +15,7 @@ from libs.entitlements import install_entitlements_middleware
 from libs.entitlements.client import Entitlements
 from libs.observability.logging import RequestContextMiddleware, configure_logging
 from libs.observability.metrics import setup_metrics
+from libs.secrets import get_secret
 from providers import FinancialModelingPrepClient, FinancialModelingPrepError
 
 from .schemas import (
@@ -38,7 +39,7 @@ setup_metrics(app, service_name="screener")
 
 async def get_fmp_client() -> FinancialModelingPrepClient:
     base_url = os.getenv("FMP_BASE_URL", "https://financialmodelingprep.com/api/v3")
-    api_key = os.getenv("FMP_API_KEY")
+    api_key = get_secret("FMP_API_KEY", default=os.getenv("FMP_API_KEY"))
     client = FinancialModelingPrepClient(api_key=api_key, base_url=base_url)
     async with client as session:
         yield session

--- a/services/streaming/app/dependencies.py
+++ b/services/streaming/app/dependencies.py
@@ -6,6 +6,7 @@ from typing import Iterable
 from fastapi import HTTPException, Request, status
 
 from libs.entitlements.client import EntitlementsClient, EntitlementsError
+from libs.secrets import get_secret
 
 from .config import Settings, get_settings
 from .pipeline import StreamingBridge
@@ -44,7 +45,7 @@ class WebsocketAuthorizer:
         self._settings = settings
         self._bypass = os.getenv("ENTITLEMENTS_BYPASS", "0") == "1"
         base_url = os.getenv("ENTITLEMENTS_SERVICE_URL", "http://entitlements-service:8000")
-        api_key = os.getenv("ENTITLEMENTS_SERVICE_API_KEY")
+        api_key = get_secret("ENTITLEMENTS_SERVICE_API_KEY", default=os.getenv("ENTITLEMENTS_SERVICE_API_KEY"))
         self._client = EntitlementsClient(base_url, api_key=api_key)
 
     async def authorize(self, websocket) -> str:

--- a/services/user-service/app/main.py
+++ b/services/user-service/app/main.py
@@ -23,6 +23,7 @@ from libs.entitlements import install_entitlements_middleware
 from libs.entitlements.client import Entitlements
 from libs.observability.logging import RequestContextMiddleware, configure_logging
 from libs.observability.metrics import setup_metrics
+from libs.secrets import get_secret
 
 from .schemas import (
     PreferencesResponse,
@@ -32,7 +33,8 @@ from .schemas import (
     UserUpdate,
 )
 
-JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret-change-me")
+_default_jwt_secret = os.getenv("JWT_SECRET", "dev-secret-change-me")
+JWT_SECRET = get_secret("JWT_SECRET", default=_default_jwt_secret) or _default_jwt_secret
 JWT_ALG = "HS256"
 
 


### PR DESCRIPTION
## Summary
- add a shared secret manager with environment, Vault, Doppler and AWS Secrets Manager providers
- switch services to resolve JWT, API keys and database secrets through the new helper
- secure local .env handling with an encryption CLI and document JWT/TOTP rotation together with a security review checklist

## Testing
- pytest services/user-service/tests/test_user.py -q *(fails: missing optional dependency `prometheus_client` in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a6a05e148332be08c29beb85da50