### PR TITLE
Add alert history storage and dashboard views

### DIFF
--- a/libs/alert_events/__init__.py
+++ b/libs/alert_events/__init__.py
@@ -1,0 +1,11 @@
+"""Shared storage primitives for persisting alert trigger events."""
+
+from .models import AlertEvent, AlertEventBase
+from .repository import AlertEventRepository, AlertHistoryPage
+
+__all__ = [
+    "AlertEvent",
+    "AlertEventBase",
+    "AlertEventRepository",
+    "AlertHistoryPage",
+]

--- a/libs/alert_events/models.py
+++ b/libs/alert_events/models.py
@@ -1,0 +1,44 @@
+"""SQLAlchemy models describing persisted alert trigger events."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import JSON, Column, DateTime, Integer, String
+from sqlalchemy.orm import declarative_base
+
+AlertEventBase = declarative_base()
+
+
+class AlertEvent(AlertEventBase):
+    """Historical record capturing a trigger handled by the alerting stack."""
+
+    __tablename__ = "alert_events"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    trigger_id: int = Column(Integer, nullable=False, index=True)
+    rule_id: int = Column(Integer, nullable=False, index=True)
+    rule_name: str = Column(String(255), nullable=False)
+    strategy: str = Column(String(128), nullable=False)
+    severity: str = Column(String(32), nullable=False, index=True)
+    symbol: str = Column(String(32), nullable=False, index=True)
+    triggered_at: datetime = Column(DateTime, nullable=False, index=True)
+    created_at: datetime = Column(DateTime, nullable=False, default=datetime.utcnow, index=True)
+    context: dict | None = Column(JSON, nullable=True)
+
+    source: str = Column(String(64), nullable=False, default="alert-engine", index=True)
+    delivery_status: str = Column(String(32), nullable=False, default="pending", index=True)
+    delivery_detail: str | None = Column(String(255), nullable=True)
+
+    notification_id: int | None = Column(Integer, nullable=True)
+    notification_channel: str | None = Column(String(32), nullable=True, index=True)
+    notification_target: str | None = Column(String(255), nullable=True)
+
+    def mark_delivered(self, status: str, detail: str | None = None) -> None:
+        """Update delivery information for the event."""
+
+        self.delivery_status = status
+        self.delivery_detail = detail
+
+
+__all__ = ["AlertEvent", "AlertEventBase"]

--- a/libs/alert_events/repository.py
+++ b/libs/alert_events/repository.py
@@ -1,0 +1,168 @@
+"""Persistence helpers for alert history records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Sequence
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from .models import AlertEvent
+
+
+@dataclass(slots=True)
+class AlertHistoryPage:
+    """Container returned when paginating alert events."""
+
+    items: Sequence[AlertEvent]
+    total: int
+    page: int
+    page_size: int
+
+    @property
+    def pages(self) -> int:
+        if self.page_size <= 0:
+            return 0
+        return (self.total + self.page_size - 1) // self.page_size
+
+
+class AlertEventRepository:
+    """Repository exposing CRUD operations for alert events."""
+
+    def __init__(self, *, default_page_size: int = 20, max_page_size: int = 100) -> None:
+        self._default_page_size = default_page_size
+        self._max_page_size = max_page_size
+
+    def record_event(
+        self,
+        session: Session,
+        *,
+        trigger_id: int,
+        rule_id: int,
+        rule_name: str,
+        strategy: str,
+        severity: str,
+        symbol: str,
+        triggered_at: datetime,
+        context: dict | None,
+        source: str = "alert-engine",
+        delivery_status: str = "pending",
+        notification_id: int | None = None,
+        notification_channel: str | None = None,
+        notification_target: str | None = None,
+    ) -> AlertEvent:
+        """Persist an alert event and return the SQLAlchemy instance."""
+
+        event = AlertEvent(
+            trigger_id=trigger_id,
+            rule_id=rule_id,
+            rule_name=rule_name,
+            strategy=strategy,
+            severity=severity,
+            symbol=symbol,
+            triggered_at=triggered_at,
+            context=context,
+            source=source,
+            delivery_status=delivery_status,
+            notification_id=notification_id,
+            notification_channel=notification_channel,
+            notification_target=notification_target,
+        )
+        session.add(event)
+        session.commit()
+        session.refresh(event)
+        return event
+
+    def update_delivery(
+        self,
+        session: Session,
+        event: AlertEvent,
+        *,
+        status: str,
+        detail: str | None = None,
+    ) -> AlertEvent:
+        """Persist delivery information updates on an existing event."""
+
+        event.mark_delivered(status, detail)
+        session.add(event)
+        session.commit()
+        session.refresh(event)
+        return event
+
+    def get_by_id(self, session: Session, event_id: int) -> AlertEvent | None:
+        """Return a single event by its identifier when present."""
+
+        return session.get(AlertEvent, event_id)
+
+    def _apply_filters(
+        self,
+        stmt: Select[tuple[AlertEvent]],
+        *,
+        start: datetime | None,
+        end: datetime | None,
+        strategy: str | None,
+        severity: str | None,
+    ) -> Select[tuple[AlertEvent]]:
+        if start is not None:
+            stmt = stmt.where(AlertEvent.triggered_at >= start)
+        if end is not None:
+            stmt = stmt.where(AlertEvent.triggered_at <= end)
+        if strategy:
+            stmt = stmt.where(AlertEvent.strategy == strategy)
+        if severity:
+            stmt = stmt.where(AlertEvent.severity == severity)
+        return stmt
+
+    def list_events(
+        self,
+        session: Session,
+        *,
+        page: int = 1,
+        page_size: int | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        strategy: str | None = None,
+        severity: str | None = None,
+    ) -> AlertHistoryPage:
+        """Return a paginated list of alert events matching optional filters."""
+
+        if page < 1:
+            page = 1
+        if page_size is None:
+            page_size = self._default_page_size
+        page_size = max(1, min(page_size, self._max_page_size))
+
+        stmt = select(AlertEvent).order_by(AlertEvent.triggered_at.desc())
+        stmt = self._apply_filters(
+            stmt,
+            start=start,
+            end=end,
+            strategy=strategy,
+            severity=severity,
+        )
+
+        total_stmt = select(func.count()).select_from(stmt.subquery())
+        total = session.execute(total_stmt).scalar_one()
+
+        offset = (page - 1) * page_size
+        items = (
+            session.execute(stmt.limit(page_size).offset(offset)).scalars().all()
+        )
+        return AlertHistoryPage(items=items, total=total, page=page, page_size=page_size)
+
+    def list_strategies(self, session: Session) -> list[str]:
+        """Return the distinct set of strategies stored in the history."""
+
+        stmt = select(AlertEvent.strategy).distinct().order_by(AlertEvent.strategy)
+        return [row[0] for row in session.execute(stmt).all() if row[0]]
+
+    def list_severities(self, session: Session) -> list[str]:
+        """Return the distinct severities stored in the history."""
+
+        stmt = select(AlertEvent.severity).distinct().order_by(AlertEvent.severity)
+        return [row[0] for row in session.execute(stmt).all() if row[0]]
+
+
+__all__ = ["AlertEventRepository", "AlertHistoryPage"]

