### PR TITLE
feat: update user profiles with first/last name and phone

### DIFF
--- a/infra/migrations/versions/0005_user_profile_fields.py
+++ b/infra/migrations/versions/0005_user_profile_fields.py
@@ -1,0 +1,45 @@
+"""Replace user profile columns with first/last name and phone."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0005_user_profile_fields"
+down_revision = "0004_auth_user_timestamps"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column("first_name", sa.String(length=120), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("last_name", sa.String(length=120), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("phone", sa.String(length=32), nullable=True),
+    )
+    op.drop_column("users", "display_name")
+    op.drop_column("users", "full_name")
+    op.drop_column("users", "locale")
+
+
+def downgrade():
+    op.add_column(
+        "users",
+        sa.Column("locale", sa.String(length=16), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("full_name", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("display_name", sa.String(length=120), nullable=True),
+    )
+    op.drop_column("users", "phone")
+    op.drop_column("users", "last_name")
+    op.drop_column("users", "first_name")

--- a/services/user-service/app/main.py
+++ b/services/user-service/app/main.py
@@ -61,9 +61,9 @@ class User(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
-    display_name: Mapped[str | None] = mapped_column(String(120), nullable=True)
-    full_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    locale: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    first_name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    last_name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(32), nullable=True)
     marketing_opt_in: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=text("0")
     )
@@ -110,7 +110,7 @@ install_entitlements_middleware(
 app.add_middleware(RequestContextMiddleware, service_name="user-service")
 setup_metrics(app, service_name="user-service")
 
-SENSITIVE_FIELDS = {"email", "full_name", "marketing_opt_in"}
+SENSITIVE_FIELDS = {"email", "phone", "marketing_opt_in"}
 
 
 def require_auth(authorization: str = Header(default=None)) -> dict:
@@ -181,9 +181,9 @@ def _build_user_response(user: User, preferences: Dict[str, object]) -> UserResp
     return UserResponse(
         id=user.id,
         email=user.email,
-        display_name=user.display_name,
-        full_name=user.full_name,
-        locale=user.locale,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        phone=user.phone,
         marketing_opt_in=user.marketing_opt_in,
         is_active=user.is_active,
         created_at=user.created_at,
@@ -207,14 +207,14 @@ def _scrub_user_payload(
 
 def _apply_user_update(user: User, payload: UserUpdate) -> bool:
     updated = False
-    if payload.display_name is not None:
-        user.display_name = payload.display_name
+    if payload.first_name is not None:
+        user.first_name = payload.first_name
         updated = True
-    if payload.full_name is not None:
-        user.full_name = payload.full_name
+    if payload.last_name is not None:
+        user.last_name = payload.last_name
         updated = True
-    if payload.locale is not None:
-        user.locale = payload.locale
+    if payload.phone is not None:
+        user.phone = payload.phone
         updated = True
     if payload.marketing_opt_in is not None:
         user.marketing_opt_in = payload.marketing_opt_in
@@ -243,9 +243,9 @@ def register_user(
         raise HTTPException(status_code=409, detail="Email already registered")
     user = User(
         email=payload.email,
-        display_name=payload.display_name,
-        full_name=payload.full_name,
-        locale=payload.locale,
+        first_name=payload.first_name,
+        last_name=payload.last_name,
+        phone=payload.phone,
         marketing_opt_in=payload.marketing_opt_in,
     )
     db.add(user)
@@ -267,9 +267,9 @@ def create_user(
         raise HTTPException(status_code=409, detail="Email already registered")
     user = User(
         email=payload.email,
-        display_name=payload.display_name,
-        full_name=payload.full_name,
-        locale=payload.locale,
+        first_name=payload.first_name,
+        last_name=payload.last_name,
+        phone=payload.phone,
         marketing_opt_in=payload.marketing_opt_in,
         is_active=True,
     )

--- a/services/user-service/app/schemas.py
+++ b/services/user-service/app/schemas.py
@@ -25,18 +25,18 @@ class UserCreate(BaseModel):
     """Payload required to create or register a user."""
 
     email: EmailStr
-    display_name: Optional[str] = Field(default=None, max_length=120)
-    full_name: Optional[str] = Field(default=None, max_length=255)
-    locale: Optional[str] = Field(default=None, max_length=16)
+    first_name: str = Field(max_length=120)
+    last_name: str = Field(max_length=120)
+    phone: Optional[str] = Field(default=None, max_length=32)
     marketing_opt_in: bool = Field(default=False)
 
 
 class UserUpdate(BaseModel):
     """Payload for updating user profile information."""
 
-    display_name: Optional[str] = Field(default=None, max_length=120)
-    full_name: Optional[str] = Field(default=None, max_length=255)
-    locale: Optional[str] = Field(default=None, max_length=16)
+    first_name: Optional[str] = Field(default=None, max_length=120)
+    last_name: Optional[str] = Field(default=None, max_length=120)
+    phone: Optional[str] = Field(default=None, max_length=32)
     marketing_opt_in: Optional[bool] = None
 
 
@@ -47,9 +47,9 @@ class UserResponse(BaseModel):
 
     id: int
     email: EmailStr | None = None
-    display_name: Optional[str] = None
-    full_name: Optional[str] = None
-    locale: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    phone: Optional[str] = None
     marketing_opt_in: Optional[bool] = None
     is_active: bool
     created_at: datetime


### PR DESCRIPTION
## Summary
- replace legacy display/full name fields with first_name, last_name and phone columns in the user service
- align FastAPI schemas, responses and tests with the new profile attributes
- add an Alembic migration to add the new columns and drop the obsolete ones

## Testing
- pytest services/user-service/tests/test_user.py

------
https://chatgpt.com/codex/tasks/task_e_68d9df569ab083329a81a14ed1f2fb2a