### PR TITLE
Refactor initial migration to focus on users table

### DIFF
--- a/infra/migrations/versions/0001_init.py
+++ b/infra/migrations/versions/0001_init.py
@@ -1,67 +1,55 @@
-﻿from alembic import op
+from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
-revision = '0001_init'
+revision = "0001_init"
 down_revision = None
 branch_labels = None
 depends_on = None
 
+
 def upgrade():
     op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto;")
-    op.create_table("roles",
-        sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("name", sa.String(50), unique=True, nullable=False),
-        sa.Column("description", sa.String(255)),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()")),
-    )
-    op.create_table("permissions",
-        sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("code", sa.String(100), unique=True, nullable=False),
-        sa.Column("description", sa.String(255)),
-    )
-    op.create_table("users",
-        sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("email", sa.String(255), unique=True, nullable=False),
+    op.create_table(
+        "users",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("email", sa.String(255), nullable=False, unique=True),
         sa.Column("password_hash", sa.String(255), nullable=False),
-        sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.text("true")),
-        sa.Column("is_superuser", sa.Boolean, nullable=False, server_default=sa.text("false")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()")),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()")),
+        sa.Column("first_name", sa.String(100), nullable=True),
+        sa.Column("last_name", sa.String(100), nullable=True),
+        sa.Column("phone", sa.String(20), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "is_admin",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
     )
-    op.create_table("user_roles",
-        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
-        sa.Column("role_id", sa.Integer, sa.ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True),
-    )
-    op.create_table("role_permissions",
-        sa.Column("role_id", sa.Integer, sa.ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True),
-        sa.Column("permission_id", sa.Integer, sa.ForeignKey("permissions.id", ondelete="CASCADE"), primary_key=True),
-    )
-    op.create_table("mfa_totp",
-        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
-        sa.Column("secret", sa.String(64), nullable=False),
-        sa.Column("enabled", sa.Boolean, nullable=False, server_default=sa.text("false")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"))
-    )
-    op.create_table("user_preferences",
-        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
-        sa.Column("preferences", sa.JSON, nullable=False, server_default=sa.text("'{}'::json")),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"))
-    )
-    op.create_table("user_actions",
-        sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id", ondelete="SET NULL")),
-        sa.Column("action", sa.String(100), nullable=False),
-        sa.Column("metadata", sa.JSON, nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"))
-    )
-    op.create_index("ix_user_actions_user_time", "user_actions", ["user_id", "created_at"])
+
 
 def downgrade():
-    op.drop_table("user_actions")
-    op.drop_table("user_preferences")
-    op.drop_table("mfa_totp")
-    op.drop_table("role_permissions")
-    op.drop_table("user_roles")
     op.drop_table("users")
-    op.drop_table("permissions")
-    op.drop_table("roles")


### PR DESCRIPTION
## Summary
- rewrite the initial Alembic revision so it only creates the users table with the required UUID primary key and profile fields
- drop the removal of all other tables from the initial migration

## Testing
- alembic -c infra/migrations/alembic.ini upgrade 0001_init

------
https://chatgpt.com/codex/tasks/task_e_68d9e42848bc8332a3c3acc68178b62c