### PR TITLE
Add session-aware filtering to InPlay data and dashboard

### DIFF
--- a/docs/inplay.md
+++ b/docs/inplay.md
@@ -28,6 +28,7 @@ GET /inplay/ws
             "target": 192.0,
             "stop": 189.5,
             "probability": 0.7,
+            "session": "london",
             "updated_at": "2024-03-19T14:35:00Z"
           }
         ]
@@ -43,11 +44,25 @@ GET /inplay/ws
 ### REST
 
 ```
-GET /inplay/watchlists/{watchlist_id}
+GET /inplay/watchlists/{watchlist_id}?session={session}
 ```
 
 * Retourne l'état courant de la watchlist (`momentum`, `futures`, etc.).
+* Paramètre optionnel `session` : filtre les setups par session de trading (`london`, `new_york`, `asia`).
+  Sans paramètre, l'API retourne l'intégralité des sessions disponibles.
 * Structure équivalente au payload WebSocket.
+
+## Sessions InPlay
+
+Chaque setup publié par le service est associé à une session de marché (`session`). Les valeurs supportées sont :
+
+| Session | Description | Valeur par défaut |
+| --- | --- | --- |
+| `london` | Séance européenne | ✅ (valeur implicite lorsque le champ est omis) |
+| `new_york` | Séance américaine | |
+| `asia` | Séance asiatique | |
+
+Le champ `session` est présent dans les payloads REST et WebSocket. Les clients peuvent exploiter ce champ pour filtrer les setups côté interface (ex. sélecteur de session dans le dashboard) ou limiter les données transférées via le paramètre de requête `session`.
 
 ## Intégration UI
 

--- a/services/inplay/app/schemas.py
+++ b/services/inplay/app/schemas.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 
 SetupStatus = Literal["validated", "pending", "failed"]
+SessionName = Literal["london", "new_york", "asia"]
 
 
 class TickPayload(BaseModel):
@@ -17,6 +18,7 @@ class TickPayload(BaseModel):
     stop: float
     probability: float = Field(..., ge=0.0, le=1.0)
     status: SetupStatus = "pending"
+    session: SessionName = "london"
     watchlists: list[str] | None = None
     source: Literal["market-data", "manual"] = "market-data"
     received_at: datetime = Field(default_factory=datetime.utcnow)
@@ -30,6 +32,7 @@ class StrategySetup(BaseModel):
     stop: float
     probability: float
     status: SetupStatus = "pending"
+    session: SessionName = "london"
     updated_at: datetime
 
 

--- a/services/inplay/app/state.py
+++ b/services/inplay/app/state.py
@@ -2,30 +2,38 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Tuple
 
-from .schemas import StrategySetup, SymbolSetups, TickPayload, WatchlistSnapshot
+from .schemas import (
+    SessionName,
+    StrategySetup,
+    SymbolSetups,
+    TickPayload,
+    WatchlistSnapshot,
+)
 
 
 class WatchlistState:
     def __init__(self, watchlist_id: str, symbols: Iterable[str]):
         self.id = watchlist_id
         self.symbols = list(symbols)
-        self._setups: dict[str, dict[str, StrategySetup]] = {}
+        self._setups: dict[str, dict[Tuple[str, SessionName], StrategySetup]] = {}
         self.updated_at: datetime | None = None
 
     def apply_setup(self, setup: StrategySetup) -> bool:
         if setup.symbol not in self.symbols:
             return False
         symbol_setups = self._setups.setdefault(setup.symbol, {})
-        symbol_setups[setup.strategy] = setup
+        symbol_setups[(setup.strategy, setup.session)] = setup
         self.updated_at = setup.updated_at
         return True
 
-    def snapshot(self) -> WatchlistSnapshot:
+    def snapshot(self, session: SessionName | None = None) -> WatchlistSnapshot:
         symbols: list[SymbolSetups] = []
         for symbol in self.symbols:
             setups = list(self._setups.get(symbol, {}).values())
+            if session is not None:
+                setups = [item for item in setups if item.session == session]
             setups.sort(key=lambda item: item.updated_at, reverse=True)
             symbols.append(SymbolSetups(symbol=symbol, setups=setups))
         return WatchlistSnapshot(id=self.id, symbols=symbols, updated_at=self.updated_at)
@@ -48,6 +56,7 @@ class InPlayState:
             stop=payload.stop,
             probability=payload.probability,
             status=payload.status,
+            session=payload.session,
             updated_at=payload.received_at,
         )
         async with self._lock:
@@ -59,11 +68,13 @@ class InPlayState:
                     updated.append(watchlist.snapshot())
             return updated
 
