### PR TITLE
Add realtime streaming client to dashboard

### DIFF
--- a/services/streaming/app/pipeline.py
+++ b/services/streaming/app/pipeline.py
@@ -185,6 +185,11 @@ class StreamingBridge:
                     await connection.close()
             self._connections.clear()
 
+    def connection_count(self, room_id: str) -> int:
+        """Return the number of active websocket connections for a room."""
+
+        return len(self._connections.get(room_id, set()))
+
 
 class StreamingConnection(Protocol):
     async def send_json(self, data: Dict[str, Any]) -> None:

--- a/services/streaming/app/routers/rooms.py
+++ b/services/streaming/app/routers/rooms.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from ..config import get_settings
-from ..dependencies import require_capability
+from ..dependencies import WebsocketAuthorizer, get_bridge, require_capability
+from ..pipeline import StreamingBridge
 from ..repositories import RoomStore, SessionStore
 from ..schemas import LiveState, Room, RoomCreate
 
@@ -56,6 +59,38 @@ async def get_room(
     sessions = await sessions_store.list_by_room(room_id)
     active_session = next((s for s in sessions if s.status in {"live", "scheduled"}), None)
     return LiveState(room=room, session=active_session)
+
+
+@router.get("/{room_id}/connection")
+async def room_connection_details(
+    room_id: str,
+    request: Request,
+    rooms_store: RoomStore = Depends(get_room_store),
+    bridge: StreamingBridge = Depends(get_bridge),
+):
+    """Expose les informations nécessaires pour rejoindre une room via WebSocket."""
+
+    authorizer: WebsocketAuthorizer = request.app.state.websocket_authorizer
+    viewer_id = await authorizer.authorize_request(request)
+    try:
+        room = await rooms_store.get(room_id)
+    except KeyError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Room not found")
+
+    ws_url = request.url_for("websocket_room", room_id=room_id)
+    parsed = urlparse(str(ws_url))
+    query_params = dict(parse_qsl(parsed.query))
+    query_params["viewer"] = viewer_id
+    scheme = "wss" if parsed.scheme == "https" else "ws"
+    websocket_url = urlunparse(parsed._replace(scheme=scheme, query=urlencode(query_params)))
+
+    return {
+        "room_id": room.room_id,
+        "title": room.title,
+        "token": viewer_id,
+        "websocket_url": websocket_url,
+        "connections": bridge.connection_count(room_id),
+    }
 
 
 __all__ = ["router"]

--- a/services/web-dashboard/app/main.py
+++ b/services/web-dashboard/app/main.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from urllib.parse import urljoin
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
@@ -20,6 +22,10 @@ app = FastAPI(title="Web Dashboard", version="0.1.0")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 templates = Jinja2Templates(directory=TEMPLATES_DIR)
+
+STREAMING_BASE_URL = os.getenv("WEB_DASHBOARD_STREAMING_BASE_URL", "http://localhost:8001/")
+STREAMING_ROOM_ID = os.getenv("WEB_DASHBOARD_STREAMING_ROOM_ID", "public-room")
+STREAMING_VIEWER_ID = os.getenv("WEB_DASHBOARD_STREAMING_VIEWER_ID", "demo-viewer")
 
 
 @app.get("/health")
@@ -58,11 +64,17 @@ def render_dashboard(request: Request) -> HTMLResponse:
     """Render an HTML dashboard that surfaces key trading signals."""
 
     context = load_dashboard_context()
+    handshake_url = urljoin(STREAMING_BASE_URL, f"rooms/{STREAMING_ROOM_ID}/connection")
     return templates.TemplateResponse(
         "dashboard.html",
         {
             "request": request,
             "context": context,
+            "streaming": {
+                "handshake_url": handshake_url,
+                "room_id": STREAMING_ROOM_ID,
+                "viewer_id": STREAMING_VIEWER_ID,
+            },
         },
     )
 

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -125,5 +125,9 @@
     <footer class="layout__footer">
       <p class="text text--muted">Données d'exemple pour la démonstration du service.</p>
     </footer>
+    <script id="dashboard-bootstrap" type="application/json">
+      {{ {"context": context.model_dump(mode='json'), "streaming": streaming}|tojson }}
+    </script>
+    <script src="/static/dashboard.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expose a `/rooms/{room_id}/connection` endpoint that reuses the websocket authorizer and bridge to hand back connection info
- relax the authorizer to accept query tokens and surface live connection counts from the streaming bridge
- add a dashboard JavaScript client that hydrates the UI from websocket updates and falls back to the static snapshot when offline

## Testing
- pytest services/streaming/tests/test_websocket.py

------
https://chatgpt.com/codex/tasks/task_e_68da257182148332b9ad1894af504feb