### PR TITLE
Add strategy report endpoint and dashboard report links

### DIFF
--- a/services/inplay/app/config.py
+++ b/services/inplay/app/config.py
@@ -22,6 +22,26 @@ class Settings(BaseSettings):
         },
         alias="INPLAY_WATCHLISTS",
     )
+    reports_base_url: str = Field(
+        "http://reports:8000/",
+        alias="INPLAY_REPORTS_BASE_URL",
+        description="Base URL du service reports-service",
+    )
+    reports_timeout_seconds: float = Field(
+        5.0,
+        alias="INPLAY_REPORTS_TIMEOUT_SECONDS",
+        description="Délai d'expiration pour les appels au reports-service",
+    )
+    market_data_base_url: str = Field(
+        "http://market-data:8000/",
+        alias="INPLAY_MARKET_DATA_BASE_URL",
+        description="Base URL du service market-data",
+    )
+    market_data_timeout_seconds: float = Field(
+        5.0,
+        alias="INPLAY_MARKET_DATA_TIMEOUT_SECONDS",
+        description="Délai d'expiration pour les appels au market-data service",
+    )
 
 
 @functools.lru_cache

--- a/services/inplay/app/schemas.py
+++ b/services/inplay/app/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -22,6 +22,10 @@ class TickPayload(BaseModel):
     watchlists: list[str] | None = None
     source: Literal["market-data", "manual"] = "market-data"
     received_at: datetime = Field(default_factory=datetime.utcnow)
+    report_url: str | None = Field(
+        default=None,
+        description="Lien pointant vers les détails du rapport de stratégie",
+    )
 
 
 class StrategySetup(BaseModel):
@@ -34,6 +38,20 @@ class StrategySetup(BaseModel):
     status: SetupStatus = "pending"
     session: SessionName = "london"
     updated_at: datetime
+    report_url: str | None = Field(
+        default=None,
+        description="Lien enrichi renvoyant vers les détails du rapport",
+    )
+
+
+class StrategyReportPayload(BaseModel):
+    symbol: str
+    strategy: str
+    session: SessionName | None = None
+    setup: StrategySetup
+    report: dict[str, Any] | None = None
+    risk: dict[str, Any] | None = None
+    market: dict[str, Any] | None = None
 
 
 class SymbolSetups(BaseModel):

--- a/services/inplay/tests/test_integration_inplay.py
+++ b/services/inplay/tests/test_integration_inplay.py
@@ -46,6 +46,7 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
         assert setups[0]["probability"] == payload.probability
         assert setups[0]["status"] == payload.status
         assert setups[0]["session"] == "london"
+        assert setups[0]["report_url"].endswith("/ORB")
 
         with client.websocket_connect("/inplay/ws") as websocket:
             initial = websocket.receive_json()
@@ -70,6 +71,7 @@ def test_tick_stream_updates_watchlist_and_websocket() -> None:
             assert latest_setup["probability"] == updated_payload.probability
             assert latest_setup["status"] == updated_payload.status
             assert latest_setup["session"] == "london"
+            assert latest_setup["report_url"].endswith("/ORB")
 
 
 def test_watchlist_session_filtering() -> None:
@@ -124,9 +126,11 @@ def test_watchlist_session_filtering() -> None:
         assert filtered_setups
         assert all(setup["session"] == "asia" for setup in filtered_setups)
         assert all(setup["strategy"] == "Breakout" for setup in filtered_setups)
+        assert all(setup["report_url"].endswith("Breakout") for setup in filtered_setups)
 
         response_default = client.get("/inplay/watchlists/momentum")
         assert response_default.status_code == 200
         combined_setups = response_default.json()["symbols"][0]["setups"]
         assert any(setup["session"] == "london" for setup in combined_setups)
         assert any(setup["session"] == "asia" for setup in combined_setups)
+        assert any(setup["report_url"].endswith("ORB") for setup in combined_setups)

