### PR TITLE
Add filtering and metadata to order and execution logs

### DIFF
--- a/schemas/order_router.py
+++ b/schemas/order_router.py
@@ -71,23 +71,43 @@ class OrderRecord(BaseModel):
         return value
 
 
-class PaginatedOrders(BaseModel):
-    items: List[OrderRecord]
+class PaginationMetadata(BaseModel):
     limit: int
     offset: int
     total: int
+
+
+class OrdersLogMetadata(PaginationMetadata):
+    account_id: str | None = None
+    symbol: str | None = None
+    start: datetime | None = None
+    end: datetime | None = None
+
+
+class ExecutionsMetadata(PaginationMetadata):
+    account_id: str | None = None
+    symbol: str | None = None
+    start: datetime | None = None
+    end: datetime | None = None
+    order_id: int | None = None
+
+
+class PaginatedOrders(BaseModel):
+    items: List[OrderRecord]
+    metadata: OrdersLogMetadata
 
 
 class PaginatedExecutions(BaseModel):
     items: List[ExecutionRecord]
-    limit: int
-    offset: int
-    total: int
+    metadata: ExecutionsMetadata
 
 
 __all__ = [
     "ExecutionRecord",
     "OrderRecord",
+    "PaginationMetadata",
+    "OrdersLogMetadata",
+    "ExecutionsMetadata",
     "PaginatedExecutions",
     "PaginatedOrders",
 ]


### PR DESCRIPTION
## Summary
- extend the order log and executions endpoints with account, symbol, and time-range filters plus pagination metadata in the responses
- update the SQLAlchemy queries to apply the new filters when retrieving persisted orders and executions
- document the additional query parameters in FastAPI and cover the new behaviour with integration tests

## Testing
- pytest services/order-router/tests/test_order_router.py

------
https://chatgpt.com/codex/tasks/task_e_68da051bb1f883329ce80e43bc5e9cd0