### PR TITLE
Add streaming cache to alert engine and integrate dashboard alerts

### DIFF
--- a/services/alert_engine/app/cache.py
+++ b/services/alert_engine/app/cache.py
@@ -1,0 +1,110 @@
+"""Caching primitives used by the alert engine."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from time import monotonic
+from typing import Any
+
+from .clients import MarketDataClient, ReportsClient
+from .schemas import MarketEvent
+
+
+@dataclass(slots=True)
+class _CacheEntry:
+    data: dict[str, Any]
+    expires_at: float | None
+
+
+class ExpiringCache:
+    """Simple TTL cache that stores dictionaries keyed by symbol."""
+
+    def __init__(self, ttl_seconds: float | None = None) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._values: dict[str, _CacheEntry] = {}
+
+    def store(self, key: str, data: dict[str, Any]) -> None:
+        expires_at: float | None
+        if self._ttl_seconds is None:
+            expires_at = None
+        else:
+            expires_at = monotonic() + self._ttl_seconds
+        self._values[key] = _CacheEntry(data=data, expires_at=expires_at)
+
+    def get(self, key: str) -> dict[str, Any] | None:
+        entry = self._values.get(key)
+        if entry is None:
+            return None
+        if entry.expires_at is not None and entry.expires_at <= monotonic():
+            self._values.pop(key, None)
+            return None
+        return entry.data
+
+
+class AlertContextCache:
+    """Maintain latest contexts by combining streamed events and service lookups."""
+
+    def __init__(
+        self,
+        *,
+        market_client: MarketDataClient,
+        reports_client: ReportsClient,
+        market_ttl_seconds: float | None = 30.0,
+        event_ttl_seconds: float | None = 2.0,
+        reports_ttl_seconds: float | None = 60.0,
+    ) -> None:
+        self._market_client = market_client
+        self._reports_client = reports_client
+        self._market_cache = ExpiringCache(market_ttl_seconds)
+        self._event_cache = ExpiringCache(event_ttl_seconds)
+        self._reports_cache = ExpiringCache(reports_ttl_seconds)
+        self._lock = asyncio.Lock()
+
+    async def build_context_for_event(self, event: MarketEvent) -> dict[str, Any]:
+        """Merge the incoming event with cached contexts from downstream services."""
+
+        base = event.model_dump(exclude_none=True)
+        async with self._lock:
+            self._event_cache.store(event.symbol, base)
+            merged = await self._compose(event.symbol, base)
+        return merged
+
+    async def build_context_for_symbol(self, symbol: str) -> dict[str, Any]:
+        """Return a context for a symbol when no fresh event is available."""
+
+        async with self._lock:
+            merged = await self._compose(symbol, {"symbol": symbol})
+        return merged
+
+    async def _compose(self, symbol: str, base: dict[str, Any]) -> dict[str, Any]:
+        context = dict(base)
+        market_context = await self._market_context(symbol)
+        reports_context = await self._reports_context(symbol)
+        context.update(market_context)
+        context.update(reports_context)
+        return context
+
+    async def _market_context(self, symbol: str) -> dict[str, Any]:
+        snapshot = self._market_cache.get(symbol)
+        if snapshot is None:
+            snapshot = await self._market_client.fetch_context(symbol)
+            self._market_cache.store(symbol, snapshot)
+        event_override = self._event_cache.get(symbol) or {}
+        if not event_override:
+            return snapshot
+        merged = dict(snapshot)
+        merged.update(event_override)
+        return merged
+
+    async def _reports_context(self, symbol: str) -> dict[str, Any]:
+        cached = self._reports_cache.get(symbol)
+        if cached is not None:
+            return cached
+        fresh = await self._reports_client.fetch_context(symbol)
+        self._reports_cache.store(symbol, fresh)
+        return fresh
+
+
+__all__ = ["AlertContextCache"]
+

--- a/services/alert_engine/app/config.py
+++ b/services/alert_engine/app/config.py
@@ -10,16 +10,34 @@ class AlertEngineSettings:
 
     database_url: str = "sqlite:///./alert_engine.db"
     market_data_url: str = "http://market-data"
+    market_data_stream_url: str = "http://market-data"
     reports_url: str = "http://reports"
     notification_url: str = "http://notification-service"
     evaluation_interval_seconds: float = 15.0
+    market_snapshot_ttl_seconds: float = 30.0
+    market_event_ttl_seconds: float = 2.0
+    reports_ttl_seconds: float = 60.0
+    stream_symbols: tuple[str, ...] = ()
 
     @classmethod
     def from_env(cls) -> "AlertEngineSettings":
         defaults = cls()
+        symbols_env = os.getenv("ALERT_ENGINE_STREAM_SYMBOLS")
+        if symbols_env is None:
+            stream_symbols = defaults.stream_symbols
+        else:
+            stream_symbols = tuple(
+                symbol.strip()
+                for symbol in symbols_env.split(",")
+                if symbol.strip()
+            )
         return cls(
             database_url=os.getenv("ALERT_ENGINE_DATABASE_URL", defaults.database_url),
             market_data_url=os.getenv("ALERT_ENGINE_MARKET_DATA_URL", defaults.market_data_url),
+            market_data_stream_url=os.getenv(
+                "ALERT_ENGINE_MARKET_DATA_STREAM_URL",
+                defaults.market_data_stream_url,
+            ),
             reports_url=os.getenv("ALERT_ENGINE_REPORTS_URL", defaults.reports_url),
             notification_url=os.getenv("ALERT_ENGINE_NOTIFICATION_URL", defaults.notification_url),
             evaluation_interval_seconds=float(
@@ -28,4 +46,23 @@ class AlertEngineSettings:
                     defaults.evaluation_interval_seconds,
                 )
             ),
+            market_snapshot_ttl_seconds=float(
+                os.getenv(
+                    "ALERT_ENGINE_MARKET_SNAPSHOT_TTL_SECONDS",
+                    defaults.market_snapshot_ttl_seconds,
+                )
+            ),
+            market_event_ttl_seconds=float(
+                os.getenv(
+                    "ALERT_ENGINE_MARKET_EVENT_TTL_SECONDS",
+                    defaults.market_event_ttl_seconds,
+                )
+            ),
+            reports_ttl_seconds=float(
+                os.getenv(
+                    "ALERT_ENGINE_REPORTS_TTL_SECONDS",
+                    defaults.reports_ttl_seconds,
+                )
+            ),
+            stream_symbols=stream_symbols,
         )

--- a/services/alert_engine/app/main.py
+++ b/services/alert_engine/app/main.py
@@ -3,13 +3,25 @@ from __future__ import annotations
 from fastapi import Depends, FastAPI
 from sqlalchemy.orm import Session, sessionmaker
 
-from .clients import MarketDataClient, NotificationPublisher, ReportsClient
+from .cache import AlertContextCache
+from .clients import (
+    MarketDataClient,
+    MarketDataStreamClient,
+    NotificationPublisher,
+    ReportsClient,
+)
 from .config import AlertEngineSettings
 from .database import create_session_factory, get_session
 from .engine import AlertEngine
 from .evaluator import RuleEvaluator
 from .repository import AlertRuleRepository
-from .schemas import AlertEvaluationResponse, AlertTriggerRead, MarketEvent
+from .schemas import (
+    AlertEvaluationResponse,
+    AlertRuleSummary,
+    AlertTriggerRead,
+    MarketEvent,
+)
+from .streaming import StreamProcessor
 
 
 def create_app(
@@ -17,6 +29,9 @@ def create_app(
     session_factory: sessionmaker[Session] | None = None,
     market_client: MarketDataClient | None = None,
     reports_client: ReportsClient | None = None,
+    stream_client: MarketDataStreamClient | None = None,
+    context_cache: AlertContextCache | None = None,
+    stream_processor: StreamProcessor | None = None,
     publisher: NotificationPublisher | None = None,
     start_background_tasks: bool = True,
 ) -> FastAPI:
@@ -24,6 +39,14 @@ def create_app(
     session_factory = session_factory or create_session_factory(settings)
     market_client = market_client or MarketDataClient(settings.market_data_url)
     reports_client = reports_client or ReportsClient(settings.reports_url)
+    context_cache = context_cache or AlertContextCache(
+        market_client=market_client,
+        reports_client=reports_client,
+        market_ttl_seconds=settings.market_snapshot_ttl_seconds,
+        event_ttl_seconds=settings.market_event_ttl_seconds,
+        reports_ttl_seconds=settings.reports_ttl_seconds,
+    )
+    stream_client = stream_client or MarketDataStreamClient(settings.market_data_stream_url)
     publisher = publisher or NotificationPublisher(settings.notification_url)
 
     repository = AlertRuleRepository()
@@ -31,25 +54,34 @@ def create_app(
     engine = AlertEngine(
         repository=repository,
         evaluator=evaluator,
-        market_client=market_client,
-        reports_client=reports_client,
+        context_cache=context_cache,
         publisher=publisher,
         evaluation_interval=settings.evaluation_interval_seconds,
+    )
+    stream_processor = stream_processor or StreamProcessor(
+        stream_client=stream_client,
+        engine=engine,
+        session_factory=session_factory,
     )
 
     app = FastAPI(title="Alert Engine")
     app.state.session_factory = session_factory
     app.state.alert_engine = engine
-    app.state.clients = [market_client, reports_client, publisher]
+    app.state.context_cache = context_cache
+    app.state.stream_processor = stream_processor
+    app.state.clients = [market_client, reports_client, stream_client, publisher]
 
     if start_background_tasks:
         @app.on_event("startup")
         async def _startup() -> None:  # pragma: no cover - FastAPI wiring
             await engine.start_periodic_evaluation(session_factory)
+            if settings.stream_symbols:
+                await stream_processor.start(list(settings.stream_symbols))
 
         @app.on_event("shutdown")
         async def _shutdown() -> None:  # pragma: no cover - FastAPI wiring
             await engine.stop()
+            await stream_processor.stop()
             for client in app.state.clients:
                 await client.aclose()
 
@@ -58,6 +90,9 @@ def create_app(
 
     def get_session_dep() -> Session:
         yield from get_session(app.state.session_factory)
+
+    def get_repository() -> AlertRuleRepository:
+        return repository
 
     @app.post("/events", response_model=AlertEvaluationResponse)
     async def receive_event(
@@ -70,6 +105,32 @@ def create_app(
             triggered=bool(triggers),
             triggers=[AlertTriggerRead.model_validate(t) for t in triggers],
         )
+
+    @app.get("/alerts", response_model=list[AlertRuleSummary])
+    async def list_recent_alerts(
+        limit: int = 20,
+        session: Session = Depends(get_session_dep),
+        repository: AlertRuleRepository = Depends(get_repository),
+    ) -> list[AlertRuleSummary]:
+        limit = max(1, min(limit, 100))
+        triggers = await repository.list_recent_triggers(session, limit=limit)
+        summaries: list[AlertRuleSummary] = []
+        for trigger in triggers:
+            if trigger.rule is None:
+                continue
+            summaries.append(
+                AlertRuleSummary(
+                    trigger_id=trigger.id,
+                    rule_id=trigger.rule_id,
+                    name=trigger.rule.name,
+                    symbol=trigger.rule.symbol,
+                    severity=trigger.rule.severity,
+                    expression=trigger.rule.expression,
+                    triggered_at=trigger.triggered_at,
+                    context=trigger.context,
+                )
+            )
+        return summaries
 
     return app
 

--- a/services/alert_engine/app/schemas.py
+++ b/services/alert_engine/app/schemas.py
@@ -24,6 +24,19 @@ class AlertTriggerRead(BaseModel):
     context: dict[str, Any] | None
 
 
+class AlertRuleSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    trigger_id: int = Field(..., description="Identifier of the trigger event")
+    rule_id: int = Field(..., description="Identifier of the originating rule")
+    name: str = Field(..., description="Rule display name")
+    symbol: str = Field(..., description="Instrument evaluated by the rule")
+    severity: str = Field(..., description="Severity declared on the rule")
+    expression: str = Field(..., description="Expression evaluated to generate the trigger")
+    triggered_at: datetime
+    context: dict[str, Any] | None = None
+
+
 class AlertEvaluationResponse(BaseModel):
     triggered: bool
     triggers: list[AlertTriggerRead] = Field(default_factory=list)

--- a/services/alert_engine/app/streaming.py
+++ b/services/alert_engine/app/streaming.py
@@ -1,0 +1,86 @@
+"""Streaming utilities for the alert engine."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from .clients import MarketDataStreamClient
+from .engine import AlertEngine
+from .schemas import MarketEvent
+
+
+logger = logging.getLogger(__name__)
+
+
+class StreamProcessor:
+    """Consume market data streams and push events into the alert engine."""
+
+    def __init__(
+        self,
+        stream_client: MarketDataStreamClient,
+        engine: AlertEngine,
+        session_factory: sessionmaker[Session],
+    ) -> None:
+        self._stream_client = stream_client
+        self._engine = engine
+        self._session_factory = session_factory
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._stop_event = asyncio.Event()
+
+    async def start(self, symbols: list[str] | tuple[str, ...]) -> None:
+        if self._tasks:
+            return
+        self._stop_event.clear()
+        for symbol in symbols:
+            task = asyncio.create_task(self._consume(symbol))
+            self._tasks[symbol] = task
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        for task in list(self._tasks.values()):
+            task.cancel()
+        for symbol, task in list(self._tasks.items()):
+            try:
+                await task
+            except asyncio.CancelledError:  # pragma: no cover - expected on shutdown
+                logger.debug("Stream task for %s cancelled", symbol)
+            except Exception:  # noqa: BLE001
+                logger.exception("Stream task for %s terminated with error", symbol)
+        self._tasks.clear()
+
+    async def _consume(self, symbol: str) -> None:
+        try:
+            async for payload in self._stream_client.subscribe(symbol):
+                if self._stop_event.is_set():
+                    break
+                await self._handle_payload(symbol, payload)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+            raise
+        except Exception:  # noqa: BLE001
+            logger.exception("Market data stream consumption failed for %s", symbol)
+
+    async def _handle_payload(self, symbol: str, payload: dict[str, Any]) -> None:
+        try:
+            event = MarketEvent.model_validate({"symbol": symbol, **payload})
+        except Exception:  # noqa: BLE001
+            logger.debug("Dropping malformed payload for %s: %s", symbol, payload, exc_info=True)
+            return
+        async with self._session_context() as session:
+            await self._engine.handle_event(session, event)
+
+    @asynccontextmanager
+    async def _session_context(self):
+        session = self._session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+
+__all__ = ["StreamProcessor"]
+

