### PR TITLE
Define ExecutionIntent contract for order router

### DIFF
--- a/docs/algo-order-contract.md
+++ b/docs/algo-order-contract.md
@@ -1,0 +1,148 @@
+# Contrat d'acheminement d'ordre sandbox
+
+Ce document décrit le contrat REST utilisé entre un algorithme et le service
+`order-router` afin de déposer un ordre standardisé dans l'environnement
+sandbox. Les structures `ExecutionIntent` (requête) et `ExecutionReport`
+(réponse) sont définies dans `schemas/order_router.py` et servent également de
+schémas FastAPI.
+
+## Transport et chemin
+
+- **Méthode** : `POST`
+- **Chemin** : `/orders`
+- **Code succès** : `201 Created`
+- **Codes d'erreur** :
+  - `400 Bad Request` : validation de schéma ou rejet du moteur de risque.
+  - `403 Forbidden` : limites journalières dépassées ou privilèges manquants.
+  - `404 Not Found` : broker ou paire non supportés.
+  - `500 Internal Server Error` : échec de persistance de l'ordre.
+
+## Spécification OpenAPI
+
+```yaml
+post:
+  summary: Route un ordre sandbox et renvoie un rapport d'exécution.
+  operationId: routeSandboxOrder
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ExecutionIntent'
+  responses:
+    '201':
+      description: Rapport d'exécution initial.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ExecutionReport'
+    '400':
+      description: Requête invalide ou verrouillage risque.
+    '403':
+      description: Limite quotidienne dépassée ou capability manquante.
+    '404':
+      description: Broker ou paire inconnus.
+    '500':
+      description: Persistance de l'ordre impossible.
+```
+
+## `ExecutionIntent`
+
+Payload enrichi combinant l'ordre standardisé et un contexte risque facultatif.
+
+| Champ | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| `broker` | `string` | oui | Identifiant du broker sandbox ciblé. |
+| `venue` | `string` | oui | Venue d'exécution (`ExecutionVenue`). |
+| `symbol` | `string` | oui | Symbole négocié (ex : `BTCUSDT`). |
+| `side` | `string` | oui | Sens de l'ordre (`buy`/`sell`). |
+| `quantity` | `number` | oui | Quantité positive à router. |
+| `order_type` | `string` | oui | `market` ou `limit`. |
+| `price` | `number` | non | Prix limite (> 0) requis pour un ordre `limit`. |
+| `time_in_force` | `string` | non | Par défaut `GTC`. |
+| `client_order_id` | `string` | non | Identifiant externe (36 caractères max). |
+| `tags` | `array[string]` | non | Labels libres propagés au rapport. |
+| `account_id` | `string` | non | Référence compte utilisée pour les règles de risque. |
+| `risk` | `object` | non | Voir `RiskOverrides`. |
+
+### `RiskOverrides`
+
+| Champ | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| `account_id` | `string` | non | Compte cible (défaut : `default`). |
+| `realized_pnl` | `number` | non | PnL réalisé utilisé par le moteur de risque. |
+| `unrealized_pnl` | `number` | non | PnL latent transmis au moteur. |
+| `stop_loss` | `number` | non | Seuil de stop-loss (> 0) à appliquer. |
+
+### Exemple de requête
+
+```json
+{
+  "broker": "binance",
+  "venue": "binance.spot",
+  "symbol": "BTCUSDT",
+  "side": "buy",
+  "quantity": 0.5,
+  "order_type": "limit",
+  "price": 29500,
+  "time_in_force": "GTC",
+  "tags": ["mvp", "sandbox"],
+  "client_order_id": "algo-1234",
+  "account_id": "demo-account",
+  "risk": {
+    "account_id": "demo-account",
+    "realized_pnl": -1250.5,
+    "unrealized_pnl": 320.0,
+    "stop_loss": 45000
+  }
+}
+```
+
+## `ExecutionReport`
+
+Accusé d'exécution renvoyé immédiatement après la soumission ; il reprend les
+champs standards partagés avec `schemas/market.py`.
+
+| Champ | Type | Description |
+| --- | --- | --- |
+| `order_id` | `string` | Identifiant de l'ordre côté broker sandbox. |
+| `status` | `string` | État initial (`accepted`, `filled`, `partially_filled`, etc.). |
+| `broker` | `string` | Broker ayant reçu l'ordre. |
+| `venue` | `string` | Venue d'exécution. |
+| `symbol` | `string` | Symbole négocié. |
+| `side` | `string` | Sens de l'ordre. |
+| `quantity` | `number` | Quantité originale. |
+| `filled_quantity` | `number` | Quantité exécutée à ce stade. |
+| `avg_price` | `number` | Prix moyen pondéré si disponible. |
+| `submitted_at` | `string(date-time)` | Horodatage ISO 8601 de soumission. |
+| `fills` | `array` | Liste des exécutions (`quantity`, `price`, `timestamp`). |
+| `tags` | `array[string]` | Tags propagés depuis l'intent. |
+
+### Exemple de réponse (`201 Created`)
+
+```json
+{
+  "order_id": "BN-1",
+  "status": "filled",
+  "broker": "binance",
+  "venue": "binance.spot",
+  "symbol": "BTCUSDT",
+  "side": "buy",
+  "quantity": 0.5,
+  "filled_quantity": 0.5,
+  "avg_price": 29500.0,
+  "submitted_at": "2023-11-15T10:32:41Z",
+  "fills": [
+    {
+      "quantity": 0.5,
+      "price": 29500.0,
+      "timestamp": "2023-11-15T10:32:41Z"
+    }
+  ],
+  "tags": ["mvp", "sandbox"]
+}
+```
+
+Ces spécifications garantissent que l'orchestrateur MVP et les clients
+externes consomment le même contrat pour initier et suivre l'exécution d'ordres
+via le routeur sandbox.

