### PR TITLE
Add async report generation jobs to reports service

### DIFF
--- a/infra/migrations/versions/8f7b4a1e5b6c_add_report_jobs_table.py
+++ b/infra/migrations/versions/8f7b4a1e5b6c_add_report_jobs_table.py
@@ -1,0 +1,39 @@
+"""Add report jobs table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "8f7b4a1e5b6c"
+down_revision = "6efde1f16e9f"
+branch_labels = None
+depends_on = None
+
+status_enum = sa.Enum(
+    "pending",
+    "running",
+    "success",
+    "failure",
+    name="reportjobstatus",
+)
+
+
+def upgrade() -> None:
+    status_enum.create(op.get_bind(), checkfirst=True)
+    op.create_table(
+        "report_jobs",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("symbol", sa.String(length=64), nullable=True),
+        sa.Column("parameters", sa.JSON(), nullable=True),
+        sa.Column("status", status_enum, nullable=False, server_default="pending"),
+        sa.Column("file_path", sa.String(length=512), nullable=True),
+    )
+    op.create_index(op.f("ix_report_jobs_symbol"), "report_jobs", ["symbol"])
+    op.alter_column("report_jobs", "status", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_report_jobs_symbol"), table_name="report_jobs")
+    op.drop_table("report_jobs")
+    status_enum.drop(op.get_bind(), checkfirst=True)

--- a/services/reports/app/tables.py
+++ b/services/reports/app/tables.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from enum import Enum
+from uuid import uuid4
 
-from sqlalchemy import Date, DateTime, Enum as SAEnum, Float, Integer, String
+from sqlalchemy import Date, DateTime, Enum as SAEnum, Float, Integer, JSON, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from schemas.report import StrategyName, Timeframe, TradeOutcome
@@ -67,10 +69,31 @@ class ReportBenchmark(Base):
     return_value: Mapped[float] = mapped_column(Float, nullable=False)
 
 
+class ReportJobStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILURE = "failure"
+
+
+class ReportJob(Base):
+    __tablename__ = "report_jobs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    symbol: Mapped[str | None] = mapped_column(String(64), index=True, nullable=True)
+    parameters: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)
+    status: Mapped[ReportJobStatus] = mapped_column(
+        SAEnum(ReportJobStatus), nullable=False, default=ReportJobStatus.PENDING
+    )
+    file_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+
+
 __all__ = [
     "Base",
     "ReportDaily",
     "ReportIntraday",
     "ReportSnapshot",
     "ReportBenchmark",
+    "ReportJob",
+    "ReportJobStatus",
 ]


### PR DESCRIPTION
## Summary
- add a ReportJob model and migration to persist asynchronous report generation state
- introduce a Celery task that renders reports to PDF, stores the file, and updates job status
- expose endpoints for creating report jobs and querying their status, along with expanded FastAPI tests

## Testing
- pytest services/reports/tests/test_reports_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ddabb401088332b8849ca71589e6fa