### PR TITLE
Add dashboard performance metrics from reports service

### DIFF
--- a/services/web-dashboard/README.md
+++ b/services/web-dashboard/README.md
@@ -1,0 +1,43 @@
+# Web Dashboard Service
+
+Le service **web-dashboard** expose une interface FastAPI servant une page HTML
+(Jinja2) permettant de visualiser l'activité des portefeuilles et la synthèse
+de performance. Les sections ci-dessous récapitulent les jeux de données
+alimentant la vue ainsi que les variables d'environnement utiles pour la
+configuration.
+
+## Sources de données
+
+| Bloc du dashboard | Source | Détails |
+| --- | --- | --- |
+| Portefeuilles, transactions, alertes | `services/web-dashboard/app/data.py` | Données d'exemple construites côté service pour illustrer la présentation des portefeuilles et flux récents. |
+| Métriques de performance | `reports-service` (`GET /reports/daily`) | Agrégation quotidienne retournant P\&L, drawdown et incidents. Le dashboard normalise les rendements à partir du champ d'exposition (`exposure`, `notional_exposure`, etc.) lorsqu'il est fourni afin de calculer un rendement composé et un ratio de Sharpe annualisé. |
+
+Lorsque la réponse du reports-service ne contient pas d'exposition, le calcul du
+Sharpe et du rendement cumulatif retombe sur les valeurs de P\&L brutes (sans
+normalisation). Les cartes signalent également l'indisponibilité des métriques
+lorsqu'un appel API échoue.
+
+## Configuration
+
+Le service s'appuie sur les variables suivantes :
+
+- `WEB_DASHBOARD_STREAMING_BASE_URL`, `WEB_DASHBOARD_STREAMING_ROOM_ID`,
+  `WEB_DASHBOARD_STREAMING_VIEWER_ID` : paramètres existants pour initialiser la
+  section temps réel.
+- `WEB_DASHBOARD_REPORTS_BASE_URL` : racine HTTP utilisée pour appeler
+  `reports-service` (par défaut `http://reports:8000/`).
+- `WEB_DASHBOARD_REPORTS_TIMEOUT` : délai (en secondes) appliqué aux requêtes
+  HTTP vers le reports-service (par défaut `5.0`).
+
+Le module `services/web-dashboard/app/data.py` encapsule ces appels via
+`_fetch_performance_metrics()` et restitue un objet `PerformanceMetrics` injecté
+dans le contexte Jinja. Toute adaptation (nouvelle source, transformation
+supplémentaire) doit se faire dans ce module pour conserver une interface
+centralisée.
+
+## Tests
+
+Aucun test spécifique n'est fourni pour le dashboard. L'ajout de tests FastAPI
+ou de tests d'intégration ciblant l'appel au reports-service est recommandé si
+le volume de logique métier augmente.

--- a/services/web-dashboard/app/schemas.py
+++ b/services/web-dashboard/app/schemas.py
@@ -68,10 +68,46 @@ class Alert(BaseModel):
     acknowledged: bool = Field(False, description="Whether the alert has been acknowledged")
 
 
+class PerformanceMetrics(BaseModel):
+    """Summarise risk and return analytics provided by the reports service."""
+
+    account: str | None = Field(default=None, description="Trading account identifier")
+    as_of: datetime | None = Field(default=None, description="Timestamp of the latest data point")
+    currency: str = Field(default="$", description="Currency symbol for monetary values")
+    current_pnl: float = Field(default=0.0, description="Most recent realised P&L")
+    current_drawdown: float = Field(default=0.0, description="Drawdown captured for the latest session")
+    cumulative_return: float = Field(
+        default=0.0,
+        description="Compounded return over the available sample (expressed as a ratio when exposure is known)",
+    )
+    cumulative_return_is_ratio: bool = Field(
+        default=False,
+        description="Flag indicating whether cumulative_return is a ratio (True) or an absolute amount (False)",
+    )
+    sharpe_ratio: float | None = Field(default=None, description="Annualised Sharpe ratio when computable")
+    sample_size: int = Field(default=0, ge=0, description="Number of daily observations considered")
+    uses_exposure: bool = Field(
+        default=False,
+        description="True when the Sharpe ratio and returns are normalised by exposure values",
+    )
+    available: bool = Field(
+        default=False,
+        description="Set to True when metrics were successfully retrieved from the reports service",
+    )
+    source: str = Field(
+        default="reports-service",
+        description="Identifier of the upstream service providing the metrics",
+    )
+
+
 class DashboardContext(BaseModel):
     """Container with all payloads rendered in the dashboard template."""
 
     portfolios: List[Portfolio]
     transactions: List[Transaction]
     alerts: List[Alert]