--- a/schemas/order_router.py
+++ b/schemas/order_router.py
@@ -1,4 +1,4 @@
-"""Pydantic schemas for persisted order router entities."""
+"""Pydantic schemas for order router contracts and persisted entities."""
 from __future__ import annotations
 
 from datetime import datetime
@@ -6,6 +6,33 @@ from decimal import Decimal
 from typing import List
 
 from pydantic import BaseModel, Field, field_validator
+
+from schemas.market import (
+    ExecutionReport as MarketExecutionReport,
+    OrderRequest,
+)
+
+
+class RiskOverrides(BaseModel):
+    """Risk adjustments provided by the caller when routing an order."""
+
+    account_id: str = Field(default="default", min_length=1, max_length=64)
+    realized_pnl: float | None = None
+    unrealized_pnl: float | None = None
+    stop_loss: float | None = Field(default=None, gt=0)
+
+
+class ExecutionIntent(OrderRequest):
+    """Order routing payload combining the shared order request and risk context."""
+
+    account_id: str | None = Field(default=None, min_length=1, max_length=64)
+    risk: RiskOverrides | None = None
+
+
+class ExecutionReport(MarketExecutionReport):
+    """Execution acknowledgment returned by the order router."""
+
+    pass
 
 
 class ExecutionRecord(BaseModel):
@@ -103,8 +130,11 @@ class PaginatedExecutions(BaseModel):
 
 
 __all__ = [
+    "ExecutionIntent",
+    "ExecutionReport",
     "ExecutionRecord",
     "OrderRecord",
+    "RiskOverrides",
     "PaginationMetadata",
     "OrdersLogMetadata",
     "ExecutionsMetadata",

--- a/services/order-router/app/brokers/base.py
+++ b/services/order-router/app/brokers/base.py
@@ -5,7 +5,8 @@ import abc
 from typing import Dict, Iterable, List
 
 from libs.connectors import ExecutionClient
-from schemas.market import ExecutionReport, ExecutionStatus, OrderRequest
+from schemas.market import ExecutionStatus, OrderRequest
+from schemas.order_router import ExecutionReport
 
 
 class BrokerAdapter(ExecutionClient, abc.ABC):

--- a/services/order-router/app/brokers/binance.py
+++ b/services/order-router/app/brokers/binance.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from schemas.market import ExecutionFill, ExecutionReport, ExecutionStatus, OrderRequest
+from schemas.market import ExecutionFill, ExecutionStatus, OrderRequest
+from schemas.order_router import ExecutionReport
 
 from .base import BrokerAdapter
 

--- a/services/order-router/app/brokers/ibkr.py
+++ b/services/order-router/app/brokers/ibkr.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from schemas.market import ExecutionFill, ExecutionReport, ExecutionStatus, OrderRequest
+from schemas.market import ExecutionFill, ExecutionStatus, OrderRequest
+from schemas.order_router import ExecutionReport
 
 from .base import BrokerAdapter
 


### PR DESCRIPTION
## Summary
- add shared ExecutionIntent, RiskOverrides, and ExecutionReport schemas for order routing payloads
- update the order-router FastAPI endpoints and broker adapters to rely on the shared contract
- document the /orders REST contract with OpenAPI details and examples for sandbox clients

## Testing
- python -m compileall schemas services/order-router/app

------
https://chatgpt.com/codex/tasks/task_e_68da11be5b688332b5ab36ed1b9719be