### PR TITLE
feat: add alert management UI and API endpoints

### DIFF
--- a/services/web-dashboard/app/alerts_client.py
+++ b/services/web-dashboard/app/alerts_client.py
@@ -1,0 +1,70 @@
+"""Client utilities for interacting with the alerting engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import httpx
+
+
+class AlertsEngineError(RuntimeError):
+    """Raised when the alert engine returns an error response."""
+
+    def __init__(self, status_code: int, message: str | None = None):
+        self.status_code = status_code
+        self.message = message or "Alert engine request failed"
+        super().__init__(self.message)
+
+
+@dataclass
+class AlertsEngineClient:
+    """Simple wrapper around the alert engine HTTP API."""
+
+    base_url: str
+    timeout: float = 5.0
+    transport: httpx.BaseTransport | None = None
+
+    def __post_init__(self) -> None:
+        self._client = httpx.Client(base_url=self.base_url, timeout=self.timeout, transport=self.transport)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def create_alert(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        response = self._client.post("/alerts", json=dict(payload))
+        return self._parse_response(response)
+
+    def update_alert(self, alert_id: str, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        response = self._client.put(f"/alerts/{alert_id}", json=dict(payload))
+        return self._parse_response(response)
+
+    def delete_alert(self, alert_id: str) -> None:
+        response = self._client.delete(f"/alerts/{alert_id}")
+        if response.status_code >= 400:
+            raise AlertsEngineError(response.status_code, self._extract_message(response))
+
+    @staticmethod
+    def _parse_response(response: httpx.Response) -> Mapping[str, Any]:
+        if response.status_code >= 400:
+            raise AlertsEngineError(response.status_code, AlertsEngineClient._extract_message(response))
+        if not response.content:
+            return {}
+        return response.json()
+
+    @staticmethod
+    def _extract_message(response: httpx.Response) -> str:
+        try:
+            data = response.json()
+        except ValueError:  # pragma: no cover - defensive guard for non-json errors
+            return response.text or ""
+        return (
+            data.get("detail")
+            or data.get("message")
+            or data.get("error")
+            or response.text
+            or ""
+        )
+
+
+__all__ = ["AlertsEngineClient", "AlertsEngineError"]

--- a/services/web-dashboard/app/main.py
+++ b/services/web-dashboard/app/main.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import os
+from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urljoin
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from .data import load_dashboard_context, load_portfolio_history
+from .alerts_client import AlertsEngineClient, AlertsEngineError
+from .schemas import Alert, AlertCreateRequest, AlertUpdateRequest
 
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -26,6 +30,61 @@ templates = Jinja2Templates(directory=TEMPLATES_DIR)
 STREAMING_BASE_URL = os.getenv("WEB_DASHBOARD_STREAMING_BASE_URL", "http://localhost:8001/")
 STREAMING_ROOM_ID = os.getenv("WEB_DASHBOARD_STREAMING_ROOM_ID", "public-room")
 STREAMING_VIEWER_ID = os.getenv("WEB_DASHBOARD_STREAMING_VIEWER_ID", "demo-viewer")
+ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alerts-engine:8000/")
+ALERT_ENGINE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_ALERT_ENGINE_TIMEOUT", "5.0"))
+
+security = HTTPBearer(auto_error=False)
+
+
+@lru_cache(maxsize=1)
+def _alerts_client_factory() -> AlertsEngineClient:
+    return AlertsEngineClient(base_url=ALERT_ENGINE_BASE_URL, timeout=ALERT_ENGINE_TIMEOUT)
+
+
+def get_alerts_client() -> AlertsEngineClient:
+    """Return a configured client for communicating with the alert engine."""
+
+    return _alerts_client_factory()
+
+
+def _handle_alert_engine_error(error: AlertsEngineError) -> None:
+    status_code = error.status_code or status.HTTP_502_BAD_GATEWAY
+    if status_code < 400 or status_code >= 600:
+        status_code = status.HTTP_502_BAD_GATEWAY
+    message = error.message or "Erreur du moteur d'alertes."
+    raise HTTPException(status_code=status_code, detail=message)
+
+
+def require_alerts_auth(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> None:
+    """Ensure alert management routes are protected by a bearer token when configured."""
+
+    token = os.getenv("WEB_DASHBOARD_ALERTS_TOKEN")
+    if not token:
+        return
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentification requise pour gérer les alertes.",
+        )
+    if credentials.credentials != token:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Jeton d'authentification invalide.",
+        )
+
+
+@app.on_event("shutdown")
+def shutdown_alerts_client() -> None:
+    """Ensure HTTP resources opened for the alerts engine are properly released."""
+
+    try:
+        client = _alerts_client_factory()
+    except Exception:  # pragma: no cover - defensive guard if instantiation fails
+        return
+    client.close()
+    _alerts_client_factory.cache_clear()
 
 
 @app.get("/health")
@@ -70,12 +129,62 @@ def list_alerts() -> dict[str, object]:
     return {"items": context.alerts}
 
 
+@app.post("/alerts", response_model=Alert, status_code=status.HTTP_201_CREATED)
+def create_alert(
+    alert: AlertCreateRequest,
+    client: AlertsEngineClient = Depends(get_alerts_client),
+    _: None = Depends(require_alerts_auth),
+) -> Alert:
+    """Create a new alert by delegating to the alert engine."""
+
+    try:
+        payload = client.create_alert(alert.model_dump(mode="json"))
+    except AlertsEngineError as error:
+        _handle_alert_engine_error(error)
+    return Alert.model_validate(payload)
+
+
+@app.put("/alerts/{alert_id}", response_model=Alert)
+def update_alert(
+    alert_id: str,
+    payload: AlertUpdateRequest,
+    client: AlertsEngineClient = Depends(get_alerts_client),
+    _: None = Depends(require_alerts_auth),
+) -> Alert:
+    """Update an existing alert by delegating to the alert engine."""
+
+    body = payload.model_dump(mode="json", exclude_unset=True)
+    try:
+        response_payload = client.update_alert(alert_id, body)
+    except AlertsEngineError as error:
+        _handle_alert_engine_error(error)
+
+    merged = {"id": alert_id, **body, **(response_payload or {})}
+    return Alert.model_validate(merged)
+
+
+@app.delete("/alerts/{alert_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_alert(
+    alert_id: str,
+    client: AlertsEngineClient = Depends(get_alerts_client),
+    _: None = Depends(require_alerts_auth),
+) -> Response:
+    """Remove an alert through the alert engine API."""
+
+    try:
+        client.delete_alert(alert_id)
+    except AlertsEngineError as error:
+        _handle_alert_engine_error(error)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 @app.get("/dashboard", response_class=HTMLResponse)
 def render_dashboard(request: Request) -> HTMLResponse:
     """Render an HTML dashboard that surfaces key trading signals."""
 
     context = load_dashboard_context()
     handshake_url = urljoin(STREAMING_BASE_URL, f"rooms/{STREAMING_ROOM_ID}/connection")
+    alerts_token = os.getenv("WEB_DASHBOARD_ALERTS_TOKEN", "")
     return templates.TemplateResponse(
         "dashboard.html",
         {
@@ -85,6 +194,10 @@ def render_dashboard(request: Request) -> HTMLResponse:
                 "handshake_url": handshake_url,
                 "room_id": STREAMING_ROOM_ID,
                 "viewer_id": STREAMING_VIEWER_ID,
+            },
+            "alerts_api": {
+                "endpoint": request.url_for("list_alerts"),
+                "token": alerts_token,
             },
         },
     )

--- a/services/web-dashboard/app/schemas.py
+++ b/services/web-dashboard/app/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class RiskLevel(str, Enum):
@@ -89,6 +89,26 @@ class Alert(BaseModel):
     risk: RiskLevel = Field(default=RiskLevel.info)
     created_at: datetime
     acknowledged: bool = Field(False, description="Whether the alert has been acknowledged")
+
+
+class AlertCreateRequest(BaseModel):
+    """Payload accepted when creating a new alert."""
+
+    title: str
+    detail: str
+    risk: RiskLevel = Field(default=RiskLevel.info)
+    acknowledged: bool = Field(default=False)
+
+
+class AlertUpdateRequest(BaseModel):
+    """Payload accepted when updating an existing alert."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    title: str | None = None
+    detail: str | None = None
+    risk: RiskLevel | None = None
+    acknowledged: bool | None = None
 
 
 class PerformanceMetrics(BaseModel):

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -328,6 +328,230 @@ body {
   color: var(--color-text);
 }
 
