### PR TITLE
Add database persistence for order router executions

### DIFF
--- a/infra/trading_models.py
+++ b/infra/trading_models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Index,
+    Integer,
     Numeric,
     String,
     func,
@@ -20,12 +21,15 @@ from sqlalchemy.orm import declarative_base, relationship
 TradingBase = declarative_base()
 
 
+SQLITE_BIGINT = BigInteger().with_variant(Integer, "sqlite")
+
+
 class Order(TradingBase):
     """Represents an order submitted by a strategy or user."""
 
     __tablename__ = "trading_orders"
 
-    id: int = Column(BigInteger, primary_key=True, autoincrement=True)
+    id: int = Column(SQLITE_BIGINT, primary_key=True, autoincrement=True)
     external_order_id: Optional[str] = Column(String(128), unique=True)
     correlation_id: Optional[str] = Column(String(128), index=True)
     account_id: str = Column(String(64), nullable=False, index=True)
@@ -66,9 +70,9 @@ class Execution(TradingBase):
 
     __tablename__ = "trading_executions"
 
-    id: int = Column(BigInteger, primary_key=True, autoincrement=True)
+    id: int = Column(SQLITE_BIGINT, primary_key=True, autoincrement=True)
     order_id: int = Column(
-        BigInteger,
+        SQLITE_BIGINT,
         ForeignKey("trading_orders.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/services/conftest.py
+++ b/services/conftest.py
@@ -26,6 +26,7 @@ from infra import (  # noqa: E402
     MarketplaceBase,
     ScreenerBase,
     SocialBase,
+    TradingBase,
 )
 
 EntitlementsBase.metadata.create_all(bind=db.engine)
@@ -33,3 +34,5 @@ ScreenerBase.metadata.create_all(bind=db.engine)
 MarketplaceBase.metadata.create_all(bind=db.engine)
 SocialBase.metadata.create_all(bind=db.engine)
 AuditBase.metadata.create_all(bind=db.engine)
+TradingBase.metadata.drop_all(bind=db.engine)
+TradingBase.metadata.create_all(bind=db.engine)

--- a/services/order-router/app/database.py
+++ b/services/order-router/app/database.py
@@ -1,0 +1,17 @@
+"""Database helpers for the order router service."""
+from __future__ import annotations
+
+from typing import Iterator
+
+from sqlalchemy.orm import Session
+
+from libs.db.db import SessionLocal
+
+
+def get_session() -> Iterator[Session]:
+    """Yield a scoped SQLAlchemy session for FastAPI dependencies."""
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- add a reusable SQLAlchemy session dependency for the order-router service
- persist routed orders and cancellation events to the trading models with transactional error handling
- make the trading models SQLite-friendly and reset the test schema for reliable order-router tests

## Testing
- pytest services/order-router/tests/test_order_router.py

------
https://chatgpt.com/codex/tasks/task_e_68da00a37b848332867bd371d5800307