### PR TITLE
Add execution flow test with mock order router

### DIFF
--- a/services/algo-engine/tests/conftest.py
+++ b/services/algo-engine/tests/conftest.py
@@ -1,0 +1,166 @@
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any, Callable
+
+import httpx
+import pytest
+
+os.environ.setdefault("ENTITLEMENTS_BYPASS", "1")
+
+prometheus_stub = types.ModuleType("prometheus_client")
+
+
+class _DummyMetric:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401 - mimic Prometheus signature
+        """No-op metric"""
+
+    def labels(self, *args: Any, **kwargs: Any) -> "_DummyMetric":
+        return self
+
+    def inc(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def observe(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def _generate_latest() -> bytes:
+    return b""
+
+
+prometheus_stub.CONTENT_TYPE_LATEST = "text/plain"
+prometheus_stub.Counter = _DummyMetric
+prometheus_stub.Histogram = _DummyMetric
+prometheus_stub.generate_latest = _generate_latest  # type: ignore[assignment]
+sys.modules.setdefault("prometheus_client", prometheus_stub)
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_package(alias: str, path: Path) -> None:
+    spec = importlib.util.spec_from_file_location(alias, path / "__init__.py")
+    module = importlib.util.module_from_spec(spec)
+    module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    sys.modules[alias] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+
+
+def _load_main_module() -> types.ModuleType:
+    _load_package("algo_engine", PACKAGE_ROOT)
+    _load_package("algo_engine.app", PACKAGE_ROOT / "app")
+    _load_package("algo_engine.app.strategies", PACKAGE_ROOT / "app" / "strategies")
+    main_spec = importlib.util.spec_from_file_location(
+        "algo_engine.app.main", PACKAGE_ROOT / "app" / "main.py"
+    )
+    main_module = importlib.util.module_from_spec(main_spec)
+    sys.modules["algo_engine.app.main"] = main_module
+    assert main_spec and main_spec.loader
+    main_spec.loader.exec_module(main_module)  # type: ignore[attr-defined]
+    return main_module
+
+
+MAIN_MODULE = _load_main_module()
+DEFAULT_ORDER_ROUTER_CLIENT = MAIN_MODULE.order_router_client
+
+
+@pytest.fixture(scope="session")
+def main_module() -> types.ModuleType:
+    return MAIN_MODULE
+
+
+@pytest.fixture(autouse=True)
+def reset_state(main_module: types.ModuleType) -> None:
+    store = main_module.store
+    orchestrator = main_module.orchestrator
+    store._strategies.clear()  # type: ignore[attr-defined]
+    orchestrator.update_daily_limit(trades_submitted=0)
+    orchestrator.set_mode("paper")
+    orchestrator._state.last_simulation = None  # type: ignore[attr-defined]
+    orchestrator._state.recent_executions.clear()  # type: ignore[attr-defined]
+    orchestrator.set_order_router_client(DEFAULT_ORDER_ROUTER_CLIENT)
+
+
+class MockRouterController:
+    def __init__(self, orchestrator: Any, order_router_factory: Callable[[httpx.AsyncClient], Any]) -> None:
+        self._orchestrator = orchestrator
+        self._factory = order_router_factory
+        self._requests: list[httpx.Request] = []
+        self._response: dict[str, Any] = {}
+        self._status_code: int = 200
+        self._exception: Exception | None = None
+        self._transport: httpx.MockTransport | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._apply_default_response()
+
+    @property
+    def requests(self) -> list[httpx.Request]:
+        return self._requests
+
+    def _apply_default_response(self) -> None:
+        self._response = {
+            "order_id": "order-1",
+            "status": "filled",
+            "broker": "mock-broker",
+            "venue": "binance.spot",
+            "symbol": "BTCUSDT",
+            "side": "buy",
+            "quantity": 1.0,
+            "filled_quantity": 1.0,
+            "avg_price": 25000.0,
+            "submitted_at": "2024-01-01T00:00:00+00:00",
+            "fills": [],
+            "tags": [],
+        }
+        self._status_code = 200
+        self._exception = None
+
+    def set_response(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self._response = payload
+        self._status_code = status_code
+        self._exception = None
+
+    def set_error(self, exception: Exception) -> None:
+        self._exception = exception
+
+    def reset(self) -> None:
+        self._requests.clear()
+        self._apply_default_response()
+
+    async def _setup(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            self._requests.append(request)
+            if self._exception is not None:
+                raise self._exception
+            return httpx.Response(self._status_code, json=self._response)
+
+        self._transport = httpx.MockTransport(handler)
+        self._client = httpx.AsyncClient(base_url="http://mock-router", transport=self._transport)
+        router_client = self._factory(self._client)
+        self._orchestrator.set_order_router_client(router_client)
+
+    async def aclose(self) -> None:
+        self._orchestrator.set_order_router_client(DEFAULT_ORDER_ROUTER_CLIENT)
+        if self._client is not None:
+            await self._client.aclose()
+        self._transport = None
+        self._client = None
+
+
+@pytest.fixture
+def mock_order_router(main_module: types.ModuleType) -> MockRouterController:
+    orchestrator = main_module.orchestrator
+
+    def build_router(async_client: httpx.AsyncClient) -> Any:
+        return main_module.OrderRouterClient(client=async_client, base_url="http://mock-router")
+
+    controller = MockRouterController(orchestrator, build_router)
+    asyncio.run(controller._setup())
+    try:
+        yield controller
+    finally:
+        asyncio.run(controller.aclose())

--- a/services/algo-engine/tests/test_execution_flow.py
+++ b/services/algo-engine/tests/test_execution_flow.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from algo_engine.app.main import StrategyRecord, StrategyStatus, orchestrator, store
+from algo_engine.app.order_router_client import OrderRouterClientError
+from algo_engine.app.strategies.base import StrategyBase, StrategyConfig
+from schemas.market import ExecutionStatus, ExecutionVenue, OrderSide, OrderType
+
+
+class StaticSignalStrategy(StrategyBase):
+    """Strategy emitting a single configurable signal when triggered."""
+
+    key: str = "static"
+    _signal: Dict[str, Any] | None = None
+
+    def __init__(self, config: StrategyConfig, signal: Dict[str, Any]) -> None:
+        super().__init__(config)
+        self._signal = signal
+
+    def generate_signals(self, market_state: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if not market_state.get("emit", True):
+            return []
+        assert self._signal is not None
+        return [dict(self._signal)]
+
+
+def test_strategy_execution_flow_updates_state_and_handles_errors(
+    mock_order_router: Any,
+) -> None:
+    """Ensure orchestrator routes signals, updates state and handles failures."""
+
+    strategy_id = str(uuid4())
+    record = store.create(
+        StrategyRecord(
+            id=strategy_id,
+            name="Static",
+            strategy_type="static",
+            parameters={},
+            enabled=True,
+            metadata={"strategy_id": strategy_id},
+        )
+    )
+
+    signal: Dict[str, Any] = {
+        "order_type": OrderType.MARKET.value,
+        "broker": "paper",
+        "symbol": "BTCUSDT",
+        "venue": ExecutionVenue.BINANCE_SPOT.value,
+        "side": OrderSide.BUY.value,
+        "quantity": 1.0,
+    }
+    config = StrategyConfig(name="Static", enabled=True, metadata={"strategy_id": strategy_id})
+    strategy = StaticSignalStrategy(config, signal)
+
+    submitted_at = datetime.now(tz=timezone.utc).isoformat()
+    mock_order_router.set_response(
+        {
+            "order_id": "order-success",
+            "status": ExecutionStatus.FILLED.value,
+            "broker": "paper",
+            "venue": ExecutionVenue.BINANCE_SPOT.value,
+            "symbol": "BTCUSDT",
+            "side": OrderSide.BUY.value,
+            "quantity": 1.0,
+            "filled_quantity": 1.0,
+            "avg_price": 25000.0,
+            "submitted_at": submitted_at,
+            "fills": [],
+            "tags": ["strategy:static"],
+        }
+    )
+
+    reports = asyncio.run(orchestrator.execute_strategy(strategy=strategy, market_state={"emit": True}))
+    assert len(reports) == 1
+    assert reports[0].order_id == "order-success"
+    assert mock_order_router.requests and mock_order_router.requests[0].url.path == "/orders"
+
+    state = orchestrator.get_state()
+    assert state.trades_submitted == 1
+    assert state.recent_executions
+    assert state.recent_executions[0]["order_id"] == "order-success"
+
+    updated = store.update(strategy_id, status=StrategyStatus.ACTIVE)
+    assert updated.status is StrategyStatus.ACTIVE
+    assert updated.last_error is None
+
+    orchestrator.update_daily_limit(trades_submitted=0)
+    orchestrator._state.recent_executions.clear()  # type: ignore[attr-defined]
+    mock_order_router.reset()
+    failure_id = str(uuid4())
+    failing_record = store.create(
+        StrategyRecord(
+            id=failure_id,
+            name="Static Failure",
+            strategy_type="static",
+            parameters={},
+            enabled=True,
+            metadata={"strategy_id": failure_id},
+        )
+    )
+    failing_config = StrategyConfig(
+        name="Static Failure",
+        enabled=True,
+        metadata={"strategy_id": failure_id},
+    )
+    failing_strategy = StaticSignalStrategy(failing_config, signal)
+
+    mock_order_router.set_error(httpx.ConnectError("boom"))
+    with pytest.raises(OrderRouterClientError):
+        asyncio.run(
+            orchestrator.execute_strategy(strategy=failing_strategy, market_state={"emit": True})
+        )
+
+    failure_state = orchestrator.get_state()
+    assert failure_state.trades_submitted == 0
+    assert failure_state.recent_executions == []
+
+    stored_failure = store.get(failure_id)
+    assert stored_failure.status is StrategyStatus.ERROR
+    assert stored_failure.last_error
+
+    # Ensure PENDING strategy without emitted signals remains untouched
+    idle_id = str(uuid4())
+    idle_record = store.create(
+        StrategyRecord(
+            id=idle_id,
+            name="Idle",
+            strategy_type="static",
+            parameters={},
+            enabled=True,
+            metadata={"strategy_id": idle_id},
+        )
+    )
+    idle_strategy = StaticSignalStrategy(
+        StrategyConfig(name="Idle", enabled=True, metadata={"strategy_id": idle_id}),
+        signal,
+    )
+    reports_idle = asyncio.run(
+        orchestrator.execute_strategy(strategy=idle_strategy, market_state={"emit": False})
+    )
+    assert reports_idle == []
+    assert store.get(idle_id).status is StrategyStatus.PENDING
+    assert orchestrator.get_state().trades_submitted == 0

--- a/services/algo-engine/tests/test_strategies.py
+++ b/services/algo-engine/tests/test_strategies.py
@@ -1,76 +1,20 @@
-import importlib.util
-import os
-import sys
 from pathlib import Path
 from typing import Dict
-import types
 
 import pytest
 from fastapi.testclient import TestClient
 from libs.entitlements.client import Entitlements
 
-os.environ.setdefault("ENTITLEMENTS_BYPASS", "1")
-
-prometheus_stub = types.ModuleType("prometheus_client")
-
-
-class _DummyMetric:
-    def __init__(self, *args, **kwargs):  # noqa: D401 - mimic Prometheus signature
-        """No-op metric"""
-
-    def labels(self, *args, **kwargs):
-        return self
-
-    def inc(self, *args, **kwargs) -> None:
-        return None
-
-    def observe(self, *args, **kwargs) -> None:
-        return None
-
-
-prometheus_stub.CONTENT_TYPE_LATEST = "text/plain"
-prometheus_stub.Counter = _DummyMetric
-prometheus_stub.Histogram = _DummyMetric
-prometheus_stub.generate_latest = lambda: b""  # type: ignore[assignment]
-sys.modules.setdefault("prometheus_client", prometheus_stub)
+from algo_engine.app.main import (
+    StrategyRecord,
+    StrategyStatus,
+    _enforce_entitlements,
+    app,
+    orchestrator,
+    store,
+)
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
-
-
-def _load_package(alias: str, path: Path) -> None:
-    spec = importlib.util.spec_from_file_location(alias, path / "__init__.py")
-    module = importlib.util.module_from_spec(spec)
-    module.__path__ = [str(path)]  # type: ignore[attr-defined]
-    sys.modules[alias] = module
-    assert spec and spec.loader
-    spec.loader.exec_module(module)  # type: ignore[attr-defined]
-
-
-_load_package("algo_engine", PACKAGE_ROOT)
-_load_package("algo_engine.app", PACKAGE_ROOT / "app")
-_load_package("algo_engine.app.strategies", PACKAGE_ROOT / "app" / "strategies")
-
-main_spec = importlib.util.spec_from_file_location("algo_engine.app.main", PACKAGE_ROOT / "app" / "main.py")
-main_module = importlib.util.module_from_spec(main_spec)
-sys.modules["algo_engine.app.main"] = main_module
-assert main_spec and main_spec.loader
-main_spec.loader.exec_module(main_module)  # type: ignore[attr-defined]
-
-app = main_module.app
-store = main_module.store
-orchestrator = main_module.orchestrator
-StrategyRecord = main_module.StrategyRecord
-StrategyStatus = main_module.StrategyStatus
-_enforce_entitlements = main_module._enforce_entitlements
-
-
-@pytest.fixture(autouse=True)
-def reset_state():
-    store._strategies.clear()  # type: ignore[attr-defined]
-    orchestrator.update_daily_limit(trades_submitted=0)
-    orchestrator.set_mode("paper")
-    orchestrator._state.last_simulation = None  # type: ignore[attr-defined]
-    yield
 
 
 def test_create_and_list_strategies():


### PR DESCRIPTION
## Summary
- extract shared algo-engine test bootstrapping into a pytest conftest
- add a stateful mock order router fixture for orchestrator tests
- add a regression test covering execution flow success, error handling, and idle paths

## Testing
- `pytest services/algo-engine/tests`


------
https://chatgpt.com/codex/tasks/task_e_68da1e176af08332bb96a09aaf0067b3