### PR TITLE
Add Playwright E2E coverage for web dashboard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,13 @@ jobs:
           pip install -r requirements-dev.txt
           pip install -r services/codex_gateway/requirements-dev.txt
           pip install -r services/codex_worker/requirements-dev.txt
+          pip install -r services/web-dashboard/requirements-dev.txt
+      - name: Install Playwright browsers
+        run: python -m playwright install --with-deps chromium
       - name: Run test suite
         run: make test
+      - name: Run web dashboard E2E tests
+        run: make web-dashboard-e2e
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 
-.PHONY: setup dev-up dev-down lint test e2e e2e-sh migrate-generate migrate-up migrate-down
+.PHONY: setup dev-up dev-down lint test e2e e2e-sh migrate-generate migrate-up migrate-down \
+        web-dashboard-e2e
 
 ALEMBIC_CONFIG ?= infra/migrations/alembic.ini
 ALEMBIC_DATABASE_URL ?= postgresql+psycopg2://trading:trading@localhost:5432/trading
@@ -35,6 +36,9 @@ e2e:
 
 e2e-sh:
         bash ./scripts/e2e/auth_e2e.sh
+
+web-dashboard-e2e:
+        python -m pytest services/web-dashboard/tests/e2e
 
 migrate-generate:
         @if [ -z "$(message)" ]; then \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,5 @@ plugins = ["pydantic.mypy"]
 testpaths = ["services"]
 addopts = "-q"
 pythonpath = ["services/config-service"]
+markers = ["asyncio: Tests asynchrones nécessitant une boucle d'événements"]
 

--- a/services/web-dashboard/README.md
+++ b/services/web-dashboard/README.md
@@ -38,6 +38,15 @@ centralisée.
 
 ## Tests
 
-Aucun test spécifique n'est fourni pour le dashboard. L'ajout de tests FastAPI
-ou de tests d'intégration ciblant l'appel au reports-service est recommandé si
-le volume de logique métier augmente.
+Deux familles de tests couvrent le service :
+
+- Tests d'API FastAPI (`pytest services/web-dashboard/tests/test_portfolio_history.py`).
+- Scénarios de bout en bout Playwright pilotant le navigateur pour vérifier
+  l'affichage des métriques, les mises à jour temps réel simulées et quelques
+  contrôles d'accessibilité (`make web-dashboard-e2e`).
+
+Avant la première exécution des scénarios Playwright, installez les dépendances
+Python (`pip install -r services/web-dashboard/requirements-dev.txt`) puis les
+binaires navigateur (`python -m playwright install chromium`). Une fois ces
+pré-requis en place, la commande `make web-dashboard-e2e` démarre le serveur
+FastAPI en tâche de fond et exécute les tests.

--- a/services/web-dashboard/requirements-dev.txt
+++ b/services/web-dashboard/requirements-dev.txt
@@ -1,3 +1,5 @@
 -r requirements.txt
 pytest
 httpx
+pytest-playwright
+playwright

--- a/services/web-dashboard/tests/conftest.py
+++ b/services/web-dashboard/tests/conftest.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from typing import Generator
+
+import pytest
+import uvicorn
+
+from .utils import load_dashboard_app
+
+
+@pytest.fixture(scope="session")
+def dashboard_app():
+    """Expose the FastAPI application for integration and E2E tests."""
+
+    return load_dashboard_app()
+
+
+@pytest.fixture(scope="session")
+def dashboard_base_url(dashboard_app) -> Generator[str, None, None]:
+    """Launch the dashboard service with uvicorn for browser-based tests."""
+
+    config = uvicorn.Config(dashboard_app, host="127.0.0.1", port=0, log_level="warning")
+    sock = config.bind_socket()
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, kwargs={"sockets": [sock]}, daemon=True)
+    thread.start()
+
+    start_time = time.time()
+    while not server.started:
+        if time.time() - start_time > 10:
+            raise RuntimeError("Dashboard test server failed to start in time")
+        time.sleep(0.05)
+
+    host, port = sock.getsockname()[:2]
+    base_url = f"http://{host}:{port}"
+
+    try:
+        yield base_url
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+        with contextlib.suppress(Exception):
+            sock.close()
+