--- a/services/alert_engine/app/config.py
+++ b/services/alert_engine/app/config.py
@@ -9,6 +9,7 @@ class AlertEngineSettings:
     """Application settings for the alert engine service."""
 
     database_url: str = "sqlite:///./alert_engine.db"
+    events_database_url: str = "sqlite:///./alert_events.db"
     market_data_url: str = "http://market-data"
     market_data_stream_url: str = "http://market-data"
     reports_url: str = "http://reports"
@@ -33,6 +34,10 @@ class AlertEngineSettings:
             )
         return cls(
             database_url=os.getenv("ALERT_ENGINE_DATABASE_URL", defaults.database_url),
+            events_database_url=os.getenv(
+                "ALERT_ENGINE_EVENTS_DATABASE_URL",
+                os.getenv("ALERT_EVENTS_DATABASE_URL", defaults.events_database_url),
+            ),
             market_data_url=os.getenv("ALERT_ENGINE_MARKET_DATA_URL", defaults.market_data_url),
             market_data_stream_url=os.getenv(
                 "ALERT_ENGINE_MARKET_DATA_STREAM_URL",

--- a/services/alert_engine/app/event_recorder.py
+++ b/services/alert_engine/app/event_recorder.py
@@ -1,0 +1,75 @@
+"""Bridge between alert engine triggers and the shared alert event store."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Callable, Protocol
+
+from sqlalchemy.orm import Session
+
+from libs.alert_events import AlertEventRepository
+from libs.db.db import SessionLocal
+
+from .models import AlertTrigger
+
+
+class SessionFactory(Protocol):
+    def __call__(self) -> AbstractContextManager[Session]:  # pragma: no cover - typing hook
+        ...
+
+
+@dataclass(slots=True)
+class AlertEventRecorder:
+    """Persist triggers in the shared alert history store."""
+
+    repository: AlertEventRepository
+    session_factory: Callable[[], Session]
+
+    def __post_init__(self) -> None:
+        session = self.session_factory()
+        try:
+            engine = session.get_bind()
+            if engine is not None:
+                from libs.alert_events import AlertEventBase
+
+                AlertEventBase.metadata.create_all(bind=engine)
+        finally:
+            session.close()
+
+    @classmethod
+    def from_defaults(cls) -> "AlertEventRecorder":
+        return cls(repository=AlertEventRepository(), session_factory=SessionLocal)
+
+    async def record(
+        self, trigger: AlertTrigger, *, source: str = "alert-engine"
+    ) -> "AlertEvent":
+        """Persist a trigger asynchronously to avoid blocking the event loop."""
+
+        def _persist():
+            session = self.session_factory()
+            try:
+                rule = trigger.rule
+                strategy = (rule.name if rule else "unknown").strip() or "unknown"
+                severity = rule.severity if rule else "info"
+                symbol = rule.symbol if rule else "UNKNOWN"
+                return self.repository.record_event(
+                    session,
+                    trigger_id=trigger.id,
+                    rule_id=trigger.rule_id,
+                    rule_name=rule.name if rule else "unknown",
+                    strategy=strategy,
+                    severity=severity,
+                    symbol=symbol,
+                    triggered_at=trigger.triggered_at,
+                    context=trigger.context or {},
+                    source=source,
+                )
+            finally:
+                session.close()
+
+        return await asyncio.to_thread(_persist)
+
+
+__all__ = ["AlertEventRecorder"]

--- a/services/notification-service/app/schemas.py
+++ b/services/notification-service/app/schemas.py
@@ -75,3 +75,24 @@ class NotificationResponse(BaseModel):
     detail: str
     target: str
 
+
+class AlertTriggerNotification(BaseModel):
+    """Payload received from the alert engine when a rule fires."""
+
+    event_id: int | None = Field(default=None, description="Identifier generated for the stored event")
+    trigger_id: int = Field(..., description="Primary key of the trigger in the alert engine store")
+    rule_id: int = Field(..., description="Identifier of the rule that fired")
+    rule_name: str = Field(..., description="Name of the alerting rule")
+    strategy: str = Field(..., description="Strategy or grouping the rule belongs to")
+    severity: str = Field(..., description="info|warning|critical severity level")
+    symbol: str = Field(..., description="Market symbol used when evaluating the rule")
+    triggered_at: datetime = Field(..., description="Timestamp when the rule fired")
+    context: Dict[str, object] = Field(default_factory=dict, description="Captured evaluation context")
+    notification_channel: str | None = Field(
+        default=None, description="Optional downstream channel suggested for delivery"
+    )
+    notification_target: str | None = Field(
+        default=None,
+        description="Optional destination identifier (email, webhook…) to pre-fill history",
+    )
+

--- a/services/notification-service/tests/test_alert_events_endpoint.py
+++ b/services/notification-service/tests/test_alert_events_endpoint.py
@@ -1,0 +1,68 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+if str(SERVICE_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVICE_DIR))
+
+
+@pytest.fixture()
+def notification_app(monkeypatch, tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'alerts_history.db'}"
+    monkeypatch.setenv("NOTIFICATION_SERVICE_EVENTS_DATABASE_URL", db_url)
+    monkeypatch.delenv("ALERT_EVENTS_DATABASE_URL", raising=False)
+
+    module = importlib.import_module("app.main")
+    module = importlib.reload(module)
+    yield module.app, module
+
+
+def test_register_alert_event_creates_and_updates(notification_app):
+    app, module = notification_app
+    client = TestClient(app)
+
+    payload = {
+        "event_id": None,
+        "trigger_id": 42,
+        "rule_id": 7,
+        "rule_name": "Momentum breakout",
+        "strategy": "Momentum",
+        "severity": "critical",
+        "symbol": "BTC",
+        "triggered_at": "2024-04-02T12:00:00Z",
+        "context": {"price": 42000},
+    }
+
+    response = client.post("/notifications/alerts", json=payload)
+    assert response.status_code == 202
+    first_event = response.json()
+    assert first_event["status"] == "recorded"
+    assert first_event["event_id"]
+
+    update_payload = {
+        **payload,
+        "event_id": first_event["event_id"],
+        "severity": "warning",
+        "notification_channel": "email",
+        "notification_target": "ops@example.com",
+    }
+
+    response = client.post("/notifications/alerts", json=update_payload)
+    assert response.status_code == 202
+    updated = response.json()
+    assert updated["event_id"] == first_event["event_id"]
+
+    session = module.EventsSessionLocal()
+    try:
+        event = module._alert_events_repository.get_by_id(session, updated["event_id"])
+        assert event is not None
+        assert event.severity == "warning"
+        assert event.notification_channel == "email"
+        assert event.notification_target == "ops@example.com"
+        assert event.delivery_status == "received"
+    finally:
+        session.close()

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -328,6 +328,65 @@ body {
   color: var(--color-text);
 }
 
+.text--critical {
+  color: var(--color-critical);
+}
+
+.history-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.history-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.history-panel__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: flex-end;
+}
+
+.history-panel__footer {
+  display: flex;
+  gap: var(--space-md);
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.table-responsive {
+  overflow-x: auto;
+}
+
+.history-table td[data-label]::before {
+  font-weight: 600;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  min-width: 160px;
+}
+
+.form-field select {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.75rem;
+  color: var(--color-text);
+}
+
+.form-field select:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.5);
+  outline-offset: 2px;
+}
+
 .alerts-manager {
   display: flex;
   flex-direction: column;

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -382,6 +382,20 @@
           </div>
         </div>
       </section>
+
+      <section class="card" aria-labelledby="alerts-history-title">
+        <div class="card__header">
+          <h2 id="alerts-history-title" class="heading heading--lg">Historique</h2>
+          <p class="text text--muted">Déclenchements archivés par le moteur d'alertes.</p>
+        </div>
+        <div class="card__body">
+          <div
+            id="alerts-history"
+            data-endpoint="{{ alerts_api.history_endpoint }}"
+            aria-live="polite"
+          ></div>
+        </div>
+      </section>
     </main>
     <footer class="layout__footer">
       <p class="text text--muted">Données d'exemple pour la démonstration du service.</p>

--- a/services/web-dashboard/src/alerts/AlertHistory.jsx
+++ b/services/web-dashboard/src/alerts/AlertHistory.jsx
@@ -1,0 +1,216 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+function formatDate(value) {
+  if (!value) {
+    return "";
+  }
+  try {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat("fr-FR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  } catch (error) {
+    return String(value);
+  }
+}
+
+function AlertHistory({ endpoint = "/alerts/history" }) {
+  const [status, setStatus] = useState("idle");
+  const [items, setItems] = useState([]);
+  const [pagination, setPagination] = useState({ page: 1, pages: 1, total: 0, page_size: 10 });
+  const [filters, setFilters] = useState({ strategy: "", severity: "" });
+  const [availableFilters, setAvailableFilters] = useState({ strategies: [], severities: [] });
+
+  const queryParams = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set("page", pagination.page);
+    params.set("page_size", pagination.page_size || 10);
+    if (filters.strategy) {
+      params.set("strategy", filters.strategy);
+    }
+    if (filters.severity) {
+      params.set("severity", filters.severity);
+    }
+    return params.toString();
+  }, [pagination.page, pagination.page_size, filters.strategy, filters.severity]);
+
+  useEffect(() => {
+    async function loadHistory() {
+      setStatus("loading");
+      try {
+        const url = `${endpoint}?${queryParams}`;
+        const response = await fetch(url, {
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json();
+        setItems(Array.isArray(payload.items) ? payload.items : []);
+        const paginationPayload = payload.pagination || {};
+        setPagination((current) => ({
+          page: paginationPayload.page || current.page,
+          pages: paginationPayload.pages || paginationPayload.total_pages || 1,
+          total: paginationPayload.total ?? current.total,
+          page_size: paginationPayload.page_size || current.page_size,
+        }));
+        if (payload.available_filters) {
+          setAvailableFilters({
+            strategies: payload.available_filters.strategies || [],
+            severities: payload.available_filters.severities || [],
+          });
+        }
+        setStatus("ready");
+      } catch (fetchError) {
+        setStatus("error");
+      }
+    }
+
+    loadHistory();
+  }, [endpoint, queryParams]);
+
+  const canPrevious = pagination.page > 1;
+  const canNext = pagination.page < (pagination.pages || 1);
+
+  function handleSeverityChange(event) {
+    setFilters((current) => ({ ...current, severity: event.target.value }));
+    setPagination((current) => ({ ...current, page: 1 }));
+  }
+
+  function handleStrategyChange(event) {
+    setFilters((current) => ({ ...current, strategy: event.target.value }));
+    setPagination((current) => ({ ...current, page: 1 }));
+  }
+
+  function handlePageSizeChange(event) {
+    const size = Number.parseInt(event.target.value, 10) || 10;
+    setPagination((current) => ({ ...current, page_size: size, page: 1 }));
+  }
+
+  function goToPreviousPage() {
+    if (!canPrevious) {
+      return;
+    }
+    setPagination((current) => ({ ...current, page: Math.max(1, current.page - 1) }));
+  }
+
+  function goToNextPage() {
+    if (!canNext) {
+      return;
+    }
+    setPagination((current) => ({ ...current, page: current.page + 1 }));
+  }
+
+  return (
+    <section className="history-panel" aria-live="polite">
+      <header className="history-panel__header">
+        <h2 className="heading heading--lg">Historique des alertes</h2>
+        <p className="text text--muted">Consultez les déclenchements passés et leurs métadonnées.</p>
+      </header>
+      <div className="history-panel__filters">
+        <label className="form-field">
+          <span className="form-field__label">Sévérité</span>
+          <select value={filters.severity} onChange={handleSeverityChange}>
+            <option value="">Toutes</option>
+            {availableFilters.severities.map((severity) => (
+              <option key={severity} value={severity}>
+                {severity}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="form-field">
+          <span className="form-field__label">Stratégie</span>
+          <select value={filters.strategy} onChange={handleStrategyChange}>
+            <option value="">Toutes</option>
+            {availableFilters.strategies.map((strategy) => (
+              <option key={strategy} value={strategy}>
+                {strategy}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="form-field">
+          <span className="form-field__label">Entrées par page</span>
+          <select value={pagination.page_size} onChange={handlePageSizeChange}>
+            {[5, 10, 20, 50].map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {status === "loading" && (
+        <p className="text" role="status">
+          Chargement de l'historique…
+        </p>
+      )}
+      {status === "error" && (
+        <p className="text text--critical" role="alert">
+          Impossible de récupérer l'historique pour le moment.
+        </p>
+      )}
+      {status === "ready" && items.length === 0 && (
+        <p className="text text--muted">Aucun déclenchement enregistré pour ces filtres.</p>
+      )}
+      {items.length > 0 && (
+        <div className="table-responsive">
+          <table className="table history-table" role="grid">
+            <thead>
+              <tr>
+                <th scope="col">Déclenchée le</th>
+                <th scope="col">Règle</th>
+                <th scope="col">Stratégie</th>
+                <th scope="col">Sévérité</th>
+                <th scope="col">Symbole</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((event) => (
+                <tr key={event.id || `${event.trigger_id}-${event.rule_id}`}> 
+                  <td data-label="Déclenchée le">{formatDate(event.triggered_at)}</td>
+                  <td data-label="Règle">{event.rule_name}</td>
+                  <td data-label="Stratégie">{event.strategy}</td>
+                  <td data-label="Sévérité">
+                    <span className={`badge badge--${event.severity || "info"}`}>
+                      {event.severity}
+                    </span>
+                  </td>
+                  <td data-label="Symbole">{event.symbol}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <footer className="history-panel__footer">
+        <button
+          type="button"
+          className="button button--ghost"
+          onClick={goToPreviousPage}
+          disabled={!canPrevious}
+        >
+          Précédent
+        </button>
+        <span className="text text--muted">
+          Page {pagination.page} sur {pagination.pages || 1} ({pagination.total} alertes)
+        </span>
+        <button
+          type="button"
+          className="button button--ghost"
+          onClick={goToNextPage}
+          disabled={!canNext}
+        >
+          Suivant
+        </button>
+      </footer>
+    </section>
+  );
+}
+
+export default AlertHistory;

--- a/services/web-dashboard/src/main.jsx
+++ b/services/web-dashboard/src/main.jsx
@@ -2,6 +2,7 @@ import React, { StrictMode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import PortfolioChart from "./components/PortfolioChart.jsx";
 import AlertManager from "./alerts/AlertManager.jsx";
+import AlertHistory from "./alerts/AlertHistory.jsx";
 
 function loadBootstrapData() {
   const bootstrapNode = document.getElementById("dashboard-bootstrap");
@@ -102,6 +103,18 @@ if (alertsContainer) {
   root.render(
     <StrictMode>
       <AlertManager initialAlerts={initialAlerts} endpoint={endpoint} authToken={token} />
+    </StrictMode>
+  );
+}
+
+const historyContainer = document.getElementById("alerts-history");
+if (historyContainer) {
+  const dataset = historyContainer.dataset || {};
+  const endpoint = dataset.endpoint || "/alerts/history";
+  const root = createRoot(historyContainer);
+  root.render(
+    <StrictMode>
+      <AlertHistory endpoint={endpoint} />
     </StrictMode>
   );
 }

--- a/services/web-dashboard/test/alerts/AlertHistory.test.jsx
+++ b/services/web-dashboard/test/alerts/AlertHistory.test.jsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AlertHistory from "../../src/alerts/AlertHistory.jsx";
+
+function createFetchResponse(data, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe("AlertHistory", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("affiche les entrées d'historique et gère la pagination", async () => {
+    const firstPage = {
+      items: [
+        {
+          id: 1,
+          rule_name: "Breakout BTC",
+          strategy: "Momentum",
+          severity: "critical",
+          symbol: "BTC",
+          triggered_at: "2024-04-10T10:00:00Z",
+        },
+        {
+          id: 2,
+          rule_name: "Reversal ETH",
+          strategy: "Mean Reversion",
+          severity: "warning",
+          symbol: "ETH",
+          triggered_at: "2024-04-10T09:00:00Z",
+        },
+      ],
+      pagination: { page: 1, page_size: 10, total: 3, pages: 2 },
+      available_filters: { strategies: ["Momentum", "Mean Reversion"], severities: ["critical", "warning"] },
+    };
+    const secondPage = {
+      items: [
+        {
+          id: 3,
+          rule_name: "Liquidity alert",
+          strategy: "Momentum",
+          severity: "critical",
+          symbol: "BTC",
+          triggered_at: "2024-04-09T15:00:00Z",
+        },
+      ],
+      pagination: { page: 2, page_size: 10, total: 3, pages: 2 },
+      available_filters: { strategies: ["Momentum", "Mean Reversion"], severities: ["critical", "warning"] },
+    };
+
+    global.fetch.mockResolvedValueOnce(createFetchResponse(firstPage));
+    global.fetch.mockResolvedValueOnce(createFetchResponse(secondPage));
+
+    const user = userEvent.setup();
+    render(<AlertHistory endpoint="/alerts/history" />);
+
+    expect(await screen.findByText(/Breakout BTC/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /précédent/i })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+    await waitFor(() => {
+      const lastCall = global.fetch.mock.calls.at(-1);
+      expect(lastCall[0]).toBe("/alerts/history?page=2&page_size=10");
+      expect(lastCall[1]).toMatchObject({
+        headers: { Accept: "application/json" },
+      });
+    });
+    expect(await screen.findByText(/Liquidity alert/)).toBeInTheDocument();
+  });
+
+  it("rafraîchit les données lorsque des filtres sont appliqués", async () => {
+    const pagePayload = {
+      items: [],
+      pagination: { page: 1, page_size: 10, total: 0, pages: 1 },
+      available_filters: { strategies: ["Momentum"], severities: ["critical"] },
+    };
+
+    global.fetch.mockResolvedValue(createFetchResponse(pagePayload));
+
+    const user = userEvent.setup();
+    render(<AlertHistory endpoint="/alerts/history" />);
+
+    expect(await screen.findByLabelText(/Sévérité/i)).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText(/Sévérité/i), "critical");
+
+    await waitFor(() => {
+      const lastCall = global.fetch.mock.calls.at(-1);
+      expect(lastCall[0]).toBe("/alerts/history?page=1&page_size=10&severity=critical");
+      expect(lastCall[1]).toMatchObject({
+        headers: { Accept: "application/json" },
+      });
+    });
+  });
+});

--- a/services/web-dashboard/tests/test_alert_history_api.py
+++ b/services/web-dashboard/tests/test_alert_history_api.py
@@ -1,0 +1,75 @@
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from libs.alert_events import AlertEventRepository
+from libs.alert_events.models import AlertEventBase
+
+from .utils import load_dashboard_app
+
+
+@pytest.fixture()
+def dashboard_history_module(monkeypatch, tmp_path):
+    db_path = tmp_path / "alerts_history.db"
+    db_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("WEB_DASHBOARD_ALERT_EVENTS_DATABASE_URL", db_url)
+    load_dashboard_app.cache_clear()
+    app = load_dashboard_app()
+    module = sys.modules["web_dashboard.app.main"]
+    # Ensure tables are created for the dedicated test database
+    AlertEventBase.metadata.create_all(bind=module._alert_events_engine)
+    module.app.dependency_overrides.clear()
+    yield module
+    module.app.dependency_overrides.clear()
+    load_dashboard_app.cache_clear()
+
+
+def seed_events(module, count=5):
+    session = module._alert_events_session_factory()
+    repository = AlertEventRepository()
+    base_time = datetime.utcnow()
+    try:
+        for index in range(count):
+            repository.record_event(
+                session,
+                trigger_id=100 + index,
+                rule_id=200 + index,
+                rule_name=f"Rule {index}",
+                strategy=f"Strategy {index % 2}",
+                severity="critical" if index % 2 == 0 else "warning",
+                symbol="BTC" if index % 2 == 0 else "ETH",
+                triggered_at=base_time - timedelta(minutes=index),
+                context={"index": index},
+                delivery_status="received",
+            )
+    finally:
+        session.close()
+
+
+def test_alert_history_pagination(dashboard_history_module):
+    seed_events(dashboard_history_module, count=5)
+    client = TestClient(dashboard_history_module.app)
+
+    response = client.get("/alerts/history", params={"page": 1, "page_size": 2})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["pagination"]["page"] == 1
+    assert payload["pagination"]["page_size"] == 2
+    assert payload["pagination"]["total"] == 5
+    assert len(payload["items"]) == 2
+    first_event = payload["items"][0]
+    assert first_event["rule_name"] == "Rule 0"
+    assert "triggered_at" in first_event
+
+    response = client.get(
+        "/alerts/history",
+        params={"page": 2, "page_size": 2, "severity": "warning", "strategy": "Strategy 1"},
+    )
+    assert response.status_code == 200
+    filtered = response.json()
+    assert filtered["pagination"]["page"] == 2
+    assert filtered["pagination"]["total"] == 2
+    assert all(item["severity"] == "warning" for item in filtered["items"])
+    assert all(item["strategy"] == "Strategy 1" for item in filtered["items"])


### PR DESCRIPTION
## Summary
- add a shared `libs.alert_events` package to persist and query alert trigger history
- persist alert events from the alert engine and notification service while exposing a dedicated history API on the dashboard backend
- surface the alert history in the dashboard UI with filtering, pagination, and accompanying automated tests

## Testing
- `pytest services/alert_engine/tests`
- `pytest services/notification-service/tests`
- `pytest services/web-dashboard/tests/test_*.py`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68da633dbce083329d35672efe84dbde