### PR TITLE
Guard auth_user timestamp migration

### DIFF
--- a/infra/migrations/versions/0004_auth_user_timestamps.py
+++ b/infra/migrations/versions/0004_auth_user_timestamps.py
@@ -1,12 +1,27 @@
-revision = '0004_auth_user_timestamps'
-down_revision = '0003_screener'
+from alembic import op
+
+
+revision = "0004_auth_user_timestamps"
+down_revision = "0003_screener"
 branch_labels = None
 depends_on = None
 
 
-def upgrade():
-    pass
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE IF EXISTS auth_user
+        ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE IF EXISTS auth_user
+        ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        """
+    )
 
 
-def downgrade():
-    pass
+def downgrade() -> None:
+    op.execute("ALTER TABLE IF EXISTS auth_user DROP COLUMN IF EXISTS updated_at")
+    op.execute("ALTER TABLE IF EXISTS auth_user DROP COLUMN IF EXISTS created_at")


### PR DESCRIPTION
## Summary
- ensure the auth_user timestamp migration only adds columns when the table or columns are missing
- provide symmetric downgrade safeguards for dropping the columns only when present

## Testing
- `alembic -c infra/migrations/alembic.ini upgrade head` *(fails: migration 0002_market_data requires TimescaleDB hypertable primary key adjustments in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f2a1a4848332af4ef54a2ce8b12f