--- a/services/inplay/tests/test_strategy_report_endpoint.py
+++ b/services/inplay/tests/test_strategy_report_endpoint.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from services.inplay.app.config import Settings
+from services.inplay.app.main import create_app
+from services.inplay.app.schemas import TickPayload
+
+
+pytestmark = pytest.mark.anyio
+
+
+class DummyAsyncClient:
+    def __init__(self, responses: Dict[str, Tuple[int, dict[str, object]]]):
+        self._responses = responses
+
+    async def __aenter__(self) -> "DummyAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def get(self, url: str, timeout: float | None = None) -> httpx.Response:
+        status_code, payload = self._responses.get(url, (404, {}))
+        request = httpx.Request("GET", url)
+        return httpx.Response(status_code=status_code, json=payload, request=request)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def test_strategy_report_endpoint_returns_combined_payload() -> None:
+    settings = Settings(
+        watchlists={"momentum": ["AAPL"]},
+        reports_base_url="http://reports.test/",
+        market_data_base_url="http://market.test/",
+    )
+    app = create_app(settings=settings, stream_factory=None)
+    state = app.state.inplay_state
+
+    payload = TickPayload(
+        symbol="AAPL",
+        strategy="ORB",
+        entry=190.0,
+        target=191.0,
+        stop=189.0,
+        probability=0.6,
+        status="pending",
+        session="london",
+        watchlists=["momentum"],
+    )
+    await state.apply_tick(payload)
+
+    responses = {
+        "http://reports.test/symbols/AAPL/summary": (
+            200,
+            {
+                "symbol": "AAPL",
+                "report": {"symbol": "AAPL", "daily": {}},
+                "risk": {"total_pnl": 5.2},
+            },
+        ),
+        "http://market.test/spot/AAPL": (
+            200,
+            {"symbol": "AAPL", "bid": 189.9, "ask": 190.1},
+        ),
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        with patch("services.inplay.app.main.httpx.AsyncClient", lambda *args, **kwargs: DummyAsyncClient(responses)):
+            response = await client.get("/inplay/setups/AAPL/ORB")
+
+    assert response.status_code == 200
+    payload_json = response.json()
+    assert payload_json["symbol"] == "AAPL"
+    assert payload_json["strategy"] == "ORB"
+    assert payload_json["setup"]["report_url"].endswith("/ORB")
+    assert payload_json["report"] == {"symbol": "AAPL", "daily": {}}
+    assert payload_json["risk"] == {"total_pnl": 5.2}
+    assert payload_json["market"] == {"symbol": "AAPL", "bid": 189.9, "ask": 190.1}
+
+
+async def test_strategy_report_endpoint_returns_404_when_setup_missing() -> None:
+    settings = Settings(watchlists={"momentum": ["AAPL"]})
+    app = create_app(settings=settings, stream_factory=None)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/inplay/setups/AAPL/ORB")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Setup introuvable"

--- a/services/web-dashboard/app/schemas.py
+++ b/services/web-dashboard/app/schemas.py
@@ -250,6 +250,10 @@ class InPlayStrategySetup(BaseModel):
         default=None,
         description="Trading session associated with the setup (london, new_york or asia)",
     )
+    report_url: str | None = Field(
+        default=None,
+        description="Lien vers le rapport détaillé pour la stratégie",
+    )
 
 
 class InPlaySymbolSetups(BaseModel):

--- a/services/web-dashboard/app/static/dashboard.js
+++ b/services/web-dashboard/app/static/dashboard.js
@@ -298,6 +298,11 @@
     if (typeof sessionRaw === "string" && sessionRaw.trim()) {
       session = sessionRaw.trim().toLowerCase();
     }
+    const reportUrlRaw = raw.report_url || raw.reportUrl || null;
+    let reportUrl = null;
+    if (typeof reportUrlRaw === "string" && reportUrlRaw.trim()) {
+      reportUrl = reportUrlRaw.trim();
+    }
 
     return {
       strategy,
@@ -311,6 +316,7 @@
           : null,
       updated_at: updatedAt,
       session,
+      report_url: reportUrl,
     };
   }
 
@@ -582,6 +588,19 @@
           appendMetric(metrics, "Stop", formatLevel(setup.stop));
           appendMetric(metrics, "Probabilité", formatProbability(setup.probability));
           card.appendChild(metrics);
+
+          if (setup.report_url) {
+            const actions = document.createElement("div");
+            actions.className = "setup-card__actions";
+            const reportLink = document.createElement("a");
+            reportLink.className = "button button--secondary";
+            reportLink.href = setup.report_url;
+            reportLink.target = "_blank";
+            reportLink.rel = "noopener noreferrer";
+            reportLink.textContent = "Voir le rapport";
+            actions.appendChild(reportLink);
+            card.appendChild(actions);
+          }
 
           container.appendChild(card);
           cardCount += 1;

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -680,6 +680,16 @@ body {
   color: var(--color-text);
 }
 
+.setup-card__actions {
+  margin-top: var(--space-sm);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.setup-card__actions .button {
+  text-decoration: none;
+}
+
 .inplay-setups__empty {
   margin: 0;
   text-align: center;

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -216,6 +216,18 @@
                   {% endif %}
                 </dd>
               </dl>
+              {% if setup.report_url %}
+              <div class="setup-card__actions">
+                <a
+                  class="button button--secondary"
+                  href="{{ setup.report_url }}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Voir le rapport
+                </a>
+              </div>
+              {% endif %}
             </article>
             {% endfor %}
             {% endfor %}

--- a/services/web-dashboard/tests/test_dashboard_template.py
+++ b/services/web-dashboard/tests/test_dashboard_template.py
@@ -14,3 +14,4 @@ def test_dashboard_template_includes_inplay_section(monkeypatch):
     assert "Setups en temps réel" in html
     assert "inplay-setups-status" in html
     assert "Instantané statique" in html
+    assert "Voir le rapport" in html


### PR DESCRIPTION
## Summary
- extend the in-play service schemas and state to carry optional report URLs and expose a new GET /inplay/setups/{symbol}/{strategy} endpoint that aggregates data from reports and market-data
- wire new report links through the dashboard data models and rendering, surfacing a "Voir le rapport" action on each setup card
- add tests covering the new in-play endpoint payload and ensuring the dashboard template includes the report link

## Testing
- `pytest services/inplay/tests/test_strategy_report_endpoint.py -vv`
- `pytest services/web-dashboard/tests/test_dashboard_template.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68dda4ab3b9083328b169600f8151b60