### PR TITLE
Add orchestrator strategy status and live logs to dashboard

### DIFF
--- a/docs/ui/dashboard-data-contracts.md
+++ b/docs/ui/dashboard-data-contracts.md
@@ -1,0 +1,121 @@
+# Contrats JSON du tableau de bord
+
+Ce document décrit la structure des données échangées entre le service **web-dashboard** et les
+systèmes amont. Il sert de référence pour la mise en cache du contexte initial `/dashboard` et pour
+les messages temps réel transmis via le service de streaming.
+
+## Contexte initial `/dashboard`
+
+L'endpoint `/dashboard` rend une page HTML qui embarque un objet `context` sérialisé en JSON.
+Les propriétés suivantes sont exposées en plus des portefeuilles, transactions, alertes et métriques
+historiquement disponibles :
+
+```jsonc
+{
+  "strategies": [
+    {
+      "id": "92a939a2-57d5-4df3-a6c7-9d0b15efc2a4",
+      "name": "Static",
+      "status": "ACTIVE",           // Valeurs possibles : PENDING, ACTIVE, ERROR
+      "enabled": true,
+      "strategy_type": "static",     // Identifiant du plugin orchestrateur
+      "tags": ["intraday"],
+      "last_error": null,
+      "last_execution": {
+        "order_id": "order-success",
+        "status": "FILLED",
+        "submitted_at": "2024-02-01T09:15:22.581729Z",
+        "symbol": "BTCUSDT",
+        "venue": "BINANCE_SPOT",
+        "side": "BUY",
+        "quantity": 1.0,
+        "filled_quantity": 1.0
+      },
+      "metadata": {
+        "strategy_id": "92a939a2-57d5-4df3-a6c7-9d0b15efc2a4"
+      }
+    }
+  ],
+  "logs": [
+    {
+      "timestamp": "2024-02-01T09:15:22.581729Z",
+      "level": "info",
+      "message": "FILLED BTCUSDT (ordre order-success)",
+      "order_id": "order-success",
+      "status": "FILLED",
+      "symbol": "BTCUSDT",
+      "strategy_id": "92a939a2-57d5-4df3-a6c7-9d0b15efc2a4",
+      "strategy_hint": "static",
+      "extra": {
+        "broker": "paper",
+        "side": "BUY"
+      }
+    }
+  ]
+}
+```
+
+### Règles de construction
+
+- Le tableau `strategies` est alimenté par l'API de l'orchestrateur (`GET /strategies`).
+  - `status` reprend l'état courant (`PENDING`, `ACTIVE`, `ERROR`).
+  - `last_execution` est calculée à partir de l'historique `recent_executions` retourné par
+    l'orchestrateur. Les correspondances se basent sur l'`id`, les métadonnées ou les tags `strategy:`.
+- Les éléments du tableau `logs` sont des instances normalisées de `recent_executions`.
+  - `timestamp` reprend le champ `submitted_at` (ou `created_at` à défaut).
+  - `strategy_id` est résolu par rapprochement avec les identifiants connus des stratégies.
+  - La clé `extra` conserve les champs bruts non affichés dans l'interface.
+
+## Messages temps réel (WebSocket)
+
+Le service de streaming transmet des événements au format JSON. Le client web supporte les
+ressources suivantes :
+
+### Mise à jour des stratégies
+
+```jsonc
+{
+  "resource": "strategies",
+  "items": [
+    {
+      "id": "92a939a2-57d5-4df3-a6c7-9d0b15efc2a4",
+      "name": "Static",
+      "status": "ERROR",
+      "enabled": false,
+      "last_error": "Order router indisponible"
+    }
+  ]
+}
+```
+
+### Journaux d'exécution
+
+Les événements de type `logs` (ou `executions`) peuvent contenir soit un champ `items` (tableau),
+soit une entrée unique `entry` :
+
+```jsonc
+{
+  "resource": "logs",
+  "items": [
+    {
+      "timestamp": "2024-02-01T09:16:02.004Z",
+      "message": "FILLED BTCUSDT (ordre order-success)",
+      "status": "FILLED",
+      "symbol": "BTCUSDT",
+      "strategy_id": "92a939a2-57d5-4df3-a6c7-9d0b15efc2a4"
+    }
+  ]
+}
+```
+
+Le client conserve au maximum 200 entrées et applique un filtrage par stratégie dans la console
+interactive.
+
+## Variables d'environnement
+
+- `WEB_DASHBOARD_ORCHESTRATOR_BASE_URL` : URL de base de l'API orchestrateur (défaut
+  `http://algo-engine:8000/`).
+- `WEB_DASHBOARD_ORCHESTRATOR_TIMEOUT` : délai maximal (secondes) pour les appels HTTP.
+- `WEB_DASHBOARD_MAX_LOG_ENTRIES` : nombre maximum d'entrées de log conservées côté client/serveur.
+
+Ces paramètres garantissent la traçabilité des échanges entre le dashboard et l'orchestrateur.