-    async def get_watchlist(self, watchlist_id: str) -> WatchlistSnapshot:
+    async def get_watchlist(
+        self, watchlist_id: str, session: SessionName | None = None
+    ) -> WatchlistSnapshot:
         async with self._lock:
             if watchlist_id not in self._watchlists:
                 raise KeyError(watchlist_id)
-            return self._watchlists[watchlist_id].snapshot()
+            return self._watchlists[watchlist_id].snapshot(session=session)
 
     async def list_watchlists(self) -> list[WatchlistSnapshot]:
         async with self._lock:

--- a/services/inplay/tests/test_integration_inplay.py
+++ b/services/inplay/tests/test_integration_inplay.py
@@ -22,10 +22,12 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
         stop=189.0,
         probability=0.65,
         status="pending",
+        session="london",
         watchlists=["momentum"],
     )
 
     with TestClient(app) as client:
+        assert stream._ready.wait(timeout=1.0)
         stream.publish(payload)
 
         deadline = time.time() + 1.0
@@ -43,6 +45,7 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
         assert setups[0]["strategy"] == "ORB"
         assert setups[0]["probability"] == payload.probability
         assert setups[0]["status"] == payload.status
+        assert setups[0]["session"] == "london"
 
         with client.websocket_connect("/inplay/ws") as websocket:
             initial = websocket.receive_json()
@@ -56,6 +59,7 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
                 stop=189.5,
                 probability=0.7,
                 status="validated",
+                session="london",
                 watchlists=["momentum"],
             )
             stream.publish(updated_payload)
@@ -65,3 +69,64 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
             assert latest_setup["target"] == updated_payload.target
             assert latest_setup["probability"] == updated_payload.probability
             assert latest_setup["status"] == updated_payload.status
+            assert latest_setup["session"] == "london"
+
+
+def test_watchlist_session_filtering() -> None:
+    stream = SimulatedTickStream()
+    settings = Settings(watchlists={"momentum": ["AAPL", "MSFT"]})
+    app = create_app(settings=settings, stream_factory=lambda: stream)
+
+    london_payload = TickPayload(
+        symbol="AAPL",
+        strategy="ORB",
+        entry=190.0,
+        target=191.5,
+        stop=189.0,
+        probability=0.65,
+        status="pending",
+        session="london",
+        watchlists=["momentum"],
+    )
+    asia_payload = TickPayload(
+        symbol="AAPL",
+        strategy="Breakout",
+        entry=189.5,
+        target=192.5,
+        stop=188.5,
+        probability=0.55,
+        status="pending",
+        session="asia",
+        watchlists=["momentum"],
+    )
+
+    with TestClient(app) as client:
+        assert stream._ready.wait(timeout=1.0)
+        stream.publish(london_payload)
+        stream.publish(asia_payload)
+
+        deadline = time.time() + 1.0
+        while time.time() < deadline:
+            response = client.get("/inplay/watchlists/momentum")
+            assert response.status_code == 200
+            data = response.json()
+            setups = data["symbols"][0]["setups"]
+            if len(setups) >= 2:
+                break
+            time.sleep(0.05)
+        else:
+            raise AssertionError("Setups not available in time")
+
+        response = client.get("/inplay/watchlists/momentum", params={"session": "asia"})
+        assert response.status_code == 200
+        filtered = response.json()
+        filtered_setups = filtered["symbols"][0]["setups"]
+        assert filtered_setups
+        assert all(setup["session"] == "asia" for setup in filtered_setups)
+        assert all(setup["strategy"] == "Breakout" for setup in filtered_setups)
+
+        response_default = client.get("/inplay/watchlists/momentum")
+        assert response_default.status_code == 200
+        combined_setups = response_default.json()["symbols"][0]["setups"]
+        assert any(setup["session"] == "london" for setup in combined_setups)
+        assert any(setup["session"] == "asia" for setup in combined_setups)

--- a/services/web-dashboard/README.md
+++ b/services/web-dashboard/README.md
@@ -12,6 +12,7 @@ configuration.
 | --- | --- | --- |
 | Portefeuilles, transactions, alertes | `services/web-dashboard/app/data.py` | Données d'exemple construites côté service pour illustrer la présentation des portefeuilles et flux récents. |
 | Métriques de performance | `reports-service` (`GET /reports/daily`) | Agrégation quotidienne retournant P\&L, drawdown et incidents. Le dashboard normalise les rendements à partir du champ d'exposition (`exposure`, `notional_exposure`, etc.) lorsqu'il est fourni afin de calculer un rendement composé et un ratio de Sharpe annualisé. |