+.alerts-manager {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.alerts-manager__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--space-lg);
+}
+
+.alerts-manager__form,
+.alerts-manager__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.alerts-manager__banner {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  border: 1px solid transparent;
+}
+
+.alerts-manager__banner--success {
+  background: rgba(34, 197, 94, 0.16);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: var(--color-success);
+}
+
+.alerts-manager__banner--info {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: var(--color-info);
+}
+
+.alerts-manager__banner--warning {
+  background: rgba(249, 115, 22, 0.16);
+  border-color: rgba(249, 115, 22, 0.35);
+  color: var(--color-warning);
+}
+
+.alerts-manager__banner--error {
+  background: rgba(239, 68, 68, 0.16);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: var(--color-critical);
+}
+
+.alerts-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.alerts-form__fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.alerts-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.alerts-form__field label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.alerts-form__field input,
+.alerts-form__field textarea,
+.alerts-form__field select {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.35);
+  padding: var(--space-sm) var(--space-md);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+}
+
+.alerts-form__field textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+.alerts-form__field input:focus,
+.alerts-form__field textarea:focus,
+.alerts-form__field select:focus {
+  outline: 2px solid var(--color-info);
+  outline-offset: 2px;
+}
+
+.alerts-form__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: flex-end;
+}
+
+.alerts-form__checkbox label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.alerts-form__checkbox input {
+  accent-color: var(--color-info);
+}
+
+.alerts-form__error {
+  margin: 0;
+  color: var(--color-critical);
+  font-size: var(--font-size-sm);
+}
+
+.alerts-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.alerts-table {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.alerts-table__content {
+  overflow-x: auto;
+}
+
+.alerts-table__title {
+  font-weight: 600;
+}
+
+.alerts-table__detail {
+  margin: var(--space-xs) 0 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.alerts-table__actions {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--color-text);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button--primary {
+  background: var(--color-info);
+  border-color: var(--color-info);
+  color: #0f172a;
+}
+
+.button--primary:hover:not(:disabled) {
+  background: #0ea5e9;
+  border-color: #0ea5e9;
+}
+
+.button--secondary {
+  background: transparent;
+  color: var(--color-text);
+}
+
+.button--ghost {
+  background: transparent;
+}
+
+.button--ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.button--danger {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: var(--color-critical);
+}
+
+.button--danger:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .card__header--inline {
   display: flex;
   align-items: center;

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -348,29 +348,38 @@
           <h2 id="alerts-title" class="heading heading--lg">Alertes</h2>
         </div>
         <div class="card__body">
-          <ul class="alert-list">
-            {% for alert in context.alerts %}
-            <li class="alert-list__item">
-              <div class="alert-list__status">
-                <span class="badge badge--{{ 'critical' if alert.risk.value == 'critical' else 'warning' if alert.risk.value == 'warning' else 'info' }}">
-                  {{ alert.risk.value | capitalize }}
-                </span>
-              </div>
-              <div class="alert-list__content">
-                <h3 class="heading heading--md">{{ alert.title }}</h3>
-                <p class="text">{{ alert.detail }}</p>
-                <p class="text text--muted">
-                  Créée {{ alert.created_at.strftime('%d/%m %H:%M') }} ·
-                  {% if alert.acknowledged %}
-                  <span class="badge badge--neutral" aria-label="Alerte confirmée">Accusée</span>
-                  {% else %}
-                  <span class="badge badge--info" aria-label="Alerte non confirmée">À traiter</span>
-                  {% endif %}
-                </p>
-              </div>
-            </li>
-            {% endfor %}
-          </ul>
+          <div
+            id="alerts-manager"
+            data-alerts-react-root="true"
+            data-endpoint="{{ alerts_api.endpoint }}"
+            data-auth-token="{{ alerts_api.token }}"
+          >
+            <noscript>
+              <ul class="alert-list">
+                {% for alert in context.alerts %}
+                <li class="alert-list__item">
+                  <div class="alert-list__status">
+                    <span class="badge badge--{{ 'critical' if alert.risk.value == 'critical' else 'warning' if alert.risk.value == 'warning' else 'info' }}">
+                      {{ alert.risk.value | capitalize }}
+                    </span>
+                  </div>
+                  <div class="alert-list__content">
+                    <h3 class="heading heading--md">{{ alert.title }}</h3>
+                    <p class="text">{{ alert.detail }}</p>
+                    <p class="text text--muted">
+                      Créée {{ alert.created_at.strftime('%d/%m %H:%M') }} ·
+                      {% if alert.acknowledged %}
+                      <span class="badge badge--neutral" aria-label="Alerte confirmée">Accusée</span>
+                      {% else %}
+                      <span class="badge badge--info" aria-label="Alerte non confirmée">À traiter</span>
+                      {% endif %}
+                    </p>
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
+            </noscript>
+          </div>
         </div>
       </section>
     </main>

--- a/services/web-dashboard/src/alerts/AlertForm.jsx
+++ b/services/web-dashboard/src/alerts/AlertForm.jsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from "react";
+
+const DEFAULT_FORM = {
+  title: "",
+  detail: "",
+  risk: "info",
+  acknowledged: false,
+};
+
+const RISK_OPTIONS = [
+  { value: "info", label: "Information" },
+  { value: "warning", label: "Avertissement" },
+  { value: "critical", label: "Critique" },
+];
+
+function AlertForm({ mode, initialAlert, onSubmit, onCancel, submitting, error }) {
+  const [formData, setFormData] = useState(() => ({
+    ...DEFAULT_FORM,
+    ...(initialAlert ? normaliseInitial(initialAlert) : {}),
+  }));
+
+  useEffect(() => {
+    setFormData({
+      ...DEFAULT_FORM,
+      ...(initialAlert ? normaliseInitial(initialAlert) : {}),
+    });
+  }, [initialAlert, mode]);
+
+  function normaliseInitial(alert) {
+    if (!alert) {
+      return {};
+    }
+    return {
+      title: alert.title || "",
+      detail: alert.detail || "",
+      risk: typeof alert.risk === "string" ? alert.risk : alert.risk?.value || "info",
+      acknowledged: Boolean(alert.acknowledged),
+    };
+  }
+
+  function handleChange(event) {
+    const { name, value, type, checked } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    if (!formData.title.trim() || !formData.detail.trim()) {
+      return;
+    }
+    onSubmit?.({
+      title: formData.title.trim(),
+      detail: formData.detail.trim(),
+      risk: formData.risk,
+      acknowledged: Boolean(formData.acknowledged),
+    });
+  }
+
+  return (
+    <form className="alerts-form" onSubmit={handleSubmit}>
+      <fieldset className="alerts-form__fieldset" disabled={submitting}>
+        <legend className="sr-only">{mode === "edit" ? "Modifier l'alerte" : "Créer une alerte"}</legend>
+        <div className="alerts-form__field">
+          <label htmlFor="alert-title">Titre</label>
+          <input
+            id="alert-title"
+            name="title"
+            type="text"
+            value={formData.title}
+            onChange={handleChange}
+            required
+            placeholder="Synthèse de l'alerte"
+          />
+        </div>
+        <div className="alerts-form__field">
+          <label htmlFor="alert-detail">Description</label>
+          <textarea
+            id="alert-detail"
+            name="detail"
+            rows={3}
+            value={formData.detail}
+            onChange={handleChange}
+            required
+            placeholder="Détails permettant d'agir"
+          />
+        </div>
+        <div className="alerts-form__row">
+          <div className="alerts-form__field">
+            <label htmlFor="alert-risk">Niveau de risque</label>
+            <select id="alert-risk" name="risk" value={formData.risk} onChange={handleChange}>
+              {RISK_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="alerts-form__checkbox">
+            <label>
+              <input
+                type="checkbox"
+                name="acknowledged"
+                checked={formData.acknowledged}
+                onChange={handleChange}
+              />
+              <span>Accusée</span>
+            </label>
+          </div>
+        </div>
+        {error ? (
+          <p className="alerts-form__error" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <div className="alerts-form__actions">
+          <button type="submit" className="button button--primary">
+            {mode === "edit" ? "Mettre à jour" : "Créer"}
+          </button>
+          {mode === "edit" ? (
+            <button type="button" className="button button--secondary" onClick={onCancel}>
+              Annuler
+            </button>
+          ) : null}
+        </div>
+      </fieldset>
+    </form>
+  );
+}
+
+export default AlertForm;

--- a/services/web-dashboard/src/alerts/AlertManager.jsx
+++ b/services/web-dashboard/src/alerts/AlertManager.jsx
@@ -1,0 +1,291 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import AlertForm from "./AlertForm.jsx";
+import AlertTable from "./AlertTable.jsx";
+
+function generateId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `alert-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normaliseAlert(alert) {
+  if (!alert || typeof alert !== "object") {
+    return null;
+  }
+  const risk = typeof alert.risk === "string" ? alert.risk : alert.risk?.value || "info";
+  const createdAt = alert.created_at || alert.createdAt || new Date().toISOString();
+  return {
+    id: String(alert.id ?? alert.title ?? generateId()),
+    title: alert.title || "Alerte",
+    detail: alert.detail || "",
+    risk,
+    acknowledged: Boolean(alert.acknowledged),
+    created_at: createdAt,
+  };
+}
+
+function normaliseList(alerts) {
+  if (!Array.isArray(alerts)) {
+    return [];
+  }
+  return alerts
+    .map((item) => normaliseAlert(item))
+    .filter(Boolean)
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+}
+
+function AlertManager({
+  initialAlerts = [],
+  endpoint = "/alerts",
+  authToken = "",
+  enableInitialFetch = true,
+}) {
+  const [alerts, setAlerts] = useState(() => normaliseList(initialAlerts));
+  const [loading, setLoading] = useState(false);
+  const [formMode, setFormMode] = useState("create");
+  const [activeAlert, setActiveAlert] = useState(null);
+  const [formError, setFormError] = useState(null);
+  const [banner, setBanner] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [pendingId, setPendingId] = useState(null);
+
+  const baseEndpoint = useMemo(() => endpoint.replace(/\/$/, ""), [endpoint]);
+
+  const buildHeaders = useCallback(
+    (withBody = false) => {
+      const headers = {
+        Accept: "application/json",
+      };
+      if (withBody) {
+        headers["Content-Type"] = "application/json";
+      }
+      if (authToken) {
+        headers.Authorization = `Bearer ${authToken}`;
+      }
+      return headers;
+    },
+    [authToken]
+  );
+
+  const request = useCallback(
+    async (method, resource = "", body) => {
+      const path = resource ? `/${String(resource).replace(/^\//, "")}` : "";
+      const url = `${baseEndpoint}${path}`;
+      const response = await fetch(url, {
+        method,
+        headers: buildHeaders(body !== undefined),
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+      let payload = null;
+      const contentType = response.headers?.get?.("content-type") || "";
+      if (contentType.includes("application/json")) {
+        payload = await response.json();
+      }
+      if (!response.ok) {
+        const detail = payload?.detail || payload?.message || payload?.error;
+        const error = new Error(detail || "Le service d'alertes a renvoyé une erreur.");
+        error.status = response.status;
+        throw error;
+      }
+      return payload || {};
+    },
+    [baseEndpoint, buildHeaders]
+  );
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const payload = await request("GET");
+      if (payload && Array.isArray(payload.items)) {
+        setAlerts(normaliseList(payload.items));
+      }
+      setBanner(null);
+    } catch (error) {
+      setBanner({
+        type: "error",
+        message: error.message || "Impossible de récupérer les alertes.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    if (!enableInitialFetch) {
+      return;
+    }
+    refresh();
+  }, [refresh, enableInitialFetch]);
+
+  useEffect(() => {
+    function handleRealtimeUpdate(event) {
+      const detail = event.detail;
+      if (!detail || !Array.isArray(detail.items)) {
+        return;
+      }
+      setAlerts(normaliseList(detail.items));
+      if (detail.message) {
+        const type = detail.type || "info";
+        setBanner({ type, message: detail.message });
+      }
+    }
+
+    function handleRealtimeError(event) {
+      const message = event.detail?.message || "Flux temps réel indisponible.";
+      setBanner({ type: "error", message });
+    }
+
+    document.addEventListener("alerts:update", handleRealtimeUpdate);
+    document.addEventListener("alerts:fallback", handleRealtimeUpdate);
+    document.addEventListener("alerts:error", handleRealtimeError);
+    return () => {
+      document.removeEventListener("alerts:update", handleRealtimeUpdate);
+      document.removeEventListener("alerts:fallback", handleRealtimeUpdate);
+      document.removeEventListener("alerts:error", handleRealtimeError);
+    };
+  }, []);
+
+  const handleCreate = useCallback(
+    async (data) => {
+      setSubmitting(true);
+      setFormError(null);
+      try {
+        const payload = await request("POST", "", data);
+        const created = normaliseAlert(payload);
+        setAlerts((previous) => {
+          if (!created) {
+            return previous;
+          }
+          const existingIndex = previous.findIndex((item) => item.id === created.id);
+          if (existingIndex >= 0) {
+            const clone = [...previous];
+            clone[existingIndex] = { ...clone[existingIndex], ...created };
+            return normaliseList(clone);
+          }
+          return normaliseList([created, ...previous]);
+        });
+        setBanner({ type: "success", message: "Alerte créée avec succès." });
+        setFormMode("create");
+        setActiveAlert(null);
+      } catch (error) {
+        setFormError(error.message || "Impossible de créer l'alerte.");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [request]
+  );
+
+  const handleEdit = useCallback((alert) => {
+    setFormMode("edit");
+    setActiveAlert(alert);
+    setFormError(null);
+  }, []);
+
+  const handleCancelEdit = useCallback(() => {
+    setFormMode("create");
+    setActiveAlert(null);
+    setFormError(null);
+  }, []);
+
+  const handleUpdate = useCallback(
+    async (data) => {
+      if (!activeAlert) {
+        return;
+      }
+      setSubmitting(true);
+      setFormError(null);
+      try {
+        const payload = await request("PUT", activeAlert.id, data);
+        const updated = normaliseAlert({ ...activeAlert, ...payload });
+        setAlerts((previous) => {
+          if (!updated) {
+            return previous;
+          }
+          const index = previous.findIndex((item) => item.id === activeAlert.id);
+          if (index < 0) {
+            return previous;
+          }
+          const clone = [...previous];
+          clone[index] = { ...clone[index], ...updated };
+          return normaliseList(clone);
+        });
+        setBanner({ type: "success", message: "Alerte mise à jour." });
+        setFormMode("create");
+        setActiveAlert(null);
+      } catch (error) {
+        setFormError(error.message || "Impossible de mettre à jour l'alerte.");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [activeAlert, request]
+  );
+
+  const handleDelete = useCallback(
+    async (alert) => {
+      if (!alert) {
+        return;
+      }
+      const confirmed = typeof window !== "undefined" ? window.confirm(`Supprimer l'alerte "${alert.title}" ?`) : true;
+      if (!confirmed) {
+        return;
+      }
+      setPendingId(alert.id);
+      try {
+        await request("DELETE", alert.id);
+        setAlerts((previous) => previous.filter((item) => item.id !== alert.id));
+        if (activeAlert && activeAlert.id === alert.id) {
+          setFormMode("create");
+          setActiveAlert(null);
+        }
+        setBanner({ type: "success", message: "Alerte supprimée." });
+      } catch (error) {
+        setBanner({ type: "error", message: error.message || "Impossible de supprimer l'alerte." });
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [activeAlert, request]
+  );
+
+  return (
+    <section className="alerts-manager" aria-labelledby="alerts-title">
+      {banner ? (
+        <div
+          className={`alerts-manager__banner alerts-manager__banner--${banner.type}`}
+          role={banner.type === "error" ? "alert" : "status"}
+        >
+          {banner.message}
+        </div>
+      ) : null}
+      <div className="alerts-manager__grid">
+        <div className="alerts-manager__form">
+          <h3 className="heading heading--md">
+            {formMode === "edit" ? "Modifier l'alerte" : "Créer une alerte"}
+          </h3>
+          <AlertForm
+            mode={formMode}
+            initialAlert={activeAlert}
+            onSubmit={formMode === "edit" ? handleUpdate : handleCreate}
+            onCancel={handleCancelEdit}
+            submitting={submitting}
+            error={formError}
+          />
+        </div>
+        <div className="alerts-manager__list">
+          <AlertTable
+            alerts={alerts}
+            loading={loading}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            pendingId={pendingId}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default AlertManager;

--- a/services/web-dashboard/src/alerts/AlertTable.jsx
+++ b/services/web-dashboard/src/alerts/AlertTable.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+
+const RISK_LABELS = {
+  info: { label: "Information", className: "badge--info" },
+  warning: { label: "Avertissement", className: "badge--warning" },
+  critical: { label: "Critique", className: "badge--critical" },
+};
+
+function formatTimestamp(value) {
+  if (!value) {
+    return "";
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toLocaleString("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function AlertTable({ alerts, onEdit, onDelete, loading, pendingId }) {
+  return (
+    <div className="alerts-table">
+      <div className="alerts-table__header">
+        <h3 className="heading heading--md">Alertes actives</h3>
+        <p className="text text--muted">Suivez les signaux générés par le moteur d'alertes.</p>
+      </div>
+      <div className="alerts-table__content" role="region" aria-live="polite">
+        <table className="table alerts-table__grid">
+          <thead>
+            <tr>
+              <th scope="col">Titre</th>
+              <th scope="col">Risque</th>
+              <th scope="col">Statut</th>
+              <th scope="col">Créée</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {alerts.length === 0 ? (
+              <tr>
+                <td colSpan={5}>
+                  <p className="text text--muted">
+                    {loading ? "Chargement des alertes…" : "Aucune alerte enregistrée pour le moment."}
+                  </p>
+                </td>
+              </tr>
+            ) : (
+              alerts.map((alert) => {
+                const risk =
+                  typeof alert.risk === "string"
+                    ? alert.risk
+                    : alert.risk?.value || "info";
+                const riskMeta = RISK_LABELS[risk] || RISK_LABELS.info;
+                return (
+                  <tr key={alert.id}>
+                    <td data-label="Titre">
+                      <div className="alerts-table__title">{alert.title}</div>
+                      <p className="alerts-table__detail">{alert.detail}</p>
+                    </td>
+                    <td data-label="Risque">
+                      <span className={`badge ${riskMeta.className}`}>{riskMeta.label}</span>
+                    </td>
+                    <td data-label="Statut">
+                      <span className={`badge ${alert.acknowledged ? "badge--neutral" : "badge--info"}`}>
+                        {alert.acknowledged ? "Accusée" : "À traiter"}
+                      </span>
+                    </td>
+                    <td data-label="Créée">{formatTimestamp(alert.created_at || alert.createdAt)}</td>
+                    <td data-label="Actions" className="alerts-table__actions">
+                      <button
+                        type="button"
+                        className="button button--ghost"
+                        onClick={() => onEdit?.(alert)}
+                        disabled={pendingId === alert.id}
+                      >
+                        Modifier
+                      </button>
+                      <button
+                        type="button"
+                        className="button button--danger"
+                        onClick={() => onDelete?.(alert)}
+                        disabled={pendingId === alert.id}
+                      >
+                        Supprimer
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default AlertTable;

--- a/services/web-dashboard/src/main.jsx
+++ b/services/web-dashboard/src/main.jsx
@@ -1,6 +1,20 @@
 import React, { StrictMode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import PortfolioChart from "./components/PortfolioChart.jsx";
+import AlertManager from "./alerts/AlertManager.jsx";
+
+function loadBootstrapData() {
+  const bootstrapNode = document.getElementById("dashboard-bootstrap");
+  if (!bootstrapNode || !bootstrapNode.textContent) {
+    return {};
+  }
+  try {
+    return JSON.parse(bootstrapNode.textContent);
+  } catch (error) {
+    console.error("Impossible de parser la configuration du tableau de bord", error);
+    return {};
+  }
+}
 
 function PortfolioChartApp({ endpoint, currency }) {
   const [state, setState] = useState({ status: "loading", items: [], currency });
@@ -61,14 +75,33 @@ function PortfolioChartApp({ endpoint, currency }) {
   return <PortfolioChart history={state.items} currency={state.currency || currency} />;
 }
 
-const container = document.getElementById("portfolio-chart");
-if (container) {
-  const endpoint = container.dataset.endpoint || "/portfolios/history";
-  const currency = container.dataset.currency || "$";
-  const root = createRoot(container);
+const bootstrap = loadBootstrapData();
+
+const chartContainer = document.getElementById("portfolio-chart");
+if (chartContainer) {
+  const endpoint = chartContainer.dataset.endpoint || "/portfolios/history";
+  const currency = chartContainer.dataset.currency || "$";
+  const root = createRoot(chartContainer);
   root.render(
     <StrictMode>
       <PortfolioChartApp endpoint={endpoint} currency={currency} />
+    </StrictMode>
+  );
+}
+
+const alertsContainer = document.getElementById("alerts-manager");
+if (alertsContainer) {
+  const dataset = alertsContainer.dataset || {};
+  const endpoint = dataset.endpoint || "/alerts";
+  const token = dataset.authToken || "";
+  const initialAlerts =
+    (bootstrap && bootstrap.context && Array.isArray(bootstrap.context.alerts)
+      ? bootstrap.context.alerts
+      : []) || [];
+  const root = createRoot(alertsContainer);
+  root.render(
+    <StrictMode>
+      <AlertManager initialAlerts={initialAlerts} endpoint={endpoint} authToken={token} />
     </StrictMode>
   );
 }

--- a/services/web-dashboard/test/alerts/AlertManager.test.jsx
+++ b/services/web-dashboard/test/alerts/AlertManager.test.jsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { act } from "react";
+import userEvent from "@testing-library/user-event";
+import AlertManager from "../../src/alerts/AlertManager.jsx";
+
+function createFetchResponse(data, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    headers: { get: () => "application/json" },
+  });
+}
+
+async function renderAlerts(props) {
+  const user = userEvent.setup();
+  await act(async () => {
+    render(<AlertManager enableInitialFetch={false} {...props} />);
+    await Promise.resolve();
+  });
+  return user;
+}
+
+describe("AlertManager", () => {
+  const initialAlerts = [
+    {
+      id: "maint-margin",
+      title: "Maintenance margin nearing threshold",
+      detail: "Portfolio Growth is at 82% of the allowed maintenance margin.",
+      risk: "warning",
+      acknowledged: false,
+      created_at: "2024-04-01T10:00:00Z",
+    },
+  ];
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("affiche les alertes existantes et permet de basculer en mode édition", async () => {
+    const user = await renderAlerts({
+      initialAlerts,
+      endpoint: "/alerts",
+      authToken: "demo-token",
+    });
+
+    expect(await screen.findByText(/Maintenance margin nearing threshold/i)).toBeInTheDocument();
+
+    const editButton = screen.getByRole("button", { name: /modifier/i });
+    await user.click(editButton);
+
+    const titleInput = screen.getByLabelText(/Titre/i);
+    expect(titleInput).toHaveValue("Maintenance margin nearing threshold");
+
+  });
+
+  it("crée une nouvelle alerte via le moteur d'alertes", async () => {
+    const createdAlert = {
+      id: "drawdown",
+      title: "Daily drawdown limit exceeded",
+      detail: "Income portfolio dropped 6% over the last trading session.",
+      risk: "critical",
+      acknowledged: false,
+      created_at: "2024-04-02T09:15:00Z",
+    };
+
+    global.fetch = vi.fn().mockReturnValueOnce(createFetchResponse(createdAlert, 201));
+
+    const user = await renderAlerts({
+      initialAlerts,
+      endpoint: "/alerts",
+      authToken: "demo-token",
+    });
+
+    await user.clear(screen.getByLabelText(/Titre/i));
+    await user.type(screen.getByLabelText(/Titre/i), "Daily drawdown limit exceeded");
+    await user.clear(screen.getByLabelText(/Description/i));
+    await user.type(
+      screen.getByLabelText(/Description/i),
+      "Income portfolio dropped 6% over the last trading session."
+    );
+    await user.selectOptions(screen.getByLabelText(/Niveau de risque/i), "critical");
+
+    await user.click(screen.getByRole("button", { name: /créer/i }));
+
+    await waitFor(() => {
+      const lastCall = global.fetch.mock.calls.at(-1);
+      expect(lastCall[0]).toBe("/alerts");
+      expect(lastCall[1].method).toBe("POST");
+      expect(lastCall[1].headers.Authorization).toBe("Bearer demo-token");
+      expect(JSON.parse(lastCall[1].body).title).toBe("Daily drawdown limit exceeded");
+    });
+
+    expect(await screen.findByText(/Daily drawdown limit exceeded/i)).toBeInTheDocument();
+  });
+
+  it("affiche un message d'erreur lorsque la création échoue", async () => {
+    global.fetch = vi.fn().mockReturnValueOnce(
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ detail: "Erreur inattendue" }),
+        headers: { get: () => "application/json" },
+      })
+    );
+
+    const user = await renderAlerts({
+      initialAlerts,
+      endpoint: "/alerts",
+      authToken: "demo-token",
+    });
+
+    await user.clear(screen.getByLabelText(/Titre/i));
+    await user.type(screen.getByLabelText(/Titre/i), "Nouvelle alerte");
+    await user.clear(screen.getByLabelText(/Description/i));
+    await user.type(screen.getByLabelText(/Description/i), "Impossible de joindre le moteur.");
+    await user.click(screen.getByRole("button", { name: /créer/i }));
+
+    const errorMessage = await screen.findByRole("alert");
+    expect(errorMessage).toHaveTextContent(/erreur inattendue/i);
+  });
+
+  it("met à jour la liste à la réception d'un évènement temps réel", async () => {
+    await renderAlerts({
+      initialAlerts,
+      endpoint: "/alerts",
+      authToken: "demo-token",
+    });
+
+    const realtimeAlert = {
+      id: "news",
+      title: "Breaking news on AAPL",
+      detail: "Apple announces quarterly earnings call for next Tuesday.",
+      risk: "info",
+      acknowledged: true,
+      created_at: "2024-04-03T11:30:00Z",
+    };
+
+    await act(async () => {
+      document.dispatchEvent(
+        new CustomEvent("alerts:update", { detail: { items: [realtimeAlert], message: "Flux mis à jour" } })
+      );
+    });
+
+    expect(await screen.findByText(/Breaking news on AAPL/i)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/Flux mis à jour/i);
+  });
+});

--- a/services/web-dashboard/tests/test_alerts_api.py
+++ b/services/web-dashboard/tests/test_alerts_api.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+
+from .utils import load_dashboard_app
+
+
+@dataclass
+class DummyAlertsClient:
+    created: List[Dict[str, Any]] = field(default_factory=list)
+    updated: List[Tuple[str, Dict[str, Any]]] = field(default_factory=list)
+    deleted: List[str] = field(default_factory=list)
+
+    def create_alert(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self.created.append(dict(payload))
+        return {
+            "id": payload.get("id", "generated-alert"),
+            "title": payload["title"],
+            "detail": payload["detail"],
+            "risk": payload.get("risk", "info"),
+            "acknowledged": payload.get("acknowledged", False),
+            "created_at": payload.get("created_at", "2024-04-02T12:00:00Z"),
+        }
+
+    def update_alert(self, alert_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self.updated.append((alert_id, dict(payload)))
+        base = {
+            "id": alert_id,
+            "title": payload.get("title", "Existing alert"),
+            "detail": payload.get("detail", "Detail"),
+            "risk": payload.get("risk", "info"),
+            "acknowledged": payload.get("acknowledged", False),
+            "created_at": payload.get("created_at", "2024-04-02T12:00:00Z"),
+        }
+        return base
+
+    def delete_alert(self, alert_id: str) -> None:
+        self.deleted.append(alert_id)
+
+
+@pytest.fixture()
+def dashboard_module(monkeypatch):
+    """Expose the dashboard FastAPI module with clean dependency overrides."""
+
+    load_dashboard_app()
+    module = importlib.import_module("web_dashboard.app.main")
+    module.app.dependency_overrides.clear()
+    yield module
+    module.app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def auth_headers(monkeypatch):
+    monkeypatch.setenv("WEB_DASHBOARD_ALERTS_TOKEN", "secret-token")
+    return {"Authorization": "Bearer secret-token"}
+
+
+def test_create_alert_delegates_to_engine(dashboard_module, auth_headers):
+    dummy = DummyAlertsClient()
+    dashboard_module.app.dependency_overrides[dashboard_module.get_alerts_client] = lambda: dummy
+    client = TestClient(dashboard_module.app)
+
+    response = client.post(
+        "/alerts",
+        json={
+            "title": "Nouvelle alerte",
+            "detail": "Supervision de la marge",
+            "risk": "critical",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["title"] == "Nouvelle alerte"
+    assert payload["risk"] == "critical"
+    assert dummy.created and dummy.created[0]["title"] == "Nouvelle alerte"
+
+
+def test_update_alert_returns_payload_from_engine(dashboard_module, auth_headers):
+    dummy = DummyAlertsClient()
+    dashboard_module.app.dependency_overrides[dashboard_module.get_alerts_client] = lambda: dummy
+    client = TestClient(dashboard_module.app)
+
+    response = client.put(
+        "/alerts/alert-1",
+        json={"detail": "Mise à jour effectuée", "acknowledged": True},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == "alert-1"
+    assert payload["detail"] == "Mise à jour effectuée"
+    assert payload["acknowledged"] is True
+    assert dummy.updated == [("alert-1", {"detail": "Mise à jour effectuée", "acknowledged": True})]
+
+
+def test_delete_alert_requires_engine_call(dashboard_module, auth_headers):
+    dummy = DummyAlertsClient()
+    dashboard_module.app.dependency_overrides[dashboard_module.get_alerts_client] = lambda: dummy
+    client = TestClient(dashboard_module.app)
+
+    response = client.delete("/alerts/alert-2", headers=auth_headers)
+
+    assert response.status_code == 204
+    assert dummy.deleted == ["alert-2"]
+
+
+def test_alert_routes_require_auth_when_token_configured(dashboard_module, auth_headers):
+    dummy = DummyAlertsClient()
+    dashboard_module.app.dependency_overrides[dashboard_module.get_alerts_client] = lambda: dummy
+    client = TestClient(dashboard_module.app)
+
+    response = client.post(
+        "/alerts",
+        json={"title": "Non autorisé", "detail": "Test"},
+    )
+    assert response.status_code == 401
+
+    invalid = client.post(
+        "/alerts",
+        json={"title": "Mauvais jeton", "detail": "Test"},
+        headers={"Authorization": "Bearer autre-chose"},
+    )
+    assert invalid.status_code == 403


### PR DESCRIPTION
## Summary
- add a reusable FastAPI client and secure CRUD endpoints that proxy alert mutations to the alert engine
- embed a React-based alert manager in the dashboard template with supporting styles and event wiring
- cover the new UI and API with Vitest component suites and pytest CRUD tests

## Testing
- npm test -- --run
- pytest services/web-dashboard/tests/test_alerts_api.py

------
https://chatgpt.com/codex/tasks/task_e_68da3ea7761c83328557f260c73ab31f