### PR TITLE
Add market data context APIs and reports symbol summaries

### DIFF
--- a/services/alert_engine/app/config.py
+++ b/services/alert_engine/app/config.py
@@ -32,18 +32,20 @@ class AlertEngineSettings:
                 for symbol in symbols_env.split(",")
                 if symbol.strip()
             )
+        market_data_url = os.getenv("ALERT_ENGINE_MARKET_DATA_URL", defaults.market_data_url)
+        reports_url = os.getenv("ALERT_ENGINE_REPORTS_URL", defaults.reports_url)
         return cls(
             database_url=os.getenv("ALERT_ENGINE_DATABASE_URL", defaults.database_url),
             events_database_url=os.getenv(
                 "ALERT_ENGINE_EVENTS_DATABASE_URL",
                 os.getenv("ALERT_EVENTS_DATABASE_URL", defaults.events_database_url),
             ),
-            market_data_url=os.getenv("ALERT_ENGINE_MARKET_DATA_URL", defaults.market_data_url),
+            market_data_url=market_data_url,
             market_data_stream_url=os.getenv(
                 "ALERT_ENGINE_MARKET_DATA_STREAM_URL",
-                defaults.market_data_stream_url,
+                market_data_url,
             ),
-            reports_url=os.getenv("ALERT_ENGINE_REPORTS_URL", defaults.reports_url),
+            reports_url=reports_url,
             notification_url=os.getenv("ALERT_ENGINE_NOTIFICATION_URL", defaults.notification_url),
             evaluation_interval_seconds=float(
                 os.getenv(

--- a/services/market_data/app/main.py
+++ b/services/market_data/app/main.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import hmac
 import json
+import math
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
 from hashlib import sha256
 
 from fastapi import (
@@ -13,13 +17,14 @@ from fastapi import (
     Query,
     Request,
 )
+from fastapi.responses import StreamingResponse
 
 from ..adapters import BinanceMarketConnector, IBKRMarketConnector
 from .config import Settings, get_settings
 from .database import session_scope
 from .persistence import persist_ticks
-from .schemas import PersistedTick, TradingViewSignal
-from providers.limits import build_orderbook, build_quote, get_pair_limit
+from .schemas import MarketContextSnapshot, MarketStreamEvent, PersistedTick, TradingViewSignal
+from providers.limits import PairLimit, build_orderbook, build_quote, get_pair_limit
 from schemas.market import ExecutionVenue, OrderBookSnapshot, Quote
 from libs.observability.logging import RequestContextMiddleware, configure_logging
 from libs.observability.metrics import setup_metrics
@@ -126,6 +131,108 @@ async def get_orderbook(
     if limit is None:
         raise HTTPException(status_code=404, detail="Unsupported trading pair")
     return build_orderbook(limit)
+
+
+def _build_market_context(limit: PairLimit) -> MarketContextSnapshot:
+    quote = build_quote(limit)
+    orderbook = build_orderbook(limit)
+    total_bid_volume = sum(level.size for level in orderbook.bids)
+    total_ask_volume = sum(level.size for level in orderbook.asks)
+    total_volume = total_bid_volume + total_ask_volume
+    moving_average = quote.mid * 0.995
+    indicators = {
+        "moving_average": moving_average,
+        "moving_average_slow": quote.mid * 0.985,
+        "rsi": 50.0 + min(45.0, limit.tick_size * orderbook.depth),
+    }
+    return MarketContextSnapshot(
+        symbol=limit.symbol,
+        venue=limit.venue,
+        price=quote.mid,
+        bid=quote.bid,
+        ask=quote.ask,
+        spread_bps=quote.spread_bps,
+        volume=total_volume,
+        total_bid_volume=total_bid_volume,
+        total_ask_volume=total_ask_volume,
+        indicators=indicators,
+        timestamp=quote.timestamp,
+    )
+
+
+def _stream_payload(limit: PairLimit, sequence: int, context: MarketContextSnapshot) -> MarketStreamEvent:
+    base_price = context.price
+    variation = math.sin(sequence / 5.0) * limit.tick_size
+    price = base_price + variation
+    bid = price - (limit.tick_size / 2)
+    ask = price + (limit.tick_size / 2)
+    depth = max(1, limit.depth_levels)
+    volume_multiplier = 1.0 + (sequence % depth) / depth
+    volume = limit.max_order_size * volume_multiplier
+    metadata = {
+        "sequence": sequence,
+        "moving_average": context.indicators.get("moving_average", context.price),
+    }
+    return MarketStreamEvent(
+        price=price,
+        bid=bid,
+        ask=ask,
+        volume=volume,
+        metadata=metadata,
+        timestamp=datetime.now(timezone.utc),
+    )
+
+
+async def _event_generator(limit: PairLimit, *, max_events: int | None = None) -> AsyncIterator[str]:
+    context = _build_market_context(limit)
+    sequence = 0
+    emitted = 0
+    try:
+        while True:
+            if max_events is not None and emitted >= max_events:
+                break
+            event = _stream_payload(limit, sequence, context)
+            payload = json.dumps(event.model_dump(mode="json")) + "\n"
+            yield payload
+            sequence += 1
+            emitted += 1
+            if max_events is None or emitted < max_events:
+                await asyncio.sleep(0.1)
+    except asyncio.CancelledError:  # pragma: no cover - cancellation during disconnect
+        return
+
+
+@app.get(
+    "/symbols/{symbol}/context",
+    response_model=MarketContextSnapshot,
+    tags=["context"],
+)
+async def get_symbol_context(
+    symbol: str,
+    venue: ExecutionVenue = Query(ExecutionVenue.BINANCE_SPOT, description="Market data venue"),
+) -> MarketContextSnapshot:
+    limit = get_pair_limit(venue, symbol.upper())
+    if limit is None:
+        raise HTTPException(status_code=404, detail="Unsupported trading pair")
+    return _build_market_context(limit)
+
+
+@app.get("/streaming/{symbol}", tags=["streaming"])
+async def stream_symbol_updates(
+    symbol: str,
+    venue: ExecutionVenue = Query(ExecutionVenue.BINANCE_SPOT, description="Market data venue"),
+    max_events: int | None = Query(
+        default=None,
+        ge=1,
+        le=1_000,
+        description="Optional cap on the number of streamed events",
+    ),
+) -> StreamingResponse:
+    limit = get_pair_limit(venue, symbol.upper())
+    if limit is None:
+        raise HTTPException(status_code=404, detail="Unsupported trading pair")
+    generator = _event_generator(limit, max_events=max_events)
+    return StreamingResponse(generator, media_type="application/x-ndjson")
 
 
 __all__ = ["app", "get_binance_adapter", "get_ibkr_adapter"]

--- a/services/market_data/tests/test_market_data_api.py
+++ b/services/market_data/tests/test_market_data_api.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import os
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("TRADINGVIEW_HMAC_SECRET", "test-secret")
+
+from services.market_data.app.main import app
+
+
+def test_symbol_context_snapshot_contains_indicators() -> None:
+    client = TestClient(app)
+    response = client.get("/symbols/BTCUSDT/context")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["symbol"] == "BTCUSDT"
+    assert payload["price"] > 0
+    assert payload["volume"] > 0
+    assert "indicators" in payload
+    assert "moving_average" in payload["indicators"]
+    assert "total_bid_volume" in payload and payload["total_bid_volume"] > 0
+
+
+def test_streaming_endpoint_emits_market_events() -> None:
+    with TestClient(app) as client:
+        with client.stream("GET", "/streaming/BTCUSDT", params={"max_events": 3}) as response:
+            assert response.status_code == 200
+            events: list[dict[str, object]] = []
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                events.append(json.loads(line))
+                if len(events) >= 3:
+                    break
+
+    assert events, "Streaming endpoint should emit events"
+    first = events[0]
+    assert "price" in first and isinstance(first["price"], (int, float))
+    assert any("moving_average" in (event.get("metadata") or {}) for event in events)


### PR DESCRIPTION
## Summary
- expose `/symbols/{symbol}/context` and `/streaming/{symbol}` in the market-data service with snapshot aggregation, streaming helpers, and schemas
- add `/symbols/{symbol}/summary` in the reports service along with risk aggregation helpers and symbol-focused daily risk generation
- cover the new APIs with FastAPI tests and allow the alert engine to reuse the same market data base URL for streaming

## Testing
- pytest services/market_data/tests/test_market_data_api.py
- pytest services/reports/tests/test_reports_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dd16cd50b0833293113ee10ad75320