--- a/services/web-dashboard/tests/e2e/test_dashboard_e2e.py
+++ b/services/web-dashboard/tests/e2e/test_dashboard_e2e.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from playwright.async_api import Page, expect
+
+
+pytestmark = pytest.mark.asyncio
+
+MOCK_WEBSOCKET_INIT = """
+(() => {
+  const sockets = [];
+
+  class MockWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.readyState = MockWebSocket.CONNECTING;
+      this.onopen = null;
+      this.onclose = null;
+      this.onmessage = null;
+      this.onerror = null;
+      sockets.push(this);
+      setTimeout(() => {
+        this.readyState = MockWebSocket.OPEN;
+        if (typeof this.onopen === 'function') {
+          this.onopen({ target: this });
+        }
+      }, 0);
+    }
+
+    send() {}
+
+    close() {
+      this.readyState = MockWebSocket.CLOSED;
+      if (typeof this.onclose === 'function') {
+        this.onclose({ target: this });
+      }
+    }
+  }
+
+  MockWebSocket.CONNECTING = 0;
+  MockWebSocket.OPEN = 1;
+  MockWebSocket.CLOSING = 2;
+  MockWebSocket.CLOSED = 3;
+
+  window.__mockSockets = sockets;
+  window.__emitMockMessage = (payload) => {
+    const message = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    sockets.forEach((socket) => {
+      if (typeof socket.onmessage === 'function') {
+        socket.onmessage({ data: message, target: socket });
+      }
+    });
+  };
+
+  window.WebSocket = MockWebSocket;
+})();
+"""
+
+
+@pytest.fixture
+async def mock_streaming(page: Page):
+    """Intercept WebSocket handshake calls and expose helpers to emit updates."""
+
+    async def _handle_handshake(route, _request):
+        await route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=json.dumps({"websocket_url": "ws://mocked/stream"}),
+        )
+
+    await page.route("**/rooms/**/connection", _handle_handshake)
+    await page.add_init_script(MOCK_WEBSOCKET_INIT)
+
+
+async def test_dashboard_displays_metrics(page: Page, dashboard_base_url: str, mock_streaming):
+    await page.goto(f"{dashboard_base_url}/dashboard", wait_until="networkidle")
+
+    await expect(page.get_by_role("heading", name="Performance")).to_be_visible()
+    metrics_list = page.get_by_role("list", name="Performance")
+    await expect(metrics_list.get_by_role("listitem").filter(has_text="P&L courant")).to_contain_text("$")
+    await expect(page.get_by_role("img", name="Graphique des valeurs cumulées des portefeuilles")).to_be_visible()
+
+
+async def test_dashboard_updates_transactions_from_websocket(
+    page: Page, dashboard_base_url: str, mock_streaming
+):
+    await page.goto(f"{dashboard_base_url}/dashboard", wait_until="networkidle")
+
+    update = {
+        "resource": "transactions",
+        "items": [
+            {
+                "timestamp": "2024-04-01T12:00:00Z",
+                "portfolio": "Momentum",
+                "symbol": "ADA",
+                "side": "buy",
+                "quantity": 12,
+                "price": 1.23,
+            }
+        ],
+    }
+
+    await page.evaluate("payload => window.__emitMockMessage(payload)", update)
+
+    await expect(page.locator("td[data-label='Symbole']", has_text="ADA")).to_be_visible()
+    await expect(page.locator("td[data-label='Sens'] span", has_text=re.compile("Buy", re.I))).to_be_visible()
+
+
+async def test_dashboard_exposes_accessible_landmarks(page: Page, dashboard_base_url: str, mock_streaming):
+    await page.goto(f"{dashboard_base_url}/dashboard", wait_until="networkidle")
+
+    await expect(page.get_by_role("heading", level=1, name=re.compile("Vue d'ensemble", re.I))).to_be_visible()
+    await expect(page.get_by_role("main")).to_be_visible()
+    await expect(page.get_by_role("list", name="Performance")).to_have_attribute("aria-describedby", "metrics-title")
+    await expect(page.get_by_role("grid", name="Transactions récentes")).to_have_attribute(
+        "aria-describedby", "transactions-title"
+    )
+

--- a/services/web-dashboard/tests/test_portfolio_history.py
+++ b/services/web-dashboard/tests/test_portfolio_history.py
@@ -1,33 +1,9 @@
-import importlib.util
-import sys
-import types
-from pathlib import Path
-
 from fastapi.testclient import TestClient
 
-
-MODULE_PATH = Path(__file__).resolve().parents[1] / "app" / "main.py"
-package_name = "web_dashboard"
-package = types.ModuleType(package_name)
-package.__path__ = [str(MODULE_PATH.parents[1])]
-sys.modules.setdefault(package_name, package)
-
-app_package_name = f"{package_name}.app"
-app_package = types.ModuleType(app_package_name)
-app_package.__path__ = [str(MODULE_PATH.parent)]
-sys.modules.setdefault(app_package_name, app_package)
-
-spec = importlib.util.spec_from_file_location(
-    f"{app_package_name}.main", MODULE_PATH, submodule_search_locations=[str(MODULE_PATH.parent)]
-)
-module = importlib.util.module_from_spec(spec)
-assert spec.loader is not None
-sys.modules[spec.name] = module
-spec.loader.exec_module(module)
-app = module.app
+from .utils import load_dashboard_app
 
 
-client = TestClient(app)
+client = TestClient(load_dashboard_app())
 
 
 def test_portfolio_history_endpoint_returns_series():

--- a/services/web-dashboard/tests/utils.py
+++ b/services/web-dashboard/tests/utils.py
@@ -1,0 +1,44 @@
+"""Test utilities for the web dashboard service."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from functools import lru_cache
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "app" / "main.py"
+PACKAGE_NAME = "web_dashboard"
+
+
+@lru_cache(maxsize=1)
+def load_dashboard_app():
+    """Return the FastAPI application exposed by the dashboard service."""
+
+    package = types.ModuleType(PACKAGE_NAME)
+    package.__path__ = [str(MODULE_PATH.parents[1])]
+    sys.modules.setdefault(PACKAGE_NAME, package)
+
+    app_package_name = f"{PACKAGE_NAME}.app"
+    app_package = types.ModuleType(app_package_name)
+    app_package.__path__ = [str(MODULE_PATH.parent)]
+    sys.modules.setdefault(app_package_name, app_package)
+
+    spec = importlib.util.spec_from_file_location(
+        f"{app_package_name}.main",
+        MODULE_PATH,
+        submodule_search_locations=[str(MODULE_PATH.parent)],
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise RuntimeError("Unable to load dashboard application module")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.app
+
+
+__all__ = ["load_dashboard_app"]
+


### PR DESCRIPTION
## Summary
- add a pytest-playwright end-to-end suite for the web dashboard covering metrics rendering, mocked WebSocket updates, and accessibility landmarks
- share a reusable helper to bootstrap the FastAPI app in tests and expose a uvicorn-powered test server fixture
- wire the new tests into the Makefile, CI workflow, and README with dependency installation guidance

## Testing
- python -m pytest services/web-dashboard/tests/test_portfolio_history.py
- python -m pytest services/web-dashboard/tests/e2e *(fails locally: Playwright browser dependencies are missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da3b63a6c88332ae5a32833e967467