+    metrics: PerformanceMetrics | None = Field(
+        default=None,
+        description="Aggregated performance analytics sourced from the reports service",
+    )
 

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -105,6 +105,53 @@ body {
   gap: var(--space-md);
 }
 
+.card--metrics .card__body {
+  gap: var(--space-lg);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-lg);
+}
+
+.metric-card {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 100%;
+}
+
+.metric-card__label {
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.metric-card__value {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.metric-card__value--positive {
+  color: var(--color-success);
+}
+
+.metric-card__value--negative {
+  color: var(--color-critical);
+}
+
+.metrics__footnote {
+  font-size: var(--font-size-sm);
+}
+
 .portfolio-list,
 .alert-list {
   list-style: none;
@@ -213,6 +260,15 @@ body {
 
   .layout__main {
     grid-template-columns: 1fr;
+  }
+
+  .metrics-grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+  }
+
+  .metric-card {
+    padding: var(--space-sm) var(--space-md);
   }
 
   .table thead {

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -14,6 +14,115 @@
       </p>
     </header>
     <main class="layout__main">
+      {% if context.metrics %}
+      <section class="card card--metrics" aria-labelledby="metrics-title">
+        <div class="card__header">
+          <h2 id="metrics-title" class="heading heading--lg">Performance</h2>
+          <p class="text text--muted">
+            {% if context.metrics.account %}
+            Compte {{ context.metrics.account }}
+            {% endif %}
+            {% if context.metrics.as_of %}
+            · Mise à jour le {{ context.metrics.as_of.strftime('%d/%m/%Y') }}
+            {% endif %}
+          </p>
+        </div>
+        <div class="card__body">
+          {% if context.metrics.available %}
+          <div class="metrics-grid" role="list" aria-describedby="metrics-title">
+            {% set pnl_positive = context.metrics.current_pnl >= 0 %}
+            <article class="metric-card" role="listitem" aria-labelledby="metric-pnl-label">
+              <p id="metric-pnl-label" class="metric-card__label">P&amp;L courant</p>
+              <p
+                class="metric-card__value {{ 'metric-card__value--positive' if pnl_positive else 'metric-card__value--negative' }}"
+              >
+                {{ '%.2f' | format(context.metrics.current_pnl) }} {{ context.metrics.currency }}
+              </p>
+              <span
+                class="badge {{ 'badge--success' if pnl_positive else 'badge--critical' }}"
+                aria-label="{{ 'Gain' if pnl_positive else 'Perte' }} sur la dernière session"
+                >{{ 'Gain' if pnl_positive else 'Perte' }}</span
+              >
+            </article>
+
+            <article class="metric-card" role="listitem" aria-labelledby="metric-dd-label">
+              <p id="metric-dd-label" class="metric-card__label">Drawdown</p>
+              <p class="metric-card__value metric-card__value--negative">
+                {{ '%.2f' | format(context.metrics.current_drawdown) }} {{ context.metrics.currency }}
+              </p>
+              <span class="badge badge--warning" aria-label="Drawdown cumulé">
+                Protection du capital
+              </span>
+            </article>
+
+            {% set cumulative_positive = context.metrics.cumulative_return >= 0 %}
+            <article class="metric-card" role="listitem" aria-labelledby="metric-return-label">
+              <p id="metric-return-label" class="metric-card__label">Rendement cumulatif</p>
+              <p
+                class="metric-card__value {{ 'metric-card__value--positive' if cumulative_positive else 'metric-card__value--negative' }}"
+              >
+                {% if context.metrics.cumulative_return_is_ratio %}
+                {{ '%.2f' | format(context.metrics.cumulative_return * 100) }} %
+                {% else %}
+                {{ '%.2f' | format(context.metrics.cumulative_return) }} {{ context.metrics.currency }}
+                {% endif %}
+              </p>
+              <span
+                class="badge {{ 'badge--success' if cumulative_positive else 'badge--critical' }}"
+                aria-label="Rendement composé basé sur les sessions disponibles"
+                >{{ 'En hausse' if cumulative_positive else 'En baisse' }}</span
+              >
+            </article>
+
+            <article class="metric-card" role="listitem" aria-labelledby="metric-sharpe-label">
+              <p id="metric-sharpe-label" class="metric-card__label">Sharpe annualisé</p>
+              <p class="metric-card__value">
+                {% if context.metrics.sharpe_ratio is not none %}
+                {{ '%.2f' | format(context.metrics.sharpe_ratio) }}
+                {% else %}
+                —
+                {% endif %}
+              </p>
+              {% if context.metrics.sharpe_ratio is not none %}
+              {% set sharpe = context.metrics.sharpe_ratio %}
+              {% set sharpe_badge = 'badge--critical' %}
+              {% set sharpe_label = 'Sous la cible' %}
+              {% if sharpe >= 1.5 %}
+              {% set sharpe_badge = 'badge--success' %}
+              {% set sharpe_label = 'Excellent' %}
+              {% elif sharpe >= 1.0 %}
+              {% set sharpe_badge = 'badge--info' %}
+              {% set sharpe_label = 'Solide' %}
+              {% elif sharpe >= 0 %}
+              {% set sharpe_badge = 'badge--warning' %}
+              {% set sharpe_label = 'À surveiller' %}
+              {% endif %}
+              <span class="badge {{ sharpe_badge }}" aria-label="{{ sharpe_label }}">{{ sharpe_label }}</span>
+              {% else %}
+              <span class="badge badge--neutral" aria-label="Sharpe non disponible">ND</span>
+              {% endif %}
+            </article>
+          </div>
+          <p class="text text--muted metrics__footnote">
+            {% if context.metrics.sample_size %}
+            Basé sur {{ context.metrics.sample_size }} session{{ 's' if context.metrics.sample_size > 1 else '' }}
+            {% else %}
+            Données insuffisantes pour calculer toutes les métriques.
+            {% endif %}
+            {% if context.metrics.uses_exposure %}
+            Normalisation par l'exposition quotidienne active.
+            {% endif %}
+          </p>
+          {% else %}
+          <p class="text text--muted">
+            Les métriques de performance ne sont pas disponibles pour le moment. Vérifiez la connexion avec
+            reports-service.
+          </p>
+          {% endif %}
+        </div>
+      </section>
+      {% endif %}
+
       <section class="card" aria-labelledby="portfolios-title">
         <div class="card__header">
           <h2 id="portfolios-title" class="heading heading--lg">Portefeuilles</h2>

--- a/services/web-dashboard/requirements.txt
+++ b/services/web-dashboard/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.110,<1.0
 uvicorn[standard]>=0.27
 jinja2>=3.1
+httpx>=0.26


### PR DESCRIPTION
## Summary
- call the reports service to derive P&L, drawdown and Sharpe-based metrics and attach them to the dashboard context
- introduce a `PerformanceMetrics` schema, responsive metric cards in the dashboard template and the necessary styling updates
- document the dashboard data sources and add the httpx dependency used for the upstream call

## Testing
- pytest services/web-dashboard *(no tests collected)*
- python -m compileall services/web-dashboard/app

------
https://chatgpt.com/codex/tasks/task_e_68da28bca22c83329efc2ec96e028a01