### PR TITLE
feat: expose in-play setup statuses across dashboard

### DIFF
--- a/services/inplay/app/schemas.py
+++ b/services/inplay/app/schemas.py
@@ -6,6 +6,9 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
+SetupStatus = Literal["validated", "pending", "failed"]
+
+
 class TickPayload(BaseModel):
     symbol: str
     strategy: str
@@ -13,6 +16,7 @@ class TickPayload(BaseModel):
     target: float
     stop: float
     probability: float = Field(..., ge=0.0, le=1.0)
+    status: SetupStatus = "pending"
     watchlists: list[str] | None = None
     source: Literal["market-data", "manual"] = "market-data"
     received_at: datetime = Field(default_factory=datetime.utcnow)
@@ -25,6 +29,7 @@ class StrategySetup(BaseModel):
     target: float
     stop: float
     probability: float
+    status: SetupStatus = "pending"
     updated_at: datetime
 
 

--- a/services/inplay/app/state.py
+++ b/services/inplay/app/state.py
@@ -47,6 +47,7 @@ class InPlayState:
             target=payload.target,
             stop=payload.stop,
             probability=payload.probability,
+            status=payload.status,
             updated_at=payload.received_at,
         )
         async with self._lock:

--- a/services/inplay/tests/test_integration_inplay.py
+++ b/services/inplay/tests/test_integration_inplay.py
@@ -21,6 +21,7 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
         target=191.5,
         stop=189.0,
         probability=0.65,
+        status="pending",
         watchlists=["momentum"],
     )
 
@@ -41,6 +42,7 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
         setups = data["symbols"][0]["setups"]
         assert setups[0]["strategy"] == "ORB"
         assert setups[0]["probability"] == payload.probability
+        assert setups[0]["status"] == payload.status
 
         with client.websocket_connect("/inplay/ws") as websocket:
             initial = websocket.receive_json()
@@ -53,6 +55,7 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
                 target=192.0,
                 stop=189.5,
                 probability=0.7,
+                status="validated",
                 watchlists=["momentum"],
             )
             stream.publish(updated_payload)
@@ -61,3 +64,4 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
             latest_setup = message["payload"]["symbols"][0]["setups"][0]
             assert latest_setup["target"] == updated_payload.target
             assert latest_setup["probability"] == updated_payload.probability
+            assert latest_setup["status"] == updated_payload.status

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -611,6 +611,80 @@ body {
   border: 0;
 }
 
