### PR TITLE
Add declarative strategy support and simulation backtesting

### DIFF
--- a/docs/strategies/README.md
+++ b/docs/strategies/README.md
@@ -1,0 +1,78 @@
+# Strategies - Declarative Format & APIs
+
+The algo engine now accepts declarative strategies that can be defined either in YAML (JSON is valid YAML) or in a lightweight Python file. Declarative strategies allow non-developers to describe trading rules that are dynamically evaluated by the engine and can be simulated before being promoted to live trading.
+
+## Declarative schema
+
+A declarative strategy definition is a mapping with the following keys:
+
+- `name` (**required**): Human readable strategy name.
+- `rules` (**required**): List of rule blocks. Each rule must define:
+  - `when`: A condition tree composed of `field`, `operator`, `value` entries or nested `any` / `all` arrays.
+  - `signal`: Arbitrary payload describing the action emitted when the condition is true (for example `{"action": "buy", "size": 1}`).
+- `parameters` (optional): Additional configuration keys copied into the strategy configuration.
+- `metadata` (optional): Arbitrary descriptive attributes stored alongside the strategy.
+
+### YAML example
+
+```yaml
+name: Gap Reversal
+parameters:
+  timeframe: 1h
+  risk: medium
+rules:
+  - when:
+      any:
+        - { field: close, operator: gt, value: 102 }
+        - { field: close, operator: lt, value: 98 }
+    signal:
+      action: rebalance
+      size: 1
+metadata:
+  author: quant-team
+  tags:
+    - declarative
+```
+
+### Python example
+
+```python
+STRATEGY = {
+    "name": "Python Breakout",
+    "rules": [
+        {
+            "when": {"field": "close", "operator": "gt", "value": 100},
+            "signal": {"action": "buy", "size": 1},
+        },
+        {
+            "when": {"field": "close", "operator": "lt", "value": 95},
+            "signal": {"action": "sell", "size": 1},
+        },
+    ],
+    "parameters": {"timeframe": "1h"},
+    "metadata": {"created_by": "quantops"},
+}
+```
+
+Python strategies may alternatively expose a `build_strategy()` function returning the same mapping. The Python loader runs in a restricted namespace with access to basic builtins only.
+
+## API usage
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/strategies/import` | `POST` | Import a declarative strategy. Body: `{ "format": "yaml" | "python", "content": "...", "name": "optional override", "tags": [], "enabled": false }`. Returns the created strategy record. |
+| `/strategies/{strategy_id}/export?fmt=yaml` | `GET` | Export the original source content for a declarative strategy. The requested format must match the original. |
+| `/strategies/{strategy_id}/backtest` | `POST` | Run a simulation for the given strategy. Body: `{ "market_data": [ {"close": 100}, ... ], "initial_balance": 10000 }`. Returns performance metrics and file paths containing logs and equity data. |
+
+Imported strategies are stored with their original source (for re-export) and the evaluated definition under `parameters.definition`.
+
+## Simulation & artefacts
+
+Backtests run through the `/strategies/{id}/backtest` endpoint leverage the new simulation mode. Results are saved inside `data/backtests/`:
+
+- `<strategy>_TIMESTAMP.json` – metrics, equity curve and summary.
+- `<strategy>_TIMESTAMP.log` – chronological trade log.
+
+Each backtest updates the orchestrator state with `mode = "simulation"` and exposes the latest summary under `/state` (`last_simulation`).
+
+Make sure the `data/backtests` directory is writable in your deployment target if you want to persist the artefacts.

--- a/services/algo-engine/app/backtest.py
+++ b/services/algo-engine/app/backtest.py
@@ -1,0 +1,129 @@
+"""Simple backtesting utilities for the algo engine."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+from .strategies.base import StrategyBase
+
+
+def _safe_filename(name: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name)
+
+
+def _max_drawdown(equity_curve: Sequence[float]) -> float:
+    peak = equity_curve[0] if equity_curve else 0.0
+    max_dd = 0.0
+    for value in equity_curve:
+        peak = max(peak, value)
+        drawdown = (peak - value) / peak if peak else 0.0
+        max_dd = max(max_dd, drawdown)
+    return max_dd
+
+
+@dataclass
+class BacktestSummary:
+    strategy_name: str
+    trades: int
+    total_return: float
+    max_drawdown: float
+    equity_curve: List[float] = field(default_factory=list)
+    metrics_path: str = ""
+    log_path: str = ""
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "strategy_name": self.strategy_name,
+            "trades": self.trades,
+            "total_return": self.total_return,
+            "max_drawdown": self.max_drawdown,
+            "equity_curve": self.equity_curve,
+            "metrics_path": self.metrics_path,
+            "log_path": self.log_path,
+        }
+
+
+class Backtester:
+    """Runs basic long-only simulations for declarative rules."""
+
+    def __init__(self, output_dir: Path | str = Path("data/backtests")) -> None:
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def run(
+        self,
+        strategy: StrategyBase,
+        market_data: Sequence[Dict[str, Any]],
+        *,
+        initial_balance: float = 10_000.0,
+    ) -> BacktestSummary:
+        balance = initial_balance
+        position_size = 0.0
+        entry_price = 0.0
+        trades = 0
+        logs: List[str] = []
+        equity_curve: List[float] = [balance]
+
+        for index, snapshot in enumerate(market_data):
+            price = float(snapshot.get("close") or snapshot.get("price") or 0.0)
+            signals = strategy.generate_signals(snapshot)
+            for signal in signals:
+                action = signal.get("action")
+                size = float(signal.get("size", 1.0))
+                if action == "buy" and position_size == 0:
+                    position_size = size
+                    entry_price = price
+                    logs.append(f"[{index}] BUY size={size} price={price}")
+                elif action == "sell" and position_size > 0:
+                    pnl = (price - entry_price) * position_size
+                    balance += pnl
+                    trades += 1
+                    logs.append(f"[{index}] SELL size={position_size} price={price} pnl={pnl}")
+                    position_size = 0
+                    entry_price = 0
+            equity = balance
+            if position_size > 0:
+                equity += (price - entry_price) * position_size
+            equity_curve.append(equity)
+
+        if position_size > 0:
+            final_price = float(market_data[-1].get("close") or market_data[-1].get("price") or 0.0)
+            pnl = (final_price - entry_price) * position_size
+            balance += pnl
+            trades += 1
+            logs.append(f"[final] SELL size={position_size} price={final_price} pnl={pnl}")
+            equity_curve.append(balance)
+
+        total_return = (balance - initial_balance) / initial_balance if initial_balance else 0.0
+        drawdown = _max_drawdown(equity_curve)
+
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        safe_name = _safe_filename(strategy.config.name)
+        metrics_path = self.output_dir / f"{safe_name}_{timestamp}.json"
+        log_path = self.output_dir / f"{safe_name}_{timestamp}.log"
+
+        metrics = {
+            "strategy": strategy.config.name,
+            "trades": trades,
+            "total_return": total_return,
+            "max_drawdown": drawdown,
+            "equity_curve": equity_curve,
+        }
+        metrics_path.write_text(json.dumps(metrics, indent=2))
+        log_path.write_text("\n".join(logs))
+
+        return BacktestSummary(
+            strategy_name=strategy.config.name,
+            trades=trades,
+            total_return=total_return,
+            max_drawdown=drawdown,
+            equity_curve=equity_curve,
+            metrics_path=str(metrics_path),
+            log_path=str(log_path),
+        )
+
+
+__all__ = ["Backtester", "BacktestSummary"]

--- a/services/algo-engine/app/declarative.py
+++ b/services/algo-engine/app/declarative.py
@@ -1,0 +1,125 @@
+"""Helpers to load declarative strategy definitions."""
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+
+try:  # pragma: no cover - import guarded for environments without PyYAML
+    import yaml
+except Exception:  # pragma: no cover - fallback handled at runtime
+    yaml = None  # type: ignore[assignment]
+
+
+class DeclarativeStrategyError(RuntimeError):
+    """Raised when a declarative strategy cannot be parsed."""
+
+
+SAFE_GLOBALS: Mapping[str, object] = {
+    "__builtins__": {
+        "True": True,
+        "False": False,
+        "None": None,
+        "dict": dict,
+        "list": list,
+        "tuple": tuple,
+        "set": set,
+        "float": float,
+        "int": int,
+        "str": str,
+        "max": max,
+        "min": min,
+        "sum": sum,
+    }
+}
+
+
+@dataclass(slots=True)
+class DeclarativeDefinition:
+    name: str
+    rules: list[dict[str, Any]]
+    parameters: dict[str, Any]
+    metadata: dict[str, Any]
+
+    def to_parameters(self) -> Dict[str, Any]:
+        params = dict(self.parameters)
+        params.setdefault("definition", {
+            "name": self.name,
+            "rules": self.rules,
+            "metadata": self.metadata,
+        })
+        return params
+
+
+def _validate_definition(payload: Mapping[str, Any]) -> DeclarativeDefinition:
+    if not isinstance(payload, Mapping):
+        raise DeclarativeStrategyError("Declarative strategies must be defined as mappings")
+    name = payload.get("name")
+    rules = payload.get("rules", [])
+    parameters = payload.get("parameters", {})
+    metadata = payload.get("metadata", {})
+
+    if not isinstance(name, str) or not name:
+        raise DeclarativeStrategyError("Declarative strategy definitions require a non-empty 'name'")
+    if not isinstance(rules, list):
+        raise DeclarativeStrategyError("'rules' must be a list of rule definitions")
+    if not isinstance(parameters, Mapping):
+        raise DeclarativeStrategyError("'parameters' must be a mapping")
+    if not isinstance(metadata, Mapping):
+        raise DeclarativeStrategyError("'metadata' must be a mapping")
+
+    for idx, rule in enumerate(rules):
+        if not isinstance(rule, Mapping):
+            raise DeclarativeStrategyError(f"Rule #{idx + 1} must be a mapping")
+        if "when" not in rule or "signal" not in rule:
+            raise DeclarativeStrategyError("Each rule must define 'when' and 'signal' sections")
+
+    return DeclarativeDefinition(
+        name=name,
+        rules=list(rules),
+        parameters=dict(parameters),
+        metadata=dict(metadata),
+    )
+
+
+def load_declarative_definition(content: str, fmt: str) -> DeclarativeDefinition:
+    """Load a declarative strategy definition from YAML or Python content."""
+
+    fmt = fmt.lower()
+    if fmt == "yaml":
+        if yaml is not None:
+            data = yaml.safe_load(content)  # type: ignore[no-untyped-call]
+        else:
+            try:
+                data = json.loads(content)
+            except json.JSONDecodeError as exc:
+                raise DeclarativeStrategyError("PyYAML is required to load YAML strategies") from exc
+    elif fmt == "python":
+        namespace: Dict[str, Any] = {}
+        try:
+            compiled = ast.parse(content, mode="exec")
+        except SyntaxError as exc:  # pragma: no cover - syntax errors bubble up
+            raise DeclarativeStrategyError(f"Invalid Python strategy: {exc}") from exc
+        exec(compile(compiled, "<strategy>", "exec"), dict(SAFE_GLOBALS), namespace)  # noqa: S102
+        if "build_strategy" in namespace and callable(namespace["build_strategy"]):
+            data = namespace["build_strategy"]()
+        elif "STRATEGY" in namespace:
+            data = namespace["STRATEGY"]
+        else:
+            raise DeclarativeStrategyError("Python strategies must define STRATEGY or build_strategy()")
+    else:
+        raise DeclarativeStrategyError("Unsupported declarative format; expected 'yaml' or 'python'")
+
+    if data is None:
+        raise DeclarativeStrategyError("Strategy definition is empty")
+
+    return _validate_definition(data)
+
+
+__all__ = [
+    "DeclarativeDefinition",
+    "DeclarativeStrategyError",
+    "load_declarative_definition",
+]

--- a/services/algo-engine/app/strategies/base.py
+++ b/services/algo-engine/app/strategies/base.py
@@ -14,6 +14,7 @@ class StrategyConfig:
     parameters: Dict[str, Any] = field(default_factory=dict)
     enabled: bool = False
     tags: Iterable[str] | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 class StrategyBase(abc.ABC):

--- a/services/algo-engine/app/strategies/declarative.py
+++ b/services/algo-engine/app/strategies/declarative.py
@@ -1,0 +1,74 @@
+"""Declarative strategy implementation evaluated against market state."""
+from __future__ import annotations
+
+import operator
+from typing import Any, Dict, Mapping
+
+from .base import StrategyBase, register_strategy
+
+
+OPERATORS: Mapping[str, Any] = {
+    "eq": operator.eq,
+    "ne": operator.ne,
+    "gt": operator.gt,
+    "gte": operator.ge,
+    "lt": operator.lt,
+    "lte": operator.le,
+}
+
+
+def _resolve(path: str, state: Mapping[str, Any]) -> Any:
+    current: Any = state
+    for part in path.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+def _evaluate_condition(condition: Mapping[str, Any], state: Mapping[str, Any]) -> bool:
+    if "all" in condition:
+        return all(_evaluate_condition(sub, state) for sub in condition["all"])
+    if "any" in condition:
+        return any(_evaluate_condition(sub, state) for sub in condition["any"])
+
+    field = condition.get("field")
+    operator_key = condition.get("operator", "eq")
+    target = condition.get("value")
+
+    if not isinstance(field, str):
+        return False
+    op = OPERATORS.get(str(operator_key).lower())
+    if op is None:
+        raise ValueError(f"Unsupported operator '{operator_key}' in declarative rule")
+    actual = _resolve(field, state)
+    return op(actual, target)
+
+
+@register_strategy
+class DeclarativeStrategy(StrategyBase):
+    key = "declarative"
+
+    def __init__(self, config):  # type: ignore[override]
+        super().__init__(config)
+        definition = config.parameters.get("definition", {})
+        if not isinstance(definition, Mapping):
+            raise ValueError("Declarative strategies require a 'definition' mapping in parameters")
+        self._rules = list(definition.get("rules", []))
+        if not isinstance(self._rules, list):
+            raise ValueError("Declarative strategy rules must be a list")
+
+    def generate_signals(self, market_state: Dict[str, Any]) -> list[Dict[str, Any]]:  # type: ignore[override]
+        signals: list[Dict[str, Any]] = []
+        for rule in self._rules:
+            when = rule.get("when", {})
+            signal = rule.get("signal", {})
+            if not when or not signal:
+                continue
+            if _evaluate_condition(when, market_state):
+                signals.append(dict(signal))
+        return signals
+
+
+__all__ = ["DeclarativeStrategy"]


### PR DESCRIPTION
## Summary
- enable declarative strategy ingestion with source metadata, import/export APIs, and simulation state tracking
- add backtesting module that saves performance artefacts to data/backtests and expose simulation endpoint
- document declarative formats and cover new workflows with tests

## Testing
- pytest services/algo-engine

------
https://chatgpt.com/codex/tasks/task_e_68d9a8a4f0d08332abdafe7424e1f288