### PR TITLE
feat: broadcast order router events to streaming ingest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql+psycopg2://trading:trading@postgres:5432/trading
+      STREAMING_INGEST_URL: ${STREAMING_INGEST_URL:-http://streaming:8000}
+      STREAMING_SERVICE_TOKEN: ${STREAMING_SERVICE_TOKEN:-reports-token}
+      STREAMING_ROOM_ID: ${STREAMING_ROOM_ID:-public-room}
     depends_on:
       - postgres
       - redis

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -21,6 +21,9 @@ Variables d'environnement disponibles :
 - `STREAMING_PIPELINE_BACKEND`: `memory` (par défaut), `redis` ou `nats` pour sélectionner le bus de diffusion.
 - `STREAMING_REDIS_URL` / `STREAMING_NATS_URL`: URLs des backends respectifs.
 - `STREAMING_SERVICE_TOKEN_REPORTS` et `STREAMING_SERVICE_TOKEN_INPLAY`: jetons partagés utilisés par les services producteurs lors des appels d'ingestion.
+- `STREAMING_INGEST_URL` : URL de base (HTTP) utilisée par les producteurs comme `order-router` pour publier les événements d'exécution (`http://streaming:8000` en développement).
+- `STREAMING_SERVICE_TOKEN` : jeton d'authentification présenté par `order-router` lors des appels `POST /ingest/reports`.
+- `STREAMING_ROOM_ID` (optionnel) : identifiant de la room cible pour les rapports temps réel (défaut `public-room`).
 - `STREAMING_ENTITLEMENTS_CAPABILITY`: capacité requise côté client (défaut `can.stream_public`).
 
 En développement/test, `ENTITLEMENTS_BYPASS=1` autorise les connexions sans contacter le service d'entitlements.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ detect-secrets>=1.4.0
 pytest>=7.4.0
 pytest-asyncio>=0.24.0
 httpx>=0.24.0
+respx>=0.20.0
 openfeature-sdk>=0.8.3
 schemathesis>=4.1.0
 coverage>=7.6

--- a/services/order-router/tests/conftest.py
+++ b/services/order-router/tests/conftest.py
@@ -50,6 +50,9 @@ def db_module(tmp_path_factory: pytest.TempPathFactory):
     db_path = tmp_path_factory.mktemp("order_router_db") / "test.sqlite"
     os.environ.setdefault("ENTITLEMENTS_BYPASS", "1")
     os.environ["DATABASE_URL"] = f"sqlite+pysqlite:///{db_path}"
+    os.environ["STREAMING_INGEST_URL"] = "http://streaming.test"
+    os.environ["STREAMING_SERVICE_TOKEN"] = "reports-token"
+    os.environ["STREAMING_ROOM_ID"] = "public-room"
 
     module = importlib.import_module("libs.db.db")
     module = importlib.reload(module)


### PR DESCRIPTION
## Summary
- add a streaming ingest client to the order router that publishes transactions and logs after order persistence and cancellations
- configure retry/backoff logic with environment-based settings and document the new variables
- add respx-based tests and docker-compose defaults to exercise the new streaming integration

## Testing
- pytest services/order-router/tests

------
https://chatgpt.com/codex/tasks/task_e_68dd1a8931b4833284825d091f5d19ea