### PR TITLE
feat(web-dashboard): fetch portfolios from order router

### DIFF
--- a/services/web-dashboard/app/order_router_client.py
+++ b/services/web-dashboard/app/order_router_client.py
@@ -1,0 +1,66 @@
+"""HTTP client utilities for interacting with the order router service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from pydantic import ValidationError
+
+from schemas.order_router import PaginatedOrders
+
+
+class OrderRouterError(RuntimeError):
+    """Raised when the order router returns an unexpected response."""
+
+    def __init__(self, message: str, *, response: httpx.Response | None = None):
+        super().__init__(message)
+        self.response = response
+
+
+@dataclass
+class OrderRouterClient:
+    """Tiny wrapper around the order-router HTTP API."""
+
+    base_url: str
+    timeout: float = 5.0
+    transport: httpx.BaseTransport | None = None
+
+    def __post_init__(self) -> None:
+        self._client = httpx.Client(
+            base_url=self.base_url, timeout=self.timeout, transport=self.transport
+        )
+
+    def __enter__(self) -> "OrderRouterClient":
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def fetch_orders(self, *, limit: int = 100, offset: int = 0) -> PaginatedOrders:
+        """Return a slice of the orders log."""
+
+        response = self._client.get(
+            "/orders/log",
+            params={"limit": limit, "offset": offset},
+            headers={"accept": "application/json"},
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise exc
+        try:
+            payload = response.json()
+        except ValueError as exc:  # pragma: no cover - defensive guard for non JSON payloads
+            raise OrderRouterError("Order router returned non JSON payload", response=response) from exc
+        try:
+            return PaginatedOrders.model_validate(payload)
+        except ValidationError as exc:
+            raise OrderRouterError("Unable to parse order router payload", response=response) from exc
+
+
+__all__ = ["OrderRouterClient", "OrderRouterError"]

--- a/services/web-dashboard/app/schemas.py
+++ b/services/web-dashboard/app/schemas.py
@@ -344,4 +344,8 @@ class DashboardContext(BaseModel):
         default=None,
         description="Latest trading setups published by the InPlay service",
     )
+    data_sources: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Map describing whether each dataset comes from live services or fallback data",
+    )
 

--- a/services/web-dashboard/tests/test_dashboard_data_sources.py
+++ b/services/web-dashboard/tests/test_dashboard_data_sources.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import httpx
+import pytest
+
+from schemas.order_router import ExecutionRecord, OrderRecord, OrdersLogMetadata, PaginatedOrders
+
+from .utils import load_dashboard_app
+
+load_dashboard_app()
+
+from web_dashboard.app import data
+from web_dashboard.app.schemas import (
+    InPlayDashboardSetups,
+    PerformanceMetrics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_external_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub out external integrations not covered by the tests."""
+
+    monkeypatch.setattr(data, "_fetch_alerts_from_engine", lambda: [])
+    monkeypatch.setattr(data, "_fetch_performance_metrics", lambda: PerformanceMetrics(available=False))
+    monkeypatch.setattr(data, "load_reports_list", lambda: [])
+    monkeypatch.setattr(
+        data,
+        "_fetch_inplay_setups",
+        lambda: InPlayDashboardSetups(watchlists=[], fallback_reason=None),
+    )
+    monkeypatch.setattr(data, "_build_strategy_statuses", lambda: ([], []))
+
+
+def _build_sample_order(now: datetime | None = None) -> PaginatedOrders:
+    reference = now or datetime.utcnow()
+    execution = ExecutionRecord(
+        id=1,
+        order_id=1,
+        external_execution_id="fill-1",
+        correlation_id=None,
+        account_id="alpha",
+        symbol="AAPL",
+        quantity=2.0,
+        price=181.25,
+        fees=0.1,
+        liquidity="added",
+        executed_at=reference,
+        created_at=reference,
+    )
+    order = OrderRecord(
+        id=1,
+        external_order_id="ORD-1",
+        correlation_id=None,
+        account_id="alpha",
+        broker="ib",
+        venue="NASDAQ",
+        symbol="AAPL",
+        side="BUY",
+        order_type="market",
+        quantity=2.0,
+        filled_quantity=2.0,
+        limit_price=None,
+        stop_price=None,
+        status="filled",
+        time_in_force="DAY",
+        submitted_at=reference - timedelta(minutes=5),
+        expires_at=None,
+        notes=None,
+        created_at=reference - timedelta(minutes=6),
+        updated_at=reference,
+        executions=[execution],
+    )
+    metadata = OrdersLogMetadata(limit=100, offset=0, total=1)
+    return PaginatedOrders(items=[order], metadata=metadata)
+
+
+def test_dashboard_context_uses_order_router_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    paginated = _build_sample_order()
+
+    class DummyOrderRouterClient:
+        def __init__(self, *args, **kwargs):
+            self.limit: int | None = None
+
+        def __enter__(self) -> "DummyOrderRouterClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        def fetch_orders(self, *, limit: int = 100, offset: int = 0) -> PaginatedOrders:
+            self.limit = limit
+            return paginated
+
+    dummy_client = DummyOrderRouterClient()
+    monkeypatch.setattr(data, "OrderRouterClient", lambda *args, **kwargs: dummy_client)
+
+    context = data.load_dashboard_context()
+
+    assert context.data_sources.get("portfolios") == "live"
+    assert context.data_sources.get("transactions") == "live"
+    names = {portfolio.name for portfolio in context.portfolios}
+    assert "Growth" not in names
+    assert "Income" not in names
+    assert context.portfolios, "Expected at least one portfolio from order router"
+    assert context.portfolios[0].owner == "alpha"
+    assert any(holding.symbol == "AAPL" for holding in context.portfolios[0].holdings)
+
+    symbols = {transaction.symbol for transaction in context.transactions}
+    assert "BTC-USD" not in symbols
+    assert "AAPL" in symbols
+
+
+def test_dashboard_context_falls_back_when_order_router_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    request = httpx.Request("GET", "http://order-router/orders/log")
+
+    class FailingOrderRouterClient:
+        def __enter__(self) -> "FailingOrderRouterClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        def fetch_orders(self, *, limit: int = 100, offset: int = 0) -> PaginatedOrders:
+            raise httpx.ConnectError("unreachable", request=request)
+
+    monkeypatch.setattr(data, "OrderRouterClient", lambda *args, **kwargs: FailingOrderRouterClient())
+
+    context = data.load_dashboard_context()
+
+    assert context.data_sources.get("portfolios") == "fallback"
+    assert context.data_sources.get("transactions") == "fallback"
+    names = {portfolio.name for portfolio in context.portfolios}
+    assert "Growth" in names
+    assert any(tx.symbol == "BTC-USD" for tx in context.transactions)


### PR DESCRIPTION
## Summary
- replace static portfolio and transaction snapshots with data sourced from the order-router API and expose dataset provenance in the dashboard context
- add a dedicated HTTPX client for the order router together with tests that mock upstream services
- surface degraded mode messaging in the dashboard UI and document the new behaviour and configuration options

## Testing
- pytest services/web-dashboard/tests/test_dashboard_data_sources.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ddb5d279bc8332a882239b8e190f49