### PR TITLE
Refactor user identity schema to use integer keys

### DIFF
--- a/infra/migrations/versions/0003_screener.py
+++ b/infra/migrations/versions/0003_screener.py
@@ -14,7 +14,12 @@ def upgrade() -> None:
     op.create_table(
         "screener_presets",
         sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-        sa.Column("user_id", sa.Integer, nullable=False),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
         sa.Column("name", sa.String(length=128), nullable=False),
         sa.Column("description", sa.String(length=255), nullable=True),
         sa.Column("filters", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
@@ -26,8 +31,17 @@ def upgrade() -> None:
     op.create_table(
         "screener_snapshots",
         sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-        sa.Column("user_id", sa.Integer, nullable=True),
-        sa.Column("preset_id", sa.Integer, sa.ForeignKey("screener_presets.id", ondelete="SET NULL")),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "preset_id",
+            sa.Integer,
+            sa.ForeignKey("screener_presets.id", ondelete="SET NULL"),
+        ),
         sa.Column("provider", sa.String(length=32), nullable=False),
         sa.Column("filters", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),

--- a/infra/migrations/versions/0004_auth_user_timestamps.py
+++ b/infra/migrations/versions/0004_auth_user_timestamps.py
@@ -1,7 +1,3 @@
-from alembic import op
-import sqlalchemy as sa
-
-
 revision = '0004_auth_user_timestamps'
 down_revision = '0003_screener'
 branch_labels = None
@@ -9,26 +5,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        'users',
-        sa.Column(
-            'created_at',
-            sa.DateTime(timezone=True),
-            server_default=sa.text('NOW()'),
-            nullable=False,
-        ),
-    )
-    op.add_column(
-        'users',
-        sa.Column(
-            'updated_at',
-            sa.DateTime(timezone=True),
-            server_default=sa.text('NOW()'),
-            nullable=False,
-        ),
-    )
+    pass
 
 
 def downgrade():
-    op.drop_column('users', 'updated_at')
-    op.drop_column('users', 'created_at')
+    pass

--- a/infra/migrations/versions/0005_user_profile_fields.py
+++ b/infra/migrations/versions/0005_user_profile_fields.py
@@ -1,8 +1,3 @@
-"""Replace user profile columns with first/last name and phone."""
-
-from alembic import op
-import sqlalchemy as sa
-
 revision = "0005_user_profile_fields"
 down_revision = "0004_auth_user_timestamps"
 branch_labels = None
@@ -10,36 +5,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        "users",
-        sa.Column("first_name", sa.String(length=120), nullable=True),
-    )
-    op.add_column(
-        "users",
-        sa.Column("last_name", sa.String(length=120), nullable=True),
-    )
-    op.add_column(
-        "users",
-        sa.Column("phone", sa.String(length=32), nullable=True),
-    )
-    op.drop_column("users", "display_name")
-    op.drop_column("users", "full_name")
-    op.drop_column("users", "locale")
+    pass
 
 
 def downgrade():
-    op.add_column(
-        "users",
-        sa.Column("locale", sa.String(length=16), nullable=True),
-    )
-    op.add_column(
-        "users",
-        sa.Column("full_name", sa.String(length=255), nullable=True),
-    )
-    op.add_column(
-        "users",
-        sa.Column("display_name", sa.String(length=120), nullable=True),
-    )
-    op.drop_column("users", "phone")
-    op.drop_column("users", "last_name")
-    op.drop_column("users", "first_name")
+    pass

--- a/scripts/e2e/auth_e2e.sh
+++ b/scripts/e2e/auth_e2e.sh
@@ -132,7 +132,7 @@ from datetime import datetime, timezone
 from jose import jwt
 secret = os.getenv('JWT_SECRET', 'dev-secret-change-me')
 now = int(datetime.now(timezone.utc).timestamp())
-payload = {"sub": str($user_id), "iat": now}
+payload = {"sub": $user_id, "iat": now}
 print(jwt.encode(payload, secret, algorithm='HS256'))
 PY
 )

--- a/services/auth-service/app/security.py
+++ b/services/auth-service/app/security.py
@@ -64,7 +64,7 @@ def verify_password(password: str, hashed: str) -> bool:
     return pwd.verify(password, hashed)
 
 
-def create_token_pair(sub: str, roles: list[str]) -> tuple[str, str]:
+def create_token_pair(sub: int, roles: list[str]) -> tuple[str, str]:
     now = datetime.now(timezone.utc)
     access = jwt.encode(
         {

--- a/services/auth-service/tests/test_auth.py
+++ b/services/auth-service/tests/test_auth.py
@@ -149,7 +149,7 @@ def test_refresh_returns_new_token_pair(client, session_factory):
     refreshed = TokenPair.model_validate(response.json())
     decoded_access = security.verify_token(refreshed.access_token)
     decoded_refresh = security.verify_token(refreshed.refresh_token)
-    assert decoded_access["sub"] == str(user.id)
+    assert decoded_access["sub"] == user.id
     assert decoded_refresh["type"] == "refresh"
 
 
@@ -167,7 +167,7 @@ def test_refresh_rejects_expired_token(client, session_factory):
     now = datetime.now(timezone.utc)
     expired_refresh = security.jwt.encode(
         {
-            "sub": str(user.id),
+            "sub": user.id,
             "type": "refresh",
             "iat": int(now.timestamp()),
             "exp": int((now - timedelta(minutes=1)).timestamp()),

--- a/services/user-service/app/main.py
+++ b/services/user-service/app/main.py
@@ -150,7 +150,10 @@ def get_authenticated_actor(
 ) -> int:
     """Validate that the JWT payload matches the optional actor header."""
 
-    user_id = int(payload["sub"])
+    sub = payload.get("sub")
+    if not isinstance(sub, int):
+        raise HTTPException(status_code=401, detail="Invalid token")
+    user_id = sub
     actor_header = request.headers.get("x-customer-id") or request.headers.get("x-user-id")
     if not actor_header:
         if os.getenv("ENTITLEMENTS_BYPASS", "0") == "1":

--- a/services/user-service/tests/test_user.py
+++ b/services/user-service/tests/test_user.py
@@ -78,7 +78,7 @@ def client(session_factory):
 
 def _auth_header(user_id: int):
     now = int(datetime.now(timezone.utc).timestamp())
-    token = jwt.encode({"sub": str(user_id), "iat": now}, JWT_SECRET, algorithm=JWT_ALG)
+    token = jwt.encode({"sub": user_id, "iat": now}, JWT_SECRET, algorithm=JWT_ALG)
     return {"Authorization": f"Bearer {token}"}
 
 


### PR DESCRIPTION
## Summary
- rewrite the initial infrastructure migration to create integer identity primary keys for users and add related auth/user tables
- tighten downstream migrations to reference the new key type and skip obsolete column mutations
- update auth and user services plus tests and scripts to work with integer JWT subject claims directly

## Testing
- `pytest services/auth-service/tests services/user-service/tests` *(fails: missing dependency schemathesis)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f09c7804833284ce199e424403f0