### PR TITLE
Define shared market and execution connector interfaces

### DIFF
--- a/libs/connectors/__init__.py
+++ b/libs/connectors/__init__.py
@@ -1,0 +1,4 @@
+"""Connector interfaces shared across services."""
+from .interfaces import ExecutionClient, MarketConnector
+
+__all__ = ["ExecutionClient", "MarketConnector"]

--- a/libs/connectors/interfaces.py
+++ b/libs/connectors/interfaces.py
@@ -1,0 +1,41 @@
+"""Common connector interfaces for market data and execution clients."""
+from __future__ import annotations
+
+import abc
+from typing import Any, AsyncIterator, Iterable
+
+
+class MarketConnector(abc.ABC):
+    """Abstract base class for market data providers.
+
+    The interface intentionally keeps the contract minimal so that concrete
+    implementations can expose vendor specific keyword arguments when
+    necessary. Implementations are expected to honour rate limiting and retry
+    semantics internally when interacting with upstream APIs.
+    """
+
+    @abc.abstractmethod
+    async def fetch_ohlcv(self, instrument: Any, **kwargs: Any) -> Iterable[Any]:
+        """Retrieve OHLCV bars for the requested instrument."""
+
+    @abc.abstractmethod
+    async def stream_trades(self, instrument: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        """Yield trades/ticks for the requested instrument."""
+
+
+class ExecutionClient(abc.ABC):
+    """Abstract base class for order execution clients."""
+
+    name: str
+
+    @abc.abstractmethod
+    def place_order(self, order: Any, **kwargs: Any) -> Any:
+        """Submit an order to the remote venue."""
+
+    @abc.abstractmethod
+    def cancel_order(self, order_id: str) -> Any:
+        """Cancel an order that was previously submitted."""
+
+    @abc.abstractmethod
+    def fetch_executions(self) -> Iterable[Any]:
+        """Fetch execution reports from the remote venue."""

--- a/services/market_data/README.md
+++ b/services/market_data/README.md
@@ -1,0 +1,28 @@
+# Market Data Service Connectors
+
+This service exposes reusable market data connectors that implement the shared
+`MarketConnector` interface from `libs.connectors`. Each connector is
+responsible for handling its own rate limiting windows and retry strategies when
+communicating with upstream exchanges.
+
+## Rate limiting
+
+* **Binance** – Requests are throttled by an asynchronous sliding-window rate
+  limiter. The limiter enforces the `request_rate` over the configured time
+  interval before allowing additional REST calls.
+* **IBKR** – The connector mirrors Interactive Brokers' native pacing rules by
+  deferring requests through the same rate limiter abstraction before issuing
+  historical data queries.
+
+## Retries
+
+Both connectors automatically retry websocket subscriptions or market data
+requests when they experience transient disconnects:
+
+* The Binance websocket client reopens the stream after temporary connection
+  errors and continues streaming once reconnected.
+* The IBKR client reconnects to the gateway, resubmits market data subscriptions
+  and resumes iteration whenever socket-level errors are raised.
+
+See `services/market_data/tests/test_connector_integration.py` for integration
+examples that exercise these behaviours using docker-style fixtures.

--- a/services/market_data/adapters/__init__.py
+++ b/services/market_data/adapters/__init__.py
@@ -1,12 +1,12 @@
-from .binance import BinanceMarketDataAdapter
+from .binance import BinanceMarketConnector
 from .dtc import DTCAdapter, DTCConfig
-from .ibkr import IBKRMarketDataAdapter
+from .ibkr import IBKRMarketConnector
 from .rate_limiter import AsyncRateLimiter
 
 __all__ = [
     "AsyncRateLimiter",
-    "BinanceMarketDataAdapter",
+    "BinanceMarketConnector",
     "DTCAdapter",
     "DTCConfig",
-    "IBKRMarketDataAdapter",
+    "IBKRMarketConnector",
 ]

--- a/services/market_data/adapters/binance.py
+++ b/services/market_data/adapters/binance.py
@@ -8,13 +8,15 @@ from typing import Any, AsyncIterator, Callable, Dict, Iterable
 from binance.spot import Spot
 from binance.websocket.websocket_client import BinanceWebsocketClient
 
+from libs.connectors import MarketConnector
+
 from .rate_limiter import AsyncRateLimiter
 
 
 logger = logging.getLogger(__name__)
 
 
-class BinanceMarketDataAdapter:
+class BinanceMarketConnector(MarketConnector):
     """Adapter that exposes a coroutine-based interface over Binance's APIs."""
 
     def __init__(

--- a/services/market_data/adapters/ibkr.py
+++ b/services/market_data/adapters/ibkr.py
@@ -6,13 +6,15 @@ from typing import Any, AsyncIterator, Iterable
 
 from ib_async.ib import IB
 
+from libs.connectors import MarketConnector
+
 from .rate_limiter import AsyncRateLimiter
 
 
 logger = logging.getLogger(__name__)
 
 
-class IBKRMarketDataAdapter:
+class IBKRMarketConnector(MarketConnector):
     """Adapter that wraps the asynchronous interface exposed by ``ib_async``."""
 
     def __init__(
@@ -66,7 +68,7 @@ class IBKRMarketDataAdapter:
             formatDate=format_date,
         )
 
-    async def stream_ticks(self, contract: Any) -> AsyncIterator[Any]:
+    async def stream_trades(self, contract: Any) -> AsyncIterator[Any]:
         while True:
             try:
                 await self.ensure_connected()

--- a/services/market_data/app/main.py
+++ b/services/market_data/app/main.py
@@ -14,7 +14,7 @@ from fastapi import (
     Request,
 )
 
-from ..adapters import BinanceMarketDataAdapter, IBKRMarketDataAdapter
+from ..adapters import BinanceMarketConnector, IBKRMarketConnector
 from .config import Settings, get_settings
 from .database import session_scope
 from .persistence import persist_ticks
@@ -31,15 +31,15 @@ app.add_middleware(RequestContextMiddleware, service_name="market-data")
 setup_metrics(app, service_name="market-data")
 
 
-def get_binance_adapter(settings: Settings = Depends(get_settings)) -> BinanceMarketDataAdapter:
-    return BinanceMarketDataAdapter(
+def get_binance_adapter(settings: Settings = Depends(get_settings)) -> BinanceMarketConnector:
+    return BinanceMarketConnector(
         api_key=settings.binance_api_key,
         api_secret=settings.binance_api_secret,
     )
 
 
-def get_ibkr_adapter(settings: Settings = Depends(get_settings)) -> IBKRMarketDataAdapter:
-    return IBKRMarketDataAdapter(
+def get_ibkr_adapter(settings: Settings = Depends(get_settings)) -> IBKRMarketConnector:
+    return IBKRMarketConnector(
         host=settings.ibkr_host,
         port=settings.ibkr_port,
         client_id=settings.ibkr_client_id,

--- a/services/market_data/tests/test_connector_integration.py
+++ b/services/market_data/tests/test_connector_integration.py
@@ -1,0 +1,189 @@
+"""Integration tests for market connectors using docker-style fixtures."""
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+from libs.connectors import MarketConnector
+from services.market_data.adapters import BinanceMarketConnector, IBKRMarketConnector
+
+
+@dataclass
+class MockDockerService:
+    """Utility representing a dockerised dependency for integration tests."""
+
+    name: str
+    startup_delay: float = 0.0
+
+    async def ready(self) -> None:
+        await asyncio.sleep(self.startup_delay)
+
+
+class DockerisedBinanceRestClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def klines(self, *, symbol: str, interval: str, limit: int) -> list[list[Any]]:
+        self.calls.append({"symbol": symbol, "interval": interval, "limit": limit})
+        return [[1_000, "1", "2", "0.5", "1.5", "10", 1_060, "100", 5]]
+
+
+class DockerisedBinanceStream:
+    def __init__(
+        self,
+        *,
+        on_message: Callable[..., None],
+        on_close: Callable[..., None],
+        on_error: Callable[..., None],
+        responses: Iterable[str],
+        error_on_first: bool,
+        **_: Any,
+    ) -> None:
+        self._on_message = on_message
+        self._on_close = on_close
+        self._on_error = on_error
+        self._responses = list(responses)
+        self._error_on_first = error_on_first
+        self.subscriptions: list[str] = []
+
+    def subscribe(self, stream: str) -> None:
+        self.subscriptions.append(stream)
+        for index, payload in enumerate(self._responses):
+            self._on_message(json.dumps({"p": payload, "s": stream.split("@")[0].upper()}))
+            if self._error_on_first and index == 0:
+                self._on_error(ConnectionError("transient"))
+                return
+        self._on_close()
+
+    def stop(self) -> None:  # pragma: no cover - no resources to release in tests
+        return None
+
+
+async def _binance_docker_clients() -> dict[str, Any]:
+    service = MockDockerService(name="binance", startup_delay=0.01)
+    await service.ready()
+    call_count = {"value": 0}
+
+    return {
+        "rest_client": DockerisedBinanceRestClient(),
+        "websocket_client_factory": lambda **kwargs: _binance_stream_factory(call_count, **kwargs),
+    }
+
+
+def _binance_stream_factory(call_count: dict[str, int], **kwargs: Any) -> DockerisedBinanceStream:
+    call_count["value"] += 1
+    if call_count["value"] == 1:
+        return DockerisedBinanceStream(
+            responses=["42000"],
+            error_on_first=True,
+            **kwargs,
+        )
+    return DockerisedBinanceStream(responses=["42001"], error_on_first=False, **kwargs)
+
+
+class DockerisedIBKR:
+    MaxRequests = 10
+    RequestsInterval = 0.5
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.pendingTickersEvent = _TickerEvent()
+        self.reqHistoricalData_calls: list[dict[str, Any]] = []
+        self.reqMktData_calls = 0
+
+    async def connectAsync(self, host: str, port: int, clientId: int) -> None:  # noqa: N802
+        self.connected = True
+        await asyncio.sleep(0)
+
+    def isConnected(self) -> bool:  # noqa: N802
+        return self.connected
+
+    async def reqHistoricalDataAsync(self, contract: Any, **kwargs: Any) -> list[str]:
+        self.reqHistoricalData_calls.append({"contract": contract, **kwargs})
+        return ["bar"]
+
+    def reqMktData(self, contract: Any, *args: Any, **kwargs: Any) -> None:  # noqa: N802
+        self.reqMktData_calls += 1
+        if self.reqMktData_calls == 1:
+            raise ConnectionError("socket closed")
+        self.pendingTickersEvent.add_sequence(
+            [type("Ticker", (), {"contract": contract, "last": 10.0})]
+        )
+
+    def cancelMktData(self, contract: Any) -> None:  # noqa: N802
+        return None
+
+    def disconnect(self) -> None:
+        self.connected = False
+
+
+class _TickerEvent:
+    def __init__(self) -> None:
+        self._sequences: list[Iterable[Any]] = []
+
+    def add_sequence(self, sequence: Iterable[Any]) -> None:
+        self._sequences.append(sequence)
+
+    async def aiter(self) -> AsyncIterator[Iterable[Any]]:
+        for sequence in list(self._sequences):
+            yield sequence
+        await asyncio.sleep(0)
+
+
+async def _ibkr_docker_client() -> DockerisedIBKR:
+    service = MockDockerService(name="ibkr", startup_delay=0.01)
+    await service.ready()
+    return DockerisedIBKR()
+
+
+def test_binance_connector_end_to_end() -> None:
+    async def run() -> None:
+        connector: MarketConnector = BinanceMarketConnector(
+            **(await _binance_docker_clients()), request_rate=1, request_interval_seconds=0.2
+        )
+        first = asyncio.get_running_loop().time()
+        await connector.fetch_ohlcv("BTCUSDT", "1m")
+        second = asyncio.get_running_loop().time()
+        await connector.fetch_ohlcv("BTCUSDT", "1m")
+        assert second - first < 0.05
+        third = asyncio.get_running_loop().time()
+        await connector.fetch_ohlcv("BTCUSDT", "1m")
+        assert third - second >= 0.18
+
+        stream = connector.stream_trades("BTCUSDT")
+        messages = []
+        async for message in stream:
+            messages.append(message)
+            if len(messages) == 2:
+                break
+        await stream.aclose()
+        assert [msg["p"] for msg in messages] == ["42000", "42001"]
+
+    asyncio.run(run())
+
+
+def test_ibkr_connector_retries_with_docker_fixture() -> None:
+    async def run() -> None:
+        ibkr_docker = await _ibkr_docker_client()
+        connector: MarketConnector = IBKRMarketConnector(
+            host="127.0.0.1",
+            port=4001,
+            client_id=1,
+            ib=ibkr_docker,
+            reconnect_delay=0.01,
+        )
+
+        await connector.fetch_ohlcv("ES", end="", duration="1 D", bar_size="1 min")
+        await connector.fetch_ohlcv("ES", end="", duration="1 D", bar_size="1 min")
+        assert len(ibkr_docker.reqHistoricalData_calls) == 2
+
+        stream = connector.stream_trades("ES")
+        ticker = await stream.__anext__()
+        await stream.aclose()
+        assert ibkr_docker.reqMktData_calls >= 2
+        assert getattr(ticker, "last", None) == 10.0
+
+    asyncio.run(run())

--- a/services/market_data/tests/test_rate_limiter.py
+++ b/services/market_data/tests/test_rate_limiter.py
@@ -3,20 +3,20 @@ from __future__ import annotations
 import asyncio
 import time
 
-import pytest
-
 from services.market_data.adapters import AsyncRateLimiter
 
 
-@pytest.mark.asyncio
-async def test_rate_limiter_enforces_spacing() -> None:
-    limiter = AsyncRateLimiter(rate=1, per_seconds=0.2)
-    timestamps: list[float] = []
+def test_rate_limiter_enforces_spacing() -> None:
+    async def run() -> None:
+        limiter = AsyncRateLimiter(rate=1, per_seconds=0.2)
+        timestamps: list[float] = []
 
-    async def call() -> None:
-        await limiter.acquire()
-        timestamps.append(time.monotonic())
+        async def call() -> None:
+            await limiter.acquire()
+            timestamps.append(time.monotonic())
 
-    await call()
-    await call()
-    assert timestamps[1] - timestamps[0] >= 0.18
+        await call()
+        await call()
+        assert timestamps[1] - timestamps[0] >= 0.18
+
+    asyncio.run(run())

--- a/services/order-router/app/brokers/base.py
+++ b/services/order-router/app/brokers/base.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import abc
-from typing import Dict, List
+from typing import Dict, Iterable, List
 
+from libs.connectors import ExecutionClient
 from schemas.market import ExecutionReport, ExecutionStatus, OrderRequest
 
 
-class BrokerAdapter(abc.ABC):
+class BrokerAdapter(ExecutionClient, abc.ABC):
     """Abstract broker adapter."""
 
     name: str
@@ -28,7 +29,7 @@ class BrokerAdapter(abc.ABC):
         self._reports[order_id] = cancelled
         return cancelled
 
-    def fetch_executions(self) -> List[ExecutionReport]:
+    def fetch_executions(self) -> Iterable[ExecutionReport]:
         return [
             report
             for report in self._reports.values()


### PR DESCRIPTION
## Summary
- add a shared `MarketConnector` and `ExecutionClient` abstraction under `libs.connectors`
- refactor Binance and IBKR market data adapters plus the order-router broker base to implement the new interfaces
- extend the market data test suite with docker-style integration checks and document rate limiting/retry behaviour

## Testing
- pytest services/market_data/tests

------
https://chatgpt.com/codex/tasks/task_e_68d9b0010ee48332955a3781339fca93