--- a/services/web-dashboard/app/static/dashboard.js
+++ b/services/web-dashboard/app/static/dashboard.js
@@ -12,7 +12,9 @@
     return;
   }
 
-  const initialState = bootstrapData.context || { portfolios: [], transactions: [], alerts: [] };
+  const initialState =
+    bootstrapData.context ||
+    { portfolios: [], transactions: [], alerts: [], strategies: [], logs: [] };
   const streamingConfig = bootstrapData.streaming || {};
   const state = {
     current: JSON.parse(JSON.stringify(initialState)),
@@ -23,7 +25,21 @@
     portfolios: document.querySelector(".portfolio-list"),
     transactions: document.querySelector(".card[aria-labelledby='transactions-title'] tbody"),
     alerts: document.querySelector(".alert-list"),
+    strategies: document.querySelector(".strategy-table__body"),
+    logs: document.getElementById("log-entries"),
+    logFilter: document.getElementById("log-filter"),
   };
+
+  const filters = {
+    logStrategy: selectors.logFilter ? selectors.logFilter.value || "all" : "all",
+  };
+
+  if (selectors.logFilter) {
+    selectors.logFilter.addEventListener("change", (event) => {
+      filters.logStrategy = event.target.value;
+      renderLogs();
+    });
+  }
 
   function formatCurrency(value) {
     if (typeof value !== "number") {
@@ -160,10 +176,214 @@
     });
   }
 
