### PR TITLE
Publish backtest summaries to reports service

### DIFF
--- a/infra/migrations/versions/9c4f7f5f7b2a_add_report_backtests_table.py
+++ b/infra/migrations/versions/9c4f7f5f7b2a_add_report_backtests_table.py
@@ -1,0 +1,51 @@
+"""Add report backtests table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "9c4f7f5f7b2a"
+down_revision = "8f7b4a1e5b6c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "report_backtests",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("strategy_id", sa.String(length=64), nullable=False),
+        sa.Column("strategy_name", sa.String(length=128), nullable=False),
+        sa.Column("strategy_type", sa.String(length=64), nullable=False),
+        sa.Column("symbol", sa.String(length=64), nullable=True),
+        sa.Column("account", sa.String(length=64), nullable=True),
+        sa.Column("initial_balance", sa.Float(), nullable=False),
+        sa.Column("trades", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_return", sa.Float(), nullable=False),
+        sa.Column("max_drawdown", sa.Float(), nullable=False),
+        sa.Column("equity_curve", sa.JSON(), nullable=False),
+        sa.Column("parameters", sa.JSON(), nullable=True),
+        sa.Column("tags", sa.JSON(), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("metrics_path", sa.String(length=512), nullable=True),
+        sa.Column("log_path", sa.String(length=512), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(op.f("ix_report_backtests_strategy_id"), "report_backtests", ["strategy_id"])
+    op.create_index(op.f("ix_report_backtests_symbol"), "report_backtests", ["symbol"])
+    op.create_index(op.f("ix_report_backtests_account"), "report_backtests", ["account"])
+    op.alter_column("report_backtests", "trades", server_default=None)
+    op.alter_column("report_backtests", "created_at", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_report_backtests_account"), table_name="report_backtests")
+    op.drop_index(op.f("ix_report_backtests_symbol"), table_name="report_backtests")
+    op.drop_index(op.f("ix_report_backtests_strategy_id"), table_name="report_backtests")
+    op.drop_table("report_backtests")

--- a/services/algo-engine/app/reports_client.py
+++ b/services/algo-engine/app/reports_client.py
@@ -1,0 +1,71 @@
+"""Client for publishing backtest results to the reports service."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Mapping
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+class ReportsPublisher:
+    """Simple HTTP client pushing analytics to the reports service."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        timeout: float | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        env_base_url = os.getenv("ALGO_ENGINE_REPORTS_BASE_URL", "http://reports:8000")
+        env_timeout = os.getenv("ALGO_ENGINE_REPORTS_TIMEOUT", "5.0")
+
+        self._base_url = (base_url or env_base_url).rstrip("/") or "http://reports:8000"
+        try:
+            timeout_value = timeout if timeout is not None else float(env_timeout)
+        except ValueError as exc:  # pragma: no cover - defensive validation
+            raise ValueError("ALGO_ENGINE_REPORTS_TIMEOUT must be numeric") from exc
+        self._timeout = timeout_value
+        self._client = client
+
+    def _get_client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(base_url=self._base_url, timeout=self._timeout)
+        return self._client
+
+    def publish_backtest(self, payload: Mapping[str, Any]) -> None:
+        """POST a backtest summary to the reports service."""
+
+        try:
+            client = self._get_client()
+            response = client.post("/reports/backtests", json=payload)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            text = exc.response.text
+            try:
+                body = exc.response.json()
+                detail = body.get("detail") if isinstance(body, Mapping) else None
+                if detail:
+                    text = json.dumps(body)
+            except ValueError:
+                pass
+            logger.warning(
+                "reports-service rejected backtest payload with status %s: %s",
+                exc.response.status_code,
+                text,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("failed to publish backtest summary to reports-service: %s", exc)
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+__all__ = ["ReportsPublisher"]

--- a/services/reports/app/tables.py
+++ b/services/reports/app/tables.py
@@ -69,6 +69,28 @@ class ReportBenchmark(Base):
     return_value: Mapped[float] = mapped_column(Float, nullable=False)
 
 
+class ReportBacktest(Base):
+    __tablename__ = "report_backtests"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    strategy_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    strategy_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    strategy_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    symbol: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    account: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    initial_balance: Mapped[float] = mapped_column(Float, nullable=False)
+    trades: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_return: Mapped[float] = mapped_column(Float, nullable=False)
+    max_drawdown: Mapped[float] = mapped_column(Float, nullable=False)
+    equity_curve: Mapped[list[float]] = mapped_column(JSON, nullable=False)
+    parameters: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)
+    tags: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    context: Mapped[dict[str, object] | None] = mapped_column("metadata", JSON, nullable=True)
+    metrics_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    log_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+
 class ReportJobStatus(str, Enum):
     PENDING = "pending"
     RUNNING = "running"
@@ -94,6 +116,7 @@ __all__ = [
     "ReportIntraday",
     "ReportSnapshot",
     "ReportBenchmark",
+    "ReportBacktest",
     "ReportJob",
     "ReportJobStatus",
 ]

--- a/services/tests/test_backtest_reporting.py
+++ b/services/tests/test_backtest_reporting.py
@@ -1,0 +1,141 @@
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+from fastapi.testclient import TestClient
+import pytest
+
+from services.reports.app import config as reports_config
+from services.reports.app.database import get_engine, reset_engine, session_scope
+from services.reports.app.main import app as reports_app
+from services.reports.app.tables import Base, ReportBacktest
+
+
+def _configure_reports_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "reports.db"
+    os.environ["REPORTS_DATABASE_URL"] = f"sqlite+pysqlite:///{db_path}"
+    reports_config.get_settings.cache_clear()
+    reset_engine()
+    engine = get_engine()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture
+def reports_client(tmp_path: Path) -> TestClient:
+    _configure_reports_database(tmp_path)
+    with TestClient(reports_app) as client:
+        client.get("/health")
+        yield client
+
+
+def _load_algo_main() -> Any:
+    package_root = Path(__file__).resolve().parents[1] / "algo-engine"
+
+    def _load_package(alias: str, path: Path) -> None:
+        spec = importlib.util.spec_from_file_location(alias, path / "__init__.py")
+        module = importlib.util.module_from_spec(spec)
+        module.__path__ = [str(path)]  # type: ignore[attr-defined]
+        sys.modules[alias] = module
+        assert spec and spec.loader
+        spec.loader.exec_module(module)  # type: ignore[attr-defined]
+
+    _load_package("algo_engine", package_root)
+    _load_package("algo_engine.app", package_root / "app")
+    _load_package("algo_engine.app.strategies", package_root / "app" / "strategies")
+
+    loader = importlib.machinery.SourceFileLoader(
+        "algo_engine.app.main",
+        str(package_root / "app" / "main.py"),
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[loader.name] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+ALGO_MAIN = _load_algo_main()
+
+
+def _build_reports_transport(client: TestClient) -> httpx.Client:
+    def handler(request: httpx.Request) -> httpx.Response:
+        json_payload = None
+        if request.content:
+            try:
+                json_payload = json.loads(request.content.decode())
+            except ValueError:
+                json_payload = None
+        response = client.request(
+            request.method,
+            request.url.path,
+            json=json_payload,
+        )
+        return httpx.Response(
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            content=response.content,
+        )
+
+    transport = httpx.MockTransport(handler)
+    return httpx.Client(base_url=str(client.base_url), transport=transport)
+
+
+def test_backtest_results_are_published_and_visible(
+    reports_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    os.environ.setdefault("ENTITLEMENTS_BYPASS", "1")
+
+    publisher_client = _build_reports_transport(reports_client)
+    publisher = ALGO_MAIN.ReportsPublisher(client=publisher_client, base_url=str(reports_client.base_url))
+    monkeypatch.setattr(ALGO_MAIN, "reports_publisher", publisher, raising=False)
+
+    # Reset strategy store for isolation
+    ALGO_MAIN.store._strategies.clear()  # type: ignore[attr-defined]
+
+    with TestClient(ALGO_MAIN.app) as algo_client:
+        create_payload = {
+            "name": "Momentum ORB",
+            "strategy_type": "orb",
+            "parameters": {"symbol": "AAPL"},
+            "metadata": {"account": "backtest-account", "report_strategy": "ORB"},
+        }
+        create_response = algo_client.post("/strategies", json=create_payload)
+        assert create_response.status_code == 201
+        strategy_id = create_response.json()["id"]
+
+        market_data = [
+            {"close": 101},
+            {"close": 103},
+            {"close": 99},
+            {"close": 112},
+        ]
+        backtest_response = algo_client.post(
+            f"/strategies/{strategy_id}/backtest",
+            json={"market_data": market_data, "initial_balance": 10_000.0},
+        )
+        assert backtest_response.status_code == 200
+
+    with session_scope() as session:
+        stored = session.query(ReportBacktest).one()
+        assert stored.strategy_id == strategy_id
+        assert stored.account == "backtest-account"
+        assert stored.symbol == "AAPL"
+        assert pytest.approx(stored.total_return, rel=1e-6) == backtest_response.json()["total_return"]
+
+    daily = reports_client.get("/reports/daily").json()
+    assert any(entry["account"] == "backtest-account" for entry in daily)
+
+    performance = reports_client.get("/reports/performance").json()
+    assert any(entry["account"] == "backtest-account" for entry in performance)
+
+    report = reports_client.get("/reports/AAPL").json()
+    assert report["daily"]["strategies"][0]["strategy"] == "ORB"
+
+    publisher.close()


### PR DESCRIPTION
## Summary
- add a reports client to the algo engine and publish backtest summaries after simulations
- expose a /reports/backtests endpoint that stores results and merges them into report calculations
- seed a migration and integration tests to verify backtest data surfaces in daily and performance metrics

## Testing
- pytest services/reports/tests/test_reports_api.py
- pytest services/tests/test_backtest_reporting.py


------
https://chatgpt.com/codex/tasks/task_e_68ddae94fdcc8332983460cf2edb3182