### PR TITLE
Add SQLAlchemy trading models

### DIFF
--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -22,6 +22,7 @@ from .screener_models import (
     ScreenerSnapshot,
 )
 from .social_models import Base as SocialBase, Activity, Follow, Leaderboard, Profile
+from .trading_models import TradingBase, Execution, Order
 
 __all__ = [
     "AuditBase",
@@ -45,4 +46,7 @@ __all__ = [
     "Follow",
     "Leaderboard",
     "Profile",
+    "TradingBase",
+    "Order",
+    "Execution",
 ]

--- a/infra/trading_models.py
+++ b/infra/trading_models.py
@@ -1,0 +1,97 @@
+"""SQLAlchemy models for core trading entities."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    String,
+    func,
+)
+from sqlalchemy.orm import declarative_base, relationship
+
+TradingBase = declarative_base()
+
+
+class Order(TradingBase):
+    """Represents an order submitted by a strategy or user."""
+
+    __tablename__ = "trading_orders"
+
+    id: int = Column(BigInteger, primary_key=True, autoincrement=True)
+    external_order_id: Optional[str] = Column(String(128), unique=True)
+    correlation_id: Optional[str] = Column(String(128), index=True)
+    account_id: str = Column(String(64), nullable=False, index=True)
+    symbol: str = Column(String(32), nullable=False, index=True)
+    side: str = Column(String(8), nullable=False)
+    order_type: str = Column(String(16), nullable=False)
+    quantity: Decimal = Column(Numeric(20, 8), nullable=False)
+    filled_quantity: Decimal = Column(Numeric(20, 8), nullable=False, default=0)
+    limit_price: Optional[Decimal] = Column(Numeric(20, 8))
+    stop_price: Optional[Decimal] = Column(Numeric(20, 8))
+    status: str = Column(String(16), nullable=False, default="pending")
+    time_in_force: Optional[str] = Column(String(16))
+    submitted_at: Optional[datetime] = Column(DateTime(timezone=True))
+    expires_at: Optional[datetime] = Column(DateTime(timezone=True))
+    notes: Optional[str] = Column(String(255))
+    created_at: datetime = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: datetime = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    executions = relationship(
+        "Execution",
+        back_populates="order",
+        cascade="all, delete-orphan",
+        order_by="Execution.executed_at.desc()",
+    )
+
+    __table_args__ = (
+        Index("ix_trading_orders_symbol_created_at", "symbol", "created_at"),
+        Index("ix_trading_orders_account_created_at", "account_id", "created_at"),
+    )
+
+
+class Execution(TradingBase):
+    """Execution events associated with an order."""
+
+    __tablename__ = "trading_executions"
+
+    id: int = Column(BigInteger, primary_key=True, autoincrement=True)
+    order_id: int = Column(
+        BigInteger,
+        ForeignKey("trading_orders.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    external_execution_id: Optional[str] = Column(String(128), unique=True)
+    correlation_id: Optional[str] = Column(String(128), index=True)
+    account_id: str = Column(String(64), nullable=False, index=True)
+    symbol: str = Column(String(32), nullable=False, index=True)
+    quantity: Decimal = Column(Numeric(20, 8), nullable=False)
+    price: Decimal = Column(Numeric(20, 8), nullable=False)
+    fees: Optional[Decimal] = Column(Numeric(20, 8))
+    liquidity: Optional[str] = Column(String(16))
+    executed_at: datetime = Column(DateTime(timezone=True), nullable=False)
+    created_at: datetime = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    order = relationship("Order", back_populates="executions")
+
+    __table_args__ = (
+        Index("ix_trading_executions_symbol_executed_at", "symbol", "executed_at"),
+        Index("ix_trading_executions_account_executed_at", "account_id", "executed_at"),
+    )
+
+
+__all__ = ["TradingBase", "Order", "Execution"]


### PR DESCRIPTION
## Summary
- add a dedicated SQLAlchemy base for trading models and define order/execution tables
- wire the new models into the infra package exports for downstream access

## Testing
- python -m compileall infra/trading_models.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fc74f3908332a25227a84d5c779d