+| Setups InPlay | `services/inplay` (`GET /inplay/watchlists/{id}` + WebSocket `/inplay/ws`) | Les setups incluent un champ `session` (`london`, `new_york`, `asia`). Le dashboard expose un sélecteur pour filtrer l'affichage par session et peut recharger un instantané via `?session=`. |
 
 Lorsque la réponse du reports-service ne contient pas d'exposition, le calcul du
 Sharpe et du rendement cumulatif retombe sur les valeurs de P\&L brutes (sans
@@ -35,6 +36,10 @@ Le module `services/web-dashboard/app/data.py` encapsule ces appels via
 dans le contexte Jinja. Toute adaptation (nouvelle source, transformation
 supplémentaire) doit se faire dans ce module pour conserver une interface
 centralisée.
+
+### Filtrage des sessions InPlay
+
+La section « Setups en temps réel » propose un sélecteur de session (`Toutes les sessions`, `Londres`, `New York`, `Asie`). Le filtrage est appliqué côté navigateur et déclenche, si besoin, une requête `GET /inplay/watchlists/{id}?session=...` pour synchroniser l'instantané InPlay. Sans sélection particulière, toutes les sessions restent visibles et les mises à jour temps réel continuent d'être diffusées via le WebSocket.
 
 ## Tests
 

--- a/services/web-dashboard/app/data.py
+++ b/services/web-dashboard/app/data.py
@@ -290,6 +290,16 @@ def _normalise_inplay_strategy(entry: dict[str, object]) -> InPlayStrategySetup 
         probability = max(0.0, min(1.0, probability))
 
     updated_at = _parse_timestamp(entry.get("updated_at") or entry.get("received_at"))
+    raw_session = (
+        entry.get("session")
+        or entry.get("session_name")
+        or entry.get("sessionName")
+        or entry.get("market")
+        or None
+    )
+    session: str | None = None
+    if isinstance(raw_session, str) and raw_session.strip():
+        session = raw_session.strip().lower().replace(" ", "_")
 
     return InPlayStrategySetup(
         strategy=strategy,
@@ -299,6 +309,7 @@ def _normalise_inplay_strategy(entry: dict[str, object]) -> InPlayStrategySetup 
         stop=stop_level,
         probability=probability,
         updated_at=updated_at,
+        session=session,
     )
 
 
@@ -371,6 +382,7 @@ def _fallback_inplay_setups() -> InPlayDashboardSetups:
                                 stop=187.8,
                                 probability=0.64,
                                 updated_at=base_time,
+                                session="london",
                             )
                         ],
                     ),
@@ -385,6 +397,7 @@ def _fallback_inplay_setups() -> InPlayDashboardSetups:
                                 stop=398.7,
                                 probability=0.58,
                                 updated_at=base_time,
+                                session="new_york",
                             )
                         ],
                     ),

--- a/services/web-dashboard/app/schemas.py
+++ b/services/web-dashboard/app/schemas.py
@@ -246,6 +246,10 @@ class InPlayStrategySetup(BaseModel):
         default=None,
         description="Last update timestamp propagated by the InPlay service",
     )
+    session: str | None = Field(
+        default=None,
+        description="Trading session associated with the setup (london, new_york or asia)",
+    )
 
 
 class InPlaySymbolSetups(BaseModel):

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -139,8 +139,19 @@
 
       <section class="card card--setups" aria-labelledby="inplay-setups-title">
         <div class="card__header card__header--inline">
-          <h2 id="inplay-setups-title" class="heading heading--lg">Setups en temps réel</h2>
-          <p class="text text--muted">Propulsé par le flux InPlay</p>
+          <div class="card__header-content">
+            <h2 id="inplay-setups-title" class="heading heading--lg">Setups en temps réel</h2>
+            <p class="text text--muted">Propulsé par le flux InPlay</p>
+          </div>
+          <label class="log-filter session-filter" for="session-filter">
+            <span class="text text--muted">Session</span>
+            <select id="session-filter" class="select">
+              <option value="all" selected>Toutes les sessions</option>
+              <option value="london">Londres</option>
+              <option value="new_york">New York</option>
+              <option value="asia">Asie</option>
+            </select>
+          </label>
         </div>
         <div class="card__body">
           <p


### PR DESCRIPTION
## Summary
- add an explicit `session` field to InPlay payloads and persist per-session setups in the state layer
- expose a `session` query parameter on the watchlist endpoint and cache pending simulated ticks to avoid race conditions
- add a session selector to the dashboard with REST fallbacks, and document available sessions in the docs and README

## Testing
- pytest services/inplay/tests/test_integration_inplay.py *(hangs in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5e673bd48332baa9286089dea5b7