--- a/services/alert_engine/tests/test_stream_integration.py
+++ b/services/alert_engine/tests/test_stream_integration.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+from sqlalchemy import create_engine
+import sqlalchemy
+from sqlalchemy.orm import Session, sessionmaker
+
+from services.alert_engine.app.cache import AlertContextCache
+from services.alert_engine.app.clients import MarketDataStreamClient
+from services.alert_engine.app.database import Base
+from services.alert_engine.app.engine import AlertEngine
+from services.alert_engine.app.evaluator import RuleEvaluator
+from services.alert_engine.app.models import AlertRule
+from services.alert_engine.app.repository import AlertRuleRepository
+from services.alert_engine.app.streaming import StreamProcessor
+from services.alert_engine.tests.test_alert_engine import (  # noqa: TID252
+    DummyPublisher,
+    FakeMarketDataClient,
+    FakeReportsClient,
+)
+
+
+class InMemoryStreamClient(MarketDataStreamClient):
+    def __init__(self) -> None:
+        self._own_client = False
+        self._client = None
+        self._queues: dict[str, asyncio.Queue[dict[str, float]]] = {}
+
+    async def subscribe(self, symbol: str) -> AsyncIterator[dict[str, float]]:  # type: ignore[override]
+        queue = self._queues.setdefault(symbol, asyncio.Queue())
+        while True:
+            payload = await queue.get()
+            yield payload
+
+    async def publish(self, symbol: str, payload: dict[str, float]) -> None:
+        queue = self._queues.setdefault(symbol, asyncio.Queue())
+        await queue.put(payload)
+
+    async def aclose(self) -> None:  # pragma: no cover - interface requirement
+        for queue in self._queues.values():
+            while not queue.empty():
+                queue.get_nowait()
+        self._queues.clear()
+
+
+@pytest.fixture()
+def stream_session_factory() -> Iterator[sessionmaker[Session]]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+    yield factory
+    engine.dispose()
+
+
+def test_stream_processing_triggers_alert(stream_session_factory: sessionmaker[Session]) -> None:
+    market_client = FakeMarketDataClient({"moving_average": 100.0})
+    reports_client = FakeReportsClient({"daily_volume": 4000})
+    context_cache = AlertContextCache(
+        market_client=market_client,
+        reports_client=reports_client,
+        market_ttl_seconds=60.0,
+        event_ttl_seconds=10.0,
+        reports_ttl_seconds=300.0,
+    )
+    publisher = DummyPublisher()
+    repository = AlertRuleRepository()
+    evaluator = RuleEvaluator()
+    engine = AlertEngine(
+        repository=repository,
+        evaluator=evaluator,
+        context_cache=context_cache,
+        publisher=publisher,
+        evaluation_interval=0.1,
+    )
+
+    stream_client = InMemoryStreamClient()
+    processor = StreamProcessor(stream_client=stream_client, engine=engine, session_factory=stream_session_factory)
+
+    rule = AlertRule(name="Spike", symbol="BTC", expression="price > moving_average")
+
+    session = stream_session_factory()
+    try:
+        asyncio.run(repository.add_rule(session, rule))
+    finally:
+        session.close()
+
+    async def _run() -> None:
+        await processor.start(["BTC"])
+        await stream_client.publish("BTC", {"price": 125.0, "volume": 5.0})
+        await asyncio.sleep(0.2)
+        await processor.stop()
+
+    asyncio.run(_run())
+
+    assert publisher.published_payloads, "Stream processor should publish an alert payload"
+
+    session = stream_session_factory()
+    try:
+        triggers = asyncio.run(repository.list_recent_triggers(session, limit=1))
+    finally:
+        session.close()
+    assert triggers and triggers[0].rule_id == rule.id


### PR DESCRIPTION
## Summary
- add an alert context cache and market data stream client/processor so the engine can evaluate rules directly from streaming updates while reusing aggregated metrics
- expose a `/alerts` API backed by repository helpers and extend settings/tests to cover streaming scenarios, including a new integration test
- update the web dashboard data loader to consume real alerts from the alert engine with graceful fallbacks

## Testing
- pytest services/alert_engine/tests -vv -s

------
https://chatgpt.com/codex/tasks/task_e_68da4984b78c8332996944492977d963