+.inplay-setups__status {
+  margin-bottom: var(--space-md);
+  font-size: var(--font-size-sm);
+}
+
+.inplay-setups__status--success {
+  color: var(--color-success);
+}
+
+.inplay-setups__status--warning {
+  color: var(--color-warning);
+}
+
+.inplay-setups__status--info {
+  color: var(--color-info);
+}
+
+.inplay-setups__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--space-md);
+}
+
+.setup-card {
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 100px;
+}
+
+.setup-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.setup-card__strategy {
+  font-size: var(--font-size-lg);
+}
+
+.setup-card__meta {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.setup-card__metrics {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-xs) var(--space-md);
+}
+
+.setup-card__metric-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.setup-card__metric-value {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.inplay-setups__empty {
+  margin: 0;
+  text-align: center;
+}
+
 .card__header--inline {
   display: flex;
   align-items: center;
@@ -714,6 +788,10 @@ body {
   .metrics-grid {
     grid-template-columns: 1fr;
     gap: var(--space-md);
+  }
+
+  .inplay-setups__grid {
+    grid-template-columns: 1fr;
   }
 
   .metric-card {

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -137,6 +137,92 @@
       </section>
       {% endif %}
 
+      <section class="card card--setups" aria-labelledby="inplay-setups-title">
+        <div class="card__header card__header--inline">
+          <h2 id="inplay-setups-title" class="heading heading--lg">Setups en temps réel</h2>
+          <p class="text text--muted">Propulsé par le flux InPlay</p>
+        </div>
+        <div class="card__body">
+          <p
+            id="inplay-setups-status"
+            class="inplay-setups__status text text--muted"
+            role="status"
+            aria-live="polite"
+          >
+            {% if context.setups and context.setups.fallback_reason %}
+            {{ context.setups.fallback_reason }}
+            {% else %}
+            Flux InPlay connecté.
+            {% endif %}
+          </p>
+          <div class="inplay-setups__grid" role="list" aria-describedby="inplay-setups-title">
+            {% if context.setups and context.setups.watchlists %}
+            {% for watchlist in context.setups.watchlists %}
+            {% for symbol in watchlist.symbols %}
+            {% for setup in symbol.setups %}
+            <article class="setup-card" role="listitem">
+              <div class="setup-card__header">
+                <span class="setup-card__strategy heading heading--md">{{ setup.strategy }}</span>
+                {% set status = setup.status.value if setup.status else setup.status %}
+                {% set status_class = 'badge--info' %}
+                {% if status == 'validated' %}
+                {% set status_class = 'badge--success' %}
+                {% elif status == 'failed' %}
+                {% set status_class = 'badge--critical' %}
+                {% elif status and status != 'pending' %}
+                {% set status_class = 'badge--warning' %}
+                {% endif %}
+                <span class="badge {{ status_class }}">{{ status.capitalize() if status else 'Pending' }}</span>
+              </div>
+              <p class="setup-card__meta text text--muted">
+                {{ symbol.symbol }}
+                {% if watchlist.id %}· Watchlist {{ watchlist.id }}{% endif %}
+                {% if setup.updated_at %}· Maj {{ setup.updated_at.strftime('%d/%m %H:%M') }}{% endif %}
+              </p>
+              <dl class="setup-card__metrics">
+                <dt class="setup-card__metric-label">Entrée</dt>
+                <dd class="setup-card__metric-value">
+                  {% if setup.entry is not none %}{{ '%.2f' | format(setup.entry) }}{% else %}—{% endif %}
+                </dd>
+                <dt class="setup-card__metric-label">Cible</dt>
+                <dd class="setup-card__metric-value">
+                  {% if setup.target is not none %}{{ '%.2f' | format(setup.target) }}{% else %}—{% endif %}
+                </dd>
+                <dt class="setup-card__metric-label">Stop</dt>
+                <dd class="setup-card__metric-value">
+                  {% if setup.stop is not none %}{{ '%.2f' | format(setup.stop) }}{% else %}—{% endif %}
+                </dd>
+                <dt class="setup-card__metric-label">Probabilité</dt>
+                <dd class="setup-card__metric-value">
+                  {% if setup.probability is not none %}
+                  {% if setup.probability <= 1 %}
+                  {{ '%.0f' | format(setup.probability * 100) }} %
+                  {% else %}
+                  {{ '%.0f' | format(setup.probability) }} %
+                  {% endif %}
+                  {% else %}
+                  —
+                  {% endif %}
+                </dd>
+              </dl>
+            </article>
+            {% endfor %}
+            {% endfor %}
+            {% endfor %}
+            {% else %}
+            <p class="text text--muted inplay-setups__empty">
+              Aucun setup en temps réel n'est disponible pour le moment.
+            </p>
+            {% endif %}
+          </div>
+          <noscript>
+            <p class="text text--muted">
+              Activez JavaScript pour suivre les mises à jour en direct du flux InPlay.
+            </p>
+          </noscript>
+        </div>
+      </section>
+
       <section class="card card--strategies" aria-labelledby="strategies-title">
         <div class="card__header card__header--inline">
           <h2 id="strategies-title" class="heading heading--lg">Stratégies</h2>

--- a/services/web-dashboard/test/dashboard-setups.test.js
+++ b/services/web-dashboard/test/dashboard-setups.test.js
@@ -1,0 +1,225 @@
+import { beforeEach, afterEach, expect, test, vi } from "vitest";
+
+const SCRIPT_PATH = "../app/static/dashboard.js";
+
+const originalFetch = global.fetch;
+const originalWebSocket = global.WebSocket;
+
+function buildBootstrapScript(data) {
+  const script = document.createElement("script");
+  script.id = "dashboard-bootstrap";
+  script.type = "application/json";
+  script.textContent = JSON.stringify(data);
+  return script;
+}
+
+function mountBaseDom(context, streaming) {
+  document.body.innerHTML = "";
+  const root = document.createElement("div");
+  root.appendChild(buildBootstrapScript({ context, streaming }));
+
+  const setupsStatus = document.createElement("p");
+  setupsStatus.id = "inplay-setups-status";
+  setupsStatus.className = "inplay-setups__status text";
+  root.appendChild(setupsStatus);
+
+  const setupsGrid = document.createElement("div");
+  setupsGrid.className = "inplay-setups__grid";
+  root.appendChild(setupsGrid);
+
+  root.appendChild(document.createElement("ul")).className = "portfolio-list";
+
+  const transactionsTable = document.createElement("table");
+  transactionsTable.setAttribute("aria-labelledby", "transactions-title");
+  const tbody = document.createElement("tbody");
+  transactionsTable.appendChild(tbody);
+  transactionsTable.className = "card";
+  root.appendChild(transactionsTable);
+
+  root.appendChild(document.createElement("ul")).className = "alert-list";
+
+  const strategyTable = document.createElement("table");
+  const strategyBody = document.createElement("tbody");
+  strategyBody.className = "strategy-table__body";
+  strategyTable.appendChild(strategyBody);
+  root.appendChild(strategyTable);
+
+  const logs = document.createElement("ul");
+  logs.id = "log-entries";
+  root.appendChild(logs);
+
+  document.body.appendChild(root);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  } else {
+    delete global.fetch;
+  }
+  if (originalWebSocket) {
+    global.WebSocket = originalWebSocket;
+  } else {
+    delete global.WebSocket;
+  }
+  document.body.innerHTML = "";
+});
+
+const SAMPLE_CONTEXT = {
+  portfolios: [],
+  transactions: [],
+  alerts: [],
+  strategies: [],
+  logs: [],
+  setups: {
+    fallback_reason: "Instantané statique utilisé faute de connexion au service InPlay.",
+    watchlists: [
+      {
+        id: "demo-momentum",
+        symbols: [
+          {
+            symbol: "AAPL",
+            setups: [
+              {
+                strategy: "ORB",
+                status: "pending",
+                entry: 189.95,
+                target: 192.1,
+                stop: 187.8,
+                probability: 0.64,
+                updated_at: "2024-05-01T10:00:00Z",
+              },
+            ],
+          },
+          {
+            symbol: "MSFT",
+            setups: [
+              {
+                strategy: "Breakout",
+                status: "validated",
+                entry: 404.2,
+                target: 409.5,
+                stop: 398.7,
+                probability: 0.58,
+                updated_at: "2024-05-01T10:05:00Z",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+test("affiche les setups initiaux et le message de fallback", async () => {
+  mountBaseDom(SAMPLE_CONTEXT, {});
+
+  await import(SCRIPT_PATH);
+
+  const cards = document.querySelectorAll(".setup-card");
+  expect(cards.length).toBe(2);
+  expect(cards[0].querySelector(".setup-card__strategy").textContent).toBe("ORB");
+  expect(cards[1].textContent).toContain("Breakout");
+
+  const statusNode = document.getElementById("inplay-setups-status");
+  expect(statusNode.textContent.trim()).toContain("Instantané statique");
+});
+
+test("met à jour les setups lors d'un événement watchlist.update", async () => {
+  const streaming = {
+    handshake_url: "https://stream.example/rooms/public-room/connection",
+    viewer_id: "viewer-1",
+  };
+
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ websocket_url: "wss://stream.example/ws" }),
+    });
+  global.fetch = fetchMock;
+
+  class FakeWebSocket {
+    static instances = [];
+    static OPEN = 1;
+    static CLOSED = 3;
+
+    constructor(url) {
+      this.url = url;
+      this.readyState = FakeWebSocket.OPEN;
+      FakeWebSocket.instances.push(this);
+      setTimeout(() => {
+        if (typeof this.onopen === "function") {
+          this.onopen();
+        }
+      }, 0);
+    }
+
+    send() {}
+
+    close() {
+      this.readyState = FakeWebSocket.CLOSED;
+      if (typeof this.onclose === "function") {
+        this.onclose();
+      }
+    }
+
+    emit(message) {
+      if (typeof this.onmessage === "function") {
+        this.onmessage({ data: JSON.stringify(message) });
+      }
+    }
+  }
+
+  global.WebSocket = FakeWebSocket;
+
+  mountBaseDom(SAMPLE_CONTEXT, streaming);
+
+  await import(SCRIPT_PATH);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(FakeWebSocket.instances.length).toBe(1);
+
+  const socket = FakeWebSocket.instances[0];
+  socket.emit({
+    type: "watchlist.update",
+    payload: {
+      id: "demo-momentum",
+      symbols: [
+        {
+          symbol: "AAPL",
+          setups: [
+            {
+              strategy: "ORB",
+              status: "validated",
+              entry: 190.5,
+              target: 194.0,
+              stop: 188.0,
+              probability: 0.7,
+              updated_at: "2024-05-01T10:15:00Z",
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const updatedCard = document.querySelector(".setup-card");
+  expect(updatedCard.querySelector(".badge").textContent.trim()).toBe("Validated");
+  const metrics = Array.from(updatedCard.querySelectorAll(".setup-card__metric-value"));
+  expect(metrics[0].textContent).toBe("190.50");
+  expect(metrics[1].textContent).toBe("194.00");
+  expect(metrics[2].textContent).toBe("188.00");
+  expect(metrics[3].textContent).toContain("70");
+
+  const statusNode = document.getElementById("inplay-setups-status");
+  expect(statusNode.textContent.trim()).toBe("Flux InPlay connecté.");
+});

--- a/services/web-dashboard/tests/test_dashboard_template.py
+++ b/services/web-dashboard/tests/test_dashboard_template.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from .utils import load_dashboard_app
+
+
+def test_dashboard_template_includes_inplay_section(monkeypatch):
+    app = load_dashboard_app()
+    client = TestClient(app)
+
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    html = response.text
+
+    assert "Setups en temps réel" in html
+    assert "inplay-setups-status" in html
+    assert "Instantané statique" in html


### PR DESCRIPTION
## Summary
- add status tracking to in-play payloads and propagate through REST and websocket responses
- hydrate dashboard context with in-play setups, render live cards with fallback messaging, and style the new section
- cover the real-time setups experience with Vitest and FastAPI template tests

## Testing
- npm --prefix services/web-dashboard test
- pytest services/web-dashboard/tests/test_dashboard_template.py


------
https://chatgpt.com/codex/tasks/task_e_68dd383b327c8332bd5b70de60dc256e