### PR TITLE
Automate Alembic migrations during startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 SHELL := /bin/bash
 
-.PHONY: setup dev-up dev-down lint test e2e e2e-sh
+.PHONY: setup dev-up dev-down lint test e2e e2e-sh migrate-generate migrate-up migrate-down
+
+ALEMBIC_CONFIG ?= infra/migrations/alembic.ini
+ALEMBIC_DATABASE_URL ?= postgresql+psycopg2://trading:trading@localhost:5432/trading
+REVISION ?= head
+DOWN_REVISION ?= -1
 
 setup:
-	pipx install pre-commit || pip install pre-commit
-	pre-commit install
+        pipx install pre-commit || pip install pre-commit
+        pre-commit install
 
 dev-up:
 	docker compose up -d postgres redis
@@ -26,7 +31,20 @@ test:
 	python -m coverage html
 
 e2e:
-	pwsh -NoProfile -File ./scripts/e2e/auth_e2e.ps1
+        pwsh -NoProfile -File ./scripts/e2e/auth_e2e.ps1
 
 e2e-sh:
-	bash ./scripts/e2e/auth_e2e.sh
+        bash ./scripts/e2e/auth_e2e.sh
+
+migrate-generate:
+        @if [ -z "$(message)" ]; then \
+                echo "Usage: make migrate-generate message=\"Add new table\""; \
+                exit 1; \
+        fi
+        ALEMBIC_DATABASE_URL=$(ALEMBIC_DATABASE_URL) alembic -c $(ALEMBIC_CONFIG) revision --autogenerate -m "$(message)"
+
+migrate-up:
+        ALEMBIC_DATABASE_URL=$(ALEMBIC_DATABASE_URL) alembic -c $(ALEMBIC_CONFIG) upgrade $(REVISION)
+
+migrate-down:
+        ALEMBIC_DATABASE_URL=$(ALEMBIC_DATABASE_URL) alembic -c $(ALEMBIC_CONFIG) downgrade $(DOWN_REVISION)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,27 @@ curl http://localhost:8011/health
 make dev-down
 ```
 
+### Database migrations
+
+Use the Makefile helpers to manage Alembic migrations locally (the commands default to
+`postgresql+psycopg2://trading:trading@localhost:5432/trading`, override it with
+`ALEMBIC_DATABASE_URL=<your-url>` when needed):
+
+```bash
+# Generate a new revision
+make migrate-generate message="add user preferences"
+
+# Apply migrations (defaults to head)
+make migrate-up
+
+# Roll back the previous revision (override DOWN_REVISION to target another one)
+make migrate-down
+```
+
+Docker services now apply migrations automatically during startup through
+[`scripts/run_migrations.sh`](scripts/run_migrations.sh), ensuring the database schema is
+up to date before each application boots.
+
 ### Technical Architecture
 
 The project uses a modern **microservices architecture**:

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+DEFAULT_DB_URL="postgresql+psycopg2://trading:trading@postgres:5432/trading"
+DB_URL="${ALEMBIC_DATABASE_URL:-${DATABASE_URL:-${DEFAULT_DB_URL}}}"
+
+export ALEMBIC_DATABASE_URL="${DB_URL}"
+
+ALEMBIC_CONFIG_PATH="${ALEMBIC_CONFIG:-infra/migrations/alembic.ini}"
+
+echo "Applying database migrations with Alembic using ${ALEMBIC_DATABASE_URL}"
+alembic -c "${ALEMBIC_CONFIG_PATH}" upgrade head

--- a/services/auth-service/Dockerfile
+++ b/services/auth-service/Dockerfile
@@ -1,12 +1,15 @@
 FROM python:3.12-slim
 WORKDIR /app
 
-COPY libs ./libs
-
 COPY services/auth-service/requirements.txt ./requirements.txt
 RUN python -m pip install --upgrade pip && pip install -r requirements.txt
 
+COPY libs ./libs
+COPY infra ./infra
+COPY scripts ./scripts
 COPY services/auth-service/app ./app
 
+RUN chmod +x ./scripts/run_migrations.sh
+
 ENV PYTHONPATH=/app
-CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]
+CMD ["bash","-c","./scripts/run_migrations.sh && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/services/auth-service/requirements.txt
+++ b/services/auth-service/requirements.txt
@@ -7,3 +7,4 @@ python-jose[cryptography]
 pyotp
 pydantic[email]>=2
 prometheus-client>=0.20
+alembic

--- a/services/user-service/Dockerfile
+++ b/services/user-service/Dockerfile
@@ -2,10 +2,15 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY services/user-service/requirements.txt services/user-service/requirements-dev.txt ./
-RUN python -m pip install --upgrade pip &&     pip install -r requirements.txt
+RUN python -m pip install --upgrade pip && \
+    pip install -r requirements.txt
 
 COPY libs ./libs
+COPY infra ./infra
+COPY scripts ./scripts
 COPY services/user-service/app ./app
 
+RUN chmod +x ./scripts/run_migrations.sh
+
 ENV PYTHONPATH=/app
-CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]
+CMD ["bash","-c","./scripts/run_migrations.sh && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/services/user-service/requirements.txt
+++ b/services/user-service/requirements.txt
@@ -5,3 +5,4 @@ SQLAlchemy>=2
 psycopg2-binary
 python-jose[cryptography]
 prometheus-client>=0.20
+alembic


### PR DESCRIPTION
## Summary
- add Makefile helpers to generate, upgrade, and downgrade Alembic revisions with a default local URL
- add a reusable migration script and invoke it from the service containers before booting the APIs
- document the workflow for developers in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9e559540c8332aad312a22d4cf0b5