### PR TITLE
Enforce password strength validation in auth register flow

### DIFF
--- a/services/auth-service/app/schemas.py
+++ b/services/auth-service/app/schemas.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
+
+from .security import (
+    PASSWORD_MIN_LENGTH,
+    PASSWORD_REQUIREMENTS_MESSAGE,
+)
 
 
 class TokenPair(BaseModel):
@@ -23,7 +28,15 @@ class LoginRequest(BaseModel):
 
 class RegisterRequest(BaseModel):
     email: EmailStr
-    password: str
+    password: str = Field(
+        ...,
+        description=PASSWORD_REQUIREMENTS_MESSAGE,
+        examples=["Str0ngPassw0rd!"],
+        json_schema_extra={
+            "min_length": PASSWORD_MIN_LENGTH,
+            "error_message": PASSWORD_REQUIREMENTS_MESSAGE,
+        },
+    )
 
 
 class Me(BaseModel):


### PR DESCRIPTION
## Summary
- add shared password validation helpers and enforce them during registration
- document password complexity expectations on the RegisterRequest schema and extend coverage
- normalize persisted user timestamps to UTC-aware datetimes to satisfy test expectations

## Testing
- pytest services/auth-service/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d9d27d5b68833290f16a51fb624c95