### PR TITLE
Add SQLite fixtures and database-backed order router tests

### DIFF
--- a/services/order-router/tests/conftest.py
+++ b/services/order-router/tests/conftest.py
@@ -1,0 +1,116 @@
+"""Pytest fixtures for the order router service tests."""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from infra.trading_models import Execution as ExecutionModel, Order as OrderModel, TradingBase
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_package(alias: str, path: Path) -> None:
+    """Load a namespace package from an arbitrary path."""
+    sys.modules.pop(alias, None)
+    spec = importlib.util.spec_from_file_location(alias, path / "__init__.py")
+    module = importlib.util.module_from_spec(spec)
+    module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    sys.modules[alias] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+
+
+def _load_main_module() -> object:
+    """Import the FastAPI application module under a stable alias."""
+    _load_package("order_router", PACKAGE_ROOT)
+    _load_package("order_router.app", PACKAGE_ROOT / "app")
+    _load_package("order_router.app.brokers", PACKAGE_ROOT / "app" / "brokers")
+    sys.modules.pop("order_router.app.main", None)
+    spec = importlib.util.spec_from_file_location(
+        "order_router.app.main", PACKAGE_ROOT / "app" / "main.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["order_router.app.main"] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+@pytest.fixture(scope="session")
+def db_module(tmp_path_factory: pytest.TempPathFactory):
+    """Configure a dedicated SQLite database for the test session."""
+    db_path = tmp_path_factory.mktemp("order_router_db") / "test.sqlite"
+    os.environ.setdefault("ENTITLEMENTS_BYPASS", "1")
+    os.environ["DATABASE_URL"] = f"sqlite+pysqlite:///{db_path}"
+
+    module = importlib.import_module("libs.db.db")
+    module = importlib.reload(module)
+    TradingBase.metadata.create_all(module.engine)
+    yield module
+    TradingBase.metadata.drop_all(module.engine)
+    module.engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def app_module(db_module) -> object:  # type: ignore[override]
+    """Load the FastAPI application once for the test session."""
+    return _load_main_module()
+
+
+@pytest.fixture(scope="session")
+def app(app_module) -> object:  # type: ignore[override]
+    return app_module.app
+
+
+@pytest.fixture(scope="session")
+def router(app_module) -> object:  # type: ignore[override]
+    return app_module.router
+
+
+@pytest.fixture()
+def client(app) -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def db_session(db_module) -> Generator[Session, None, None]:
+    session = db_module.SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture(autouse=True)
+def clean_database(db_module, router) -> Generator[None, None, None]:
+    """Ensure each test starts from an empty persistence layer."""
+    session = db_module.SessionLocal()
+    try:
+        session.query(ExecutionModel).delete()
+        session.query(OrderModel).delete()
+        session.commit()
+    finally:
+        session.close()
+
+    router.update_state(mode="paper", limit=1_000_000.0)
+    router._state.notional_routed = 0.0  # type: ignore[attr-defined]
+    router.set_stop_loss("default", 50_000.0)
+
+    yield
+
+    session = db_module.SessionLocal()
+    try:
+        session.query(ExecutionModel).delete()
+        session.query(OrderModel).delete()
+        session.commit()
+    finally:
+        session.close()

--- a/services/order-router/tests/test_order_router.py
+++ b/services/order-router/tests/test_order_router.py
@@ -1,197 +1,171 @@
-import importlib.util
-import os
-import sys
-from pathlib import Path
+"""Integration tests for the order router service."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
 
 import pytest
-from fastapi.testclient import TestClient
 
 from infra.trading_models import Execution as ExecutionModel, Order as OrderModel
-from libs.db.db import SessionLocal
-
-os.environ.setdefault("ENTITLEMENTS_BYPASS", "1")
-
-PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 
 
-def _load_package(alias: str, path: Path) -> None:
-    spec = importlib.util.spec_from_file_location(alias, path / "__init__.py")
-    module = importlib.util.module_from_spec(spec)
-    module.__path__ = [str(path)]  # type: ignore[attr-defined]
-    sys.modules[alias] = module
-    assert spec and spec.loader
-    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+DEFAULT_ORDER: Dict[str, Any] = {
+    "broker": "binance",
+    "venue": "binance.spot",
+    "symbol": "BTCUSDT",
+    "side": "buy",
+    "order_type": "limit",
+    "quantity": 0.5,
+    "price": 30_000,
+}
 
 
-_load_package("order_router", PACKAGE_ROOT)
-_load_package("order_router.app", PACKAGE_ROOT / "app")
-_load_package("order_router.app.brokers", PACKAGE_ROOT / "app" / "brokers")
-
-main_spec = importlib.util.spec_from_file_location("order_router.app.main", PACKAGE_ROOT / "app" / "main.py")
-main_module = importlib.util.module_from_spec(main_spec)
-sys.modules["order_router.app.main"] = main_module
-assert main_spec and main_spec.loader
-main_spec.loader.exec_module(main_module)  # type: ignore[attr-defined]
-
-app = main_module.app
-router = main_module.router
+def _submit_order(client, **overrides: Any) -> Dict[str, Any]:
+    payload = DEFAULT_ORDER | overrides
+    response = client.post("/orders", json=payload)
+    assert response.status_code == 201, response.text
+    return response.json()
 
 
-@pytest.fixture(autouse=True)
-def reset_router_state():
-    router._state.notional_routed = 0.0  # type: ignore[attr-defined]
-    router._risk_alerts.clear()  # type: ignore[attr-defined]
-    router._limit_store._positions.clear()  # type: ignore[attr-defined]
-    router._limit_store._stop_losses.clear()  # type: ignore[attr-defined]
-    router._limit_store.set_stop_loss("default", 50_000.0)  # type: ignore[attr-defined]
-    router.update_state(mode="paper", limit=1_000_000.0)
-    yield
+def _parse_timestamp(value: str | None) -> datetime:
+    assert value is not None, "timestamp must be present"
+    timestamp = datetime.fromisoformat(value)
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
 
 
-@pytest.fixture(autouse=True)
-def clean_database():
-    def _clear() -> None:
-        session = SessionLocal()
-        try:
-            session.query(ExecutionModel).delete()
-            session.query(OrderModel).delete()
-            session.commit()
-        finally:
-            session.close()
-
-    _clear()
-    yield
-    _clear()
-
-
-def test_route_order_and_logging():
-    client = TestClient(app)
-    response = client.post(
-        "/orders",
-        json={
-            "broker": "binance",
-            "venue": "binance.spot",
-            "symbol": "BTCUSDT",
-            "side": "buy",
-            "order_type": "limit",
-            "quantity": 0.5,
-            "price": 30_000,
-        },
+@pytest.mark.usefixtures("clean_database")
+def test_order_persistence_and_filters(client, db_session):
+    first = _submit_order(client, account_id="acct-1")
+    second = _submit_order(
+        client, symbol="ETHUSDT", price=2_000, account_id="acct-2"
     )
-    assert response.status_code == 201
-    order = response.json()
-    assert order["order_id"].startswith("BN-")
-    assert order["status"] in {"filled", "partially_filled"}
-
-    log_resp = client.get("/orders/log")
-    assert log_resp.status_code == 200
-    log_payload = log_resp.json()
-    metadata = log_payload["metadata"]
-    assert metadata["total"] == 1
-    assert metadata["limit"] == 100
-    assert metadata["offset"] == 0
-    assert len(log_payload["items"]) == 1
-    assert log_payload["items"][0]["broker"] == "binance"
-
-    exec_resp = client.get("/executions")
-    assert exec_resp.status_code == 200
-    exec_payload = exec_resp.json()
-    exec_metadata = exec_payload["metadata"]
-    assert exec_metadata["total"] >= 1
-    assert exec_metadata["limit"] == 100
-    assert exec_metadata["offset"] == 0
-    assert exec_payload["items"]
-
-
-def test_orders_log_filters_by_account():
-    client = TestClient(app)
-    first = client.post(
-        "/orders",
-        json={
-            "broker": "binance",
-            "venue": "binance.spot",
-            "symbol": "BTCUSDT",
-            "side": "buy",
-            "order_type": "limit",
-            "quantity": 0.5,
-            "price": 30_000,
-            "account_id": "acct-1",
-        },
+    third = _submit_order(
+        client, symbol="BTCUSDT", quantity=0.2, price=31_000, account_id="acct-1"
     )
-    assert first.status_code == 201
 
-    second = client.post(
-        "/orders",
-        json={
-            "broker": "binance",
-            "venue": "binance.spot",
-            "symbol": "ETHUSDT",
-            "side": "buy",
-            "order_type": "limit",
-            "quantity": 1.0,
-            "price": 2_000,
-            "account_id": "acct-2",
-        },
+    db_session.expire_all()
+    stored_orders = db_session.query(OrderModel).order_by(OrderModel.created_at).all()
+    assert len(stored_orders) == 3
+    assert {order.account_id for order in stored_orders} == {"acct-1", "acct-2"}
+    assert {order.symbol for order in stored_orders} >= {"BTCUSDT", "ETHUSDT"}
+
+    account_filtered = client.get("/orders/log", params={"account_id": "acct-1"})
+    assert account_filtered.status_code == 200
+    account_payload = account_filtered.json()
+    assert account_payload["metadata"]["total"] == 2
+    assert all(item["account_id"] == "acct-1" for item in account_payload["items"])
+
+    symbol_filtered = client.get("/orders/log", params={"symbol": "ETHUSDT"})
+    assert symbol_filtered.status_code == 200
+    symbol_payload = symbol_filtered.json()
+    assert symbol_payload["metadata"]["total"] == 1
+    assert all(item["symbol"] == "ETHUSDT" for item in symbol_payload["items"])
+
+    start_time = _parse_timestamp(second["submitted_at"])
+    start_filtered = client.get("/orders/log", params={"start": start_time.isoformat()})
+    assert start_filtered.status_code == 200
+    start_payload = start_filtered.json()
+    assert start_payload["metadata"]["total"] == 2
+    for item in start_payload["items"]:
+        submitted = item.get("submitted_at") or item["created_at"]
+        assert _parse_timestamp(submitted) >= start_time
+
+    end_time = _parse_timestamp(first["submitted_at"])
+    end_filtered = client.get("/orders/log", params={"end": end_time.isoformat()})
+    assert end_filtered.status_code == 200
+    end_payload = end_filtered.json()
+    for item in end_payload["items"]:
+        submitted = item.get("submitted_at") or item["created_at"]
+        assert _parse_timestamp(submitted) <= end_time
+
+
+@pytest.mark.usefixtures("clean_database")
+def test_cancel_order_records_cancellation(client, db_session):
+    report = _submit_order(client, account_id="acct-cancel")
+    cancel_response = client.post(
+        f"/orders/{report['broker']}/cancel", json={"order_id": report["order_id"]}
     )
-    assert second.status_code == 201
+    assert cancel_response.status_code == 200
+    cancel_payload = cancel_response.json()
+    assert cancel_payload["status"].lower() == "cancelled"
 
-    response = client.get("/orders/log", params={"account_id": "acct-1"})
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["metadata"]["total"] == 1
-    assert all(order["account_id"] == "acct-1" for order in payload["items"])
-
-
-def test_executions_filters_by_symbol_and_account():
-    client = TestClient(app)
-    first = client.post(
-        "/orders",
-        json={
-            "broker": "binance",
-            "venue": "binance.spot",
-            "symbol": "BTCUSDT",
-            "side": "buy",
-            "order_type": "limit",
-            "quantity": 0.5,
-            "price": 30_000,
-            "account_id": "acct-1",
-        },
+    db_session.expire_all()
+    stored_order = (
+        db_session.query(OrderModel)
+        .filter(OrderModel.external_order_id == report["order_id"])
+        .one()
     )
-    assert first.status_code == 201
-
-    second = client.post(
-        "/orders",
-        json={
-            "broker": "binance",
-            "venue": "binance.spot",
-            "symbol": "ETHUSDT",
-            "side": "buy",
-            "order_type": "limit",
-            "quantity": 1.0,
-            "price": 2_000,
-            "account_id": "acct-2",
-        },
+    assert stored_order.status == "cancelled"
+    executions = (
+        db_session.query(ExecutionModel)
+        .filter(ExecutionModel.order_id == stored_order.id)
+        .order_by(ExecutionModel.executed_at)
+        .all()
     )
-    assert second.status_code == 201
+    assert len(executions) >= 2
+    assert executions[-1].liquidity == "cancelled"
+    assert executions[-1].quantity == 0
 
-    response = client.get(
-        "/executions", params={"symbol": "ETHUSDT", "account_id": "acct-2"}
+    log_response = client.get("/orders/log", params={"account_id": "acct-cancel"})
+    assert log_response.status_code == 200
+    log_payload = log_response.json()
+    assert log_payload["items"][0]["status"] == "cancelled"
+
+
+@pytest.mark.usefixtures("clean_database")
+def test_execution_filters_by_account_symbol_and_time(client, db_session):
+    first = _submit_order(client, account_id="acct-1", symbol="BTCUSDT")
+    second = _submit_order(client, account_id="acct-2", symbol="ETHUSDT", price=2_000)
+    third = _submit_order(
+        client,
+        account_id="acct-2",
+        symbol="ETHUSDT",
+        quantity=1.5,
+        price=2_100,
     )
-    assert response.status_code == 200
-    payload = response.json()
-    metadata = payload["metadata"]
-    assert metadata["total"] >= 1
-    assert metadata["symbol"] == "ETHUSDT"
-    assert metadata["account_id"] == "acct-2"
-    assert all(exec_["symbol"] == "ETHUSDT" for exec_ in payload["items"])
-    assert all(exec_["account_id"] == "acct-2" for exec_ in payload["items"])
+
+    db_session.expire_all()
+    executions = db_session.query(ExecutionModel).all()
+    assert len(executions) >= 3
+
+    target_order = (
+        db_session.query(OrderModel)
+        .filter(OrderModel.external_order_id == second["order_id"])
+        .one()
+    )
+
+    filtered = client.get(
+        "/executions",
+        params={"account_id": "acct-2", "symbol": "ETHUSDT"},
+    )
+    assert filtered.status_code == 200
+    filtered_payload = filtered.json()
+    assert filtered_payload["metadata"]["total"] == 2
+    assert all(item["symbol"] == "ETHUSDT" for item in filtered_payload["items"])
+    assert all(item["account_id"] == "acct-2" for item in filtered_payload["items"])
+
+    by_order = client.get("/executions", params={"order_id": target_order.id})
+    assert by_order.status_code == 200
+    by_order_payload = by_order.json()
+    assert by_order_payload["metadata"]["total"] == 1
+    assert all(item["order_id"] == target_order.id for item in by_order_payload["items"])
+
+    start_time = _parse_timestamp(third["fills"][0]["timestamp"])
+    start_filtered = client.get(
+        "/executions", params={"start": start_time.isoformat()}
+    )
+    assert start_filtered.status_code == 200
+    start_payload = start_filtered.json()
+    for item in start_payload["items"]:
+        assert _parse_timestamp(item["executed_at"]) >= start_time
 
 
-def test_daily_notional_limit_enforced():
-    client = TestClient(app)
+def test_daily_notional_limit_enforced(client, router):
     router.update_state(limit=30_000.0)
 
-    response = client.post(
+    first = client.post(
         "/orders",
         json={
             "broker": "ibkr",
@@ -203,7 +177,7 @@ def test_daily_notional_limit_enforced():
             "price": 100,
         },
     )
-    assert response.status_code == 201
+    assert first.status_code == 201
 
     second = client.post(
         "/orders",
@@ -221,8 +195,7 @@ def test_daily_notional_limit_enforced():
     assert "Daily notional" in second.json()["detail"]
 
 
-def test_risk_rule_rejection():
-    client = TestClient(app)
+def test_risk_rule_rejection(client):
     response = client.post(
         "/orders",
         json={
@@ -239,8 +212,7 @@ def test_risk_rule_rejection():
     assert "notional" in response.json()["detail"].lower()
 
 
-def test_stop_loss_alert_and_endpoint():
-    client = TestClient(app)
+def test_stop_loss_alert_and_endpoint(client):
     response = client.post(
         "/orders",
         json={
@@ -266,8 +238,7 @@ def test_stop_loss_alert_and_endpoint():
     assert any(alert["rule_id"] == "stop_loss" for alert in alerts)
 
 
-def test_preview_execution_plan():
-    client = TestClient(app)
+def test_preview_execution_plan(client):
     response = client.post(
         "/plans",
         json={


### PR DESCRIPTION
## Summary
- configure a session-wide SQLite database fixture and reusable FastAPI client for the order router tests
- expand order and execution test coverage to assert database persistence, filtering, and cancellation behaviour

## Testing
- pytest services/order-router/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68da060546e88332b94a19ef40c5e3db