### PR TITLE
Add retry logic and strategy error propagation for order routing failures

### DIFF
--- a/docs/mvp-sandbox-flow.md
+++ b/docs/mvp-sandbox-flow.md
@@ -4,6 +4,19 @@ Ce guide décrit le flux cible entre les services `market_data`, `algo-engine` e
 pour une exécution spot simplifiée. Il s'appuie sur les nouveaux contrats de données partagés
 (`schemas/market.py`) et sur les limites configurées dans `providers/limits.py`.
 
+## Politique de retry du client order-router
+
+Le client asynchrone `OrderRouterClient` applique désormais une stratégie de retry
+exponentiel pour sécuriser l'appel `POST /orders` :
+
+- jusqu'à trois tentatives sur les erreurs réseau (`httpx.HTTPError`) ou les réponses 5xx,
+- des délais d'attente de 0,5 s, 1 s puis 2 s entre chaque tentative,
+- journalisation de chaque tentative échouée pour faciliter l'observabilité.
+
+Au-delà de ces trois essais ou en cas d'erreur fonctionnelle (4xx), le client renvoie une
+erreur `OrderRouterClientError` afin que l'orchestrateur puisse placer la stratégie en état
+`ERROR` et déclencher les alertes correspondantes.
+
 ## Endpoints exposés
 
 | Service | Endpoint | Description |


### PR DESCRIPTION
## Summary
- add exponential backoff retry logic and logging to the asynchronous order router client
- propagate routing failures through the orchestrator so strategies transition to ERROR state with alerts
- document the retry policy for the sandbox MVP flow

## Testing
- pytest services/algo-engine/tests/test_strategies.py

------
https://chatgpt.com/codex/tasks/task_e_68da1d0d215483328bfb47046842b58e