### PR TITLE
Add performance analytics endpoint to reports service

### DIFF
--- a/schemas/report.py
+++ b/schemas/report.py
@@ -85,3 +85,26 @@ class DailyRiskReport(BaseModel):
             datetime: lambda value: value.isoformat(),
             date: lambda value: value.isoformat(),
         }
+
+
+class PortfolioPerformance(BaseModel):
+    """Summarise portfolio level performance analytics."""
+
+    account: str
+    start_date: date | None = None
+    end_date: date | None = None
+    total_return: float
+    cumulative_return: float
+    average_return: float
+    volatility: float
+    sharpe_ratio: float
+    max_drawdown: float = Field(..., ge=0.0)
+    observation_count: int = Field(..., ge=0)
+    positive_days: int = Field(..., ge=0)
+    negative_days: int = Field(..., ge=0)
+
+    class Config:
+        json_encoders = {
+            datetime: lambda value: value.isoformat(),
+            date: lambda value: value.isoformat(),
+        }


### PR DESCRIPTION
## Summary
- add a PortfolioPerformance schema to capture portfolio-level metrics such as cumulative return, volatility, and Sharpe ratio
- compute performance aggregates from the existing daily report data and expose them through a new /reports/performance endpoint
- extend the reports API tests to cover the new analytics and account-level edge cases

## Testing
- pytest services/reports/tests/test_reports_api.py

------
https://chatgpt.com/codex/tasks/task_e_68da359f42e48332bc5c9b4060efa24f