+  function updateLogFilterOptions() {
+    const select = selectors.logFilter;
+    if (!select) {
+      return;
+    }
+    const previous = select.value || filters.logStrategy || "all";
+    const options = new Map();
+    options.set("all", "Toutes les stratégies");
+    (state.current.strategies || []).forEach((strategy) => {
+      if (!strategy || typeof strategy !== "object") {
+        return;
+      }
+      const id = String(strategy.id || "");
+      const name = strategy.name || id || "Stratégie";
+      if (id) {
+        options.set(id, name);
+      }
+    });
+
+    select.innerHTML = "";
+    options.forEach((label, value) => {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = label;
+      select.appendChild(option);
+    });
+
+    if (options.has(previous)) {
+      select.value = previous;
+    } else {
+      select.value = "all";
+    }
+    filters.logStrategy = select.value;
+  }
+
+  function renderStrategies() {
+    const container = selectors.strategies;
+    if (!container) {
+      return;
+    }
+    container.innerHTML = "";
+    const strategies = Array.isArray(state.current.strategies)
+      ? state.current.strategies
+      : [];
+    if (!strategies.length) {
+      const row = document.createElement("tr");
+      row.innerHTML = `
+        <td colspan="5">
+          <p class="text text--muted">Aucune stratégie enregistrée pour le moment.</p>
+        </td>
+      `;
+      container.appendChild(row);
+      updateLogFilterOptions();
+      return;
+    }
+
+    strategies.forEach((strategy) => {
+      if (!strategy || typeof strategy !== "object") {
+        return;
+      }
+      const row = document.createElement("tr");
+      const statusValue = (strategy.status && strategy.status.value) || strategy.status || "PENDING";
+      let badgeClass = "badge--info";
+      if (statusValue === "ACTIVE") {
+        badgeClass = "badge--success";
+      } else if (statusValue === "ERROR") {
+        badgeClass = "badge--critical";
+      } else if (statusValue === "PENDING") {
+        badgeClass = "badge--info";
+      } else {
+        badgeClass = "badge--warning";
+      }
+
+      const lastExecution = strategy.last_execution || strategy.lastExecution || null;
+      const submittedAt = lastExecution && (lastExecution.submitted_at || lastExecution.submittedAt);
+      const submittedDate = submittedAt ? new Date(submittedAt) : null;
+      const submittedText =
+        submittedDate && !Number.isNaN(submittedDate.getTime())
+          ? submittedDate.toLocaleString("fr-FR", {
+              day: "2-digit",
+              month: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            })
+          : null;
+      const executionStatus = lastExecution && (lastExecution.status || lastExecution.execution_status);
+      const executionSymbol = lastExecution && (lastExecution.symbol || lastExecution.instrument);
+      const executionOrderId = lastExecution && (lastExecution.order_id || lastExecution.orderId);
+
+      row.innerHTML = `
+        <td data-label="Nom">
+          <div class="strategy-name">
+            <span class="heading heading--md">${strategy.name || "Stratégie"}</span>
+            ${strategy.strategy_type || strategy.strategyType ? `<span class="badge badge--neutral">${
+              strategy.strategy_type || strategy.strategyType
+            }</span>` : ""}
+          </div>
+        </td>
+        <td data-label="Statut">
+          <span class="badge ${badgeClass}">${statusValue}</span>
+        </td>
+        <td data-label="Dernière exécution">
+          ${submittedText ? submittedText : '<span class="text text--muted">Aucune</span>'}
+        </td>
+        <td data-label="Détails">
+          ${lastExecution
+            ? `<p class="text text--muted">
+                ${executionStatus ? executionStatus : ""}
+                ${executionSymbol ? ` · ${executionSymbol}` : ""}
+                ${executionOrderId ? ` · Ordre ${executionOrderId}` : ""}
+              </p>`
+            : '<span class="text text--muted">En attente d\'exécution</span>'}
+        </td>
+        <td data-label="Erreur récente">
+          ${strategy.last_error || strategy.lastError
+            ? `<p class="text text--critical">${strategy.last_error || strategy.lastError}</p>`
+            : '<span class="text text--muted">—</span>'}
+        </td>
+      `;
+
+      container.appendChild(row);
+    });
+
+    updateLogFilterOptions();
+  }
+
+  function normaliseLogEntry(entry) {
+    if (!entry || typeof entry !== "object") {
+      return null;
+    }
+    const timestampValue = entry.timestamp || entry.time || entry.created_at || entry.createdAt;
+    const timestamp = timestampValue ? new Date(timestampValue) : null;
+    if (!timestamp || Number.isNaN(timestamp.getTime())) {
+      return null;
+    }
+    return {
+      timestamp,
+      message: entry.message || "",
+      status: entry.status || entry.state || null,
+      symbol: entry.symbol || null,
+      orderId: entry.order_id || entry.orderId || null,
+      strategyId: entry.strategy_id || entry.strategyId || null,
+      strategyHint: entry.strategy_hint || entry.strategyHint || null,
+    };
+  }
+
+  function renderLogs() {
+    const container = selectors.logs;
+    if (!container) {
+      return;
+    }
+    container.innerHTML = "";
+    const entries = Array.isArray(state.current.logs) ? state.current.logs : [];
+    const normalised = entries
+      .map((entry) => normaliseLogEntry(entry))
+      .filter((entry) => entry !== null)
+      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+
+    let rendered = 0;
+    normalised.forEach((entry) => {
+      if (
+        filters.logStrategy !== "all" &&
+        entry.strategyId &&
+        entry.strategyId !== filters.logStrategy
+      ) {
+        return;
+      }
+      if (filters.logStrategy !== "all" && !entry.strategyId) {
+        return;
+      }
+      const item = document.createElement("li");
+      item.className = "log-console__item";
+      item.dataset.strategy = entry.strategyId || "";
+      const timestampText = entry.timestamp.toLocaleString("fr-FR", {
+        day: "2-digit",
+        month: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      item.innerHTML = `
+        <div class="log-console__meta">
+          <time datetime="${entry.timestamp.toISOString()}">${timestampText}</time>
+          ${entry.status ? `<span class="badge badge--neutral">${entry.status}</span>` : ""}
+          ${entry.symbol ? `<span class="badge badge--info">${entry.symbol}</span>` : ""}
+        </div>
+        <p class="log-console__message">${entry.message || ""}</p>
+      `;
+      container.appendChild(item);
+      rendered += 1;
+    });
+
+    if (!rendered) {
+      const empty = document.createElement("li");
+      empty.className = "log-console__item log-console__item--empty";
+      empty.innerHTML = `
+        <p class="text text--muted">En attente d'événements. Les exécutions apparaîtront ici en temps réel.</p>
+      `;
+      container.appendChild(empty);
+    }
+  }
+
   function renderAll() {
+    renderStrategies();
     renderPortfolios();
     renderTransactions();
     renderAlerts();
+    renderLogs();
   }
 
   let websocket;
@@ -208,6 +428,47 @@
     } else if (resource === "alerts" && Array.isArray(payload.items)) {
       state.current.alerts = payload.items;
       renderAlerts();
+    } else if (resource === "strategies" && Array.isArray(payload.items)) {
+      state.current.strategies = payload.items;
+      renderStrategies();
+      renderLogs();
+    } else if (resource === "logs" || resource === "executions") {
+      const items = [];
+      if (Array.isArray(payload.items)) {
+        items.push(...payload.items);
+      } else if (payload.entry) {
+        items.push(payload.entry);
+      } else if (!payload.resource && !payload.type) {
+        items.push(payload);
+      }
+      if (!state.current.logs) {
+        state.current.logs = [];
+      }
+      const combined = items.concat(state.current.logs);
+      const unique = [];
+      const seen = new Set();
+      combined.forEach((entry) => {
+        const normalised = normaliseLogEntry(entry);
+        if (!normalised) {
+          return;
+        }
+        const key = `${normalised.timestamp.toISOString()}-${normalised.orderId || "unknown"}`;
+        if (seen.has(key)) {
+          return;
+        }
+        seen.add(key);
+        unique.push({
+          timestamp: normalised.timestamp.toISOString(),
+          message: normalised.message,
+          status: normalised.status,
+          symbol: normalised.symbol,
+          order_id: normalised.orderId,
+          strategy_id: normalised.strategyId,
+          strategy_hint: normalised.strategyHint,
+        });
+      });
+      state.current.logs = unique.slice(0, 200);
+      renderLogs();
     }
   }
 

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -328,6 +328,97 @@ body {
   color: var(--color-text);
 }
 
+.card__header--inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.strategy-table .heading--md {
+  font-size: var(--font-size-md);
+}
+
+.strategy-name {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.text--critical {
+  color: var(--color-critical);
+  font-weight: 500;
+}
+
+.select {
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-sm);
+}
+
+.log-filter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  align-items: flex-end;
+}
+
+.log-console {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  max-height: 320px;
+  overflow-y: auto;
+  padding: var(--space-sm);
+}
+
+.log-console__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.log-console__item {
+  border-left: 3px solid rgba(56, 189, 248, 0.35);
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.log-console__item--empty {
+  border-left-color: rgba(148, 163, 184, 0.3);
+  text-align: center;
+}
+
+.log-console__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.log-console__meta time {
+  font-variant-numeric: tabular-nums;
+}
+
+.log-console__message {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
 @media (max-width: 768px) {
   body {
     padding: var(--space-lg);

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -137,6 +137,135 @@
       </section>
       {% endif %}
 
+      <section class="card card--strategies" aria-labelledby="strategies-title">
+        <div class="card__header card__header--inline">
+          <h2 id="strategies-title" class="heading heading--lg">Stratégies</h2>
+          <p class="text text--muted">Synchronisées avec l'orchestrateur</p>
+        </div>
+        <div class="card__body">
+          <table class="table strategy-table" role="grid" aria-describedby="strategies-title">
+            <thead>
+              <tr>
+                <th scope="col">Nom</th>
+                <th scope="col">Statut</th>
+                <th scope="col">Dernière exécution</th>
+                <th scope="col">Détails</th>
+                <th scope="col">Erreur récente</th>
+              </tr>
+            </thead>
+            <tbody class="strategy-table__body">
+              {% if context.strategies %}
+              {% for strategy in context.strategies %}
+              <tr>
+                <td data-label="Nom">
+                  <div class="strategy-name">
+                    <span class="heading heading--md">{{ strategy.name }}</span>
+                    {% if strategy.strategy_type %}
+                    <span class="badge badge--neutral">{{ strategy.strategy_type }}</span>
+                    {% endif %}
+                  </div>
+                </td>
+                <td data-label="Statut">
+                  {% set status = strategy.status.value if strategy.status else strategy.status %}
+                  {% set status_lower = status.lower() if status else 'pending' %}
+                  {% set status_badge = 'badge--warning' %}
+                  {% if status == 'ACTIVE' %}
+                  {% set status_badge = 'badge--success' %}
+                  {% elif status == 'ERROR' %}
+                  {% set status_badge = 'badge--critical' %}
+                  {% elif status == 'PENDING' %}
+                  {% set status_badge = 'badge--info' %}
+                  {% endif %}
+                  <span class="badge {{ status_badge }}">{{ status }}</span>
+                </td>
+                <td data-label="Dernière exécution">
+                  {% if strategy.last_execution and strategy.last_execution.submitted_at %}
+                  {{ strategy.last_execution.submitted_at.strftime('%d/%m %H:%M') }}
+                  {% else %}
+                  <span class="text text--muted">Aucune</span>
+                  {% endif %}
+                </td>
+                <td data-label="Détails">
+                  {% if strategy.last_execution %}
+                  <p class="text text--muted">
+                    {% if strategy.last_execution.status %}
+                    {{ strategy.last_execution.status }}
+                    {% endif %}
+                    {% if strategy.last_execution.symbol %}
+                    · {{ strategy.last_execution.symbol }}
+                    {% endif %}
+                    {% if strategy.last_execution.order_id %}
+                    · Ordre {{ strategy.last_execution.order_id }}
+                    {% endif %}
+                  </p>
+                  {% else %}
+                  <span class="text text--muted">En attente d'exécution</span>
+                  {% endif %}
+                </td>
+                <td data-label="Erreur récente">
+                  {% if strategy.last_error %}
+                  <p class="text text--critical">{{ strategy.last_error }}</p>
+                  {% else %}
+                  <span class="text text--muted">—</span>
+                  {% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+              {% else %}
+              <tr>
+                <td colspan="5">
+                  <p class="text text--muted">Aucune stratégie enregistrée pour le moment.</p>
+                </td>
+              </tr>
+              {% endif %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card card--logs" aria-labelledby="logs-title">
+        <div class="card__header card__header--inline">
+          <h2 id="logs-title" class="heading heading--lg">Activité en direct</h2>
+          <label class="log-filter" for="log-filter">
+            <span class="text text--muted">Filtrer par stratégie</span>
+            <select id="log-filter" class="select">
+              <option value="all" selected>Toutes les stratégies</option>
+              {% for strategy in context.strategies %}
+              <option value="{{ strategy.id }}">{{ strategy.name }}</option>
+              {% endfor %}
+            </select>
+          </label>
+        </div>
+        <div class="card__body">
+          <div class="log-console" role="log" aria-live="polite">
+            <ul id="log-entries" class="log-console__list">
+              {% if context.logs %}
+              {% for entry in context.logs %}
+              <li class="log-console__item" data-strategy="{{ entry.strategy_id or '' }}">
+                <div class="log-console__meta">
+                  <time datetime="{{ entry.timestamp.isoformat() }}">
+                    {{ entry.timestamp.strftime('%d/%m %H:%M:%S') }}
+                  </time>
+                  {% if entry.status %}
+                  <span class="badge badge--neutral">{{ entry.status }}</span>
+                  {% endif %}
+                  {% if entry.symbol %}
+                  <span class="badge badge--info">{{ entry.symbol }}</span>
+                  {% endif %}
+                </div>
+                <p class="log-console__message">{{ entry.message }}</p>
+              </li>
+              {% endfor %}
+              {% else %}
+              <li class="log-console__item log-console__item--empty">
+                <p class="text text--muted">En attente d'événements. Les exécutions apparaîtront ici en temps réel.</p>
+              </li>
+              {% endif %}
+            </ul>
+          </div>
+        </div>
+      </section>
+
       <section class="card" aria-labelledby="portfolios-title">
         <div class="card__header">
           <h2 id="portfolios-title" class="heading heading--lg">Portefeuilles</h2>


### PR DESCRIPTION
## Summary
- fetch strategy status and recent execution logs from the orchestrator when building the dashboard context
- expose the new data in the UI with a strategy status table and live log console backed by websocket updates
- document the JSON contracts for the dashboard context and streaming payloads

## Testing
- pytest services/web-dashboard/tests

------
https://chatgpt.com/codex/tasks/task_e_68da3956bc988332b724cabc2cbe645c