### PR TITLE
feat(designer): enrich blocks and add validation coverage

### DIFF
--- a/services/web-dashboard/src/strategies/designer/StrategyBlock.jsx
+++ b/services/web-dashboard/src/strategies/designer/StrategyBlock.jsx
@@ -82,6 +82,117 @@ function IndicatorFields({ node, onChange }) {
   );
 }
 
+function IndicatorMacdFields({ node, onChange }) {
+  return (
+    <div className="designer-field-grid">
+      <Field label="Source">
+        <select
+          value={node.config.source || "close"}
+          onChange={(event) => onChange({ ...node.config, source: event.target.value })}
+        >
+          <option value="close">Clôture</option>
+          <option value="open">Ouverture</option>
+          <option value="high">Haut</option>
+          <option value="low">Bas</option>
+        </select>
+      </Field>
+      <Field label="Période rapide">
+        <input
+          type="number"
+          min="1"
+          value={node.config.fastPeriod || ""}
+          onChange={(event) => onChange({ ...node.config, fastPeriod: event.target.value })}
+        />
+      </Field>
+      <Field label="Période lente">
+        <input
+          type="number"
+          min="1"
+          value={node.config.slowPeriod || ""}
+          onChange={(event) => onChange({ ...node.config, slowPeriod: event.target.value })}
+        />
+      </Field>
+      <Field label="Période signal">
+        <input
+          type="number"
+          min="1"
+          value={node.config.signalPeriod || ""}
+          onChange={(event) => onChange({ ...node.config, signalPeriod: event.target.value })}
+        />
+      </Field>
+    </div>
+  );
+}
+
+function IndicatorBollingerFields({ node, onChange }) {
+  return (
+    <div className="designer-field-grid">
+      <Field label="Source">
+        <select
+          value={node.config.source || "close"}
+          onChange={(event) => onChange({ ...node.config, source: event.target.value })}
+        >
+          <option value="close">Clôture</option>
+          <option value="open">Ouverture</option>
+          <option value="high">Haut</option>
+          <option value="low">Bas</option>
+        </select>
+      </Field>
+      <Field label="Période">
+        <input
+          type="number"
+          min="1"
+          value={node.config.period || ""}
+          onChange={(event) => onChange({ ...node.config, period: event.target.value })}
+        />
+      </Field>
+      <Field label="Déviation">
+        <input
+          type="number"
+          step="0.1"
+          min="0"
+          value={node.config.deviation || ""}
+          onChange={(event) => onChange({ ...node.config, deviation: event.target.value })}
+        />
+      </Field>
+    </div>
+  );
+}
+
+function IndicatorAtrFields({ node, onChange }) {
+  return (
+    <div className="designer-field-grid">
+      <Field label="Source">
+        <select
+          value={node.config.source || "hlc3"}
+          onChange={(event) => onChange({ ...node.config, source: event.target.value })}
+        >
+          <option value="hlc3">HLC3</option>
+          <option value="close">Clôture</option>
+          <option value="high">Haut</option>
+          <option value="low">Bas</option>
+        </select>
+      </Field>
+      <Field label="Période">
+        <input
+          type="number"
+          min="1"
+          value={node.config.period || ""}
+          onChange={(event) => onChange({ ...node.config, period: event.target.value })}
+        />
+      </Field>
+      <Field label="Lissage">
+        <input
+          type="number"
+          min="1"
+          value={node.config.smoothing || ""}
+          onChange={(event) => onChange({ ...node.config, smoothing: event.target.value })}
+        />
+      </Field>
+    </div>
+  );
+}
+
 function LogicFields({ node, onChange }) {
   return (
     <Field label="Mode">
@@ -90,6 +201,81 @@ function LogicFields({ node, onChange }) {
         <option value="any">Au moins une condition</option>
       </select>
     </Field>
+  );
+}
+
+function MarketCrossFields({ node, onChange }) {
+  return (
+    <div className="designer-field-grid">
+      <Field label="Direction du croisement">
+        <select
+          value={node.config.direction || "above"}
+          onChange={(event) => onChange({ ...node.config, direction: event.target.value })}
+        >
+          <option value="above">Croise au-dessus</option>
+          <option value="below">Croise sous</option>
+        </select>
+      </Field>
+      <Field label="Fenêtre d'observation">
+        <input
+          type="number"
+          min="1"
+          value={node.config.lookback || ""}
+          onChange={(event) => onChange({ ...node.config, lookback: event.target.value })}
+        />
+      </Field>
+    </div>
+  );
+}
+
+function MarketVolumeFields({ node, onChange }) {
+  return (
+    <div className="designer-field-grid">
+      <Field label="Opérateur">
+        <select
+          value={node.config.operator || "gt"}
+          onChange={(event) => onChange({ ...node.config, operator: event.target.value })}
+        >
+          <option value="gt">Supérieur à</option>
+          <option value="lt">Inférieur à</option>
+          <option value="gte">Supérieur ou égal</option>
+          <option value="lte">Inférieur ou égal</option>
+          <option value="eq">Égal</option>
+          <option value="neq">Différent</option>
+        </select>
+      </Field>
+      <Field label="Seuil">
+        <input
+          type="number"
+          min="0"
+          value={node.config.value || ""}
+          onChange={(event) => onChange({ ...node.config, value: event.target.value })}
+        />
+      </Field>
+      <Field label="Intervalle">
+        <input
+          type="text"
+          value={node.config.timeframe || ""}
+          onChange={(event) => onChange({ ...node.config, timeframe: event.target.value })}
+        />
+      </Field>
+    </div>
+  );
+}
+
+function NegationFields() {
+  return (
+    <p className="text text--muted">
+      Ce bloc inverse le résultat de son enfant direct.
+    </p>
+  );
+}
+
+function GroupFields() {
+  return (
+    <p className="text text--muted">
+      Utilisez ce regroupement pour prioriser l'évaluation des sous-conditions.
+    </p>
   );
 }
 
@@ -119,6 +305,119 @@ function ActionFields({ node, onChange }) {
   );
 }
 
+function TakeProfitFields({ node, onChange }) {
+  return (
+    <div className="designer-field-grid">
+      <Field label="Type de cible">
+        <select
+          value={node.config.mode || "percent"}
+          onChange={(event) => onChange({ ...node.config, mode: event.target.value })}
+        >
+          <option value="percent">Pourcentage</option>
+          <option value="price">Prix</option>
+        </select>
+      </Field>
+      <Field label="Valeur">
+        <input
+          type="number"
+          step="0.1"
+          value={node.config.value || ""}
+          onChange={(event) => onChange({ ...node.config, value: event.target.value })}
+        />
+      </Field>
+      <Field label="Part de la position">
+        <select
+          value={node.config.size || "full"}
+          onChange={(event) => onChange({ ...node.config, size: event.target.value })}
+        >
+          <option value="full">100 %</option>
+          <option value="half">50 %</option>
+          <option value="custom">Personnalisé</option>
+        </select>
+      </Field>
+      {node.config.size === "custom" ? (
+        <Field label="Taille personnalisée">
+          <input
+            type="number"
+            step="0.1"
+            value={node.config.customSize || ""}
+            onChange={(event) => onChange({ ...node.config, customSize: event.target.value })}
+          />
+        </Field>
+      ) : null}
+    </div>
+  );
+}
+
+function StopLossFields({ node, onChange }) {
+  const handleToggle = (event) => {
+    onChange({ ...node.config, trailing: event.target.checked });
+  };
+  return (
+    <div className="designer-field-grid">
+      <Field label="Type de seuil">
+        <select
+          value={node.config.mode || "percent"}
+          onChange={(event) => onChange({ ...node.config, mode: event.target.value })}
+        >
+          <option value="percent">Pourcentage</option>
+          <option value="price">Prix</option>
+        </select>
+      </Field>
+      <Field label="Valeur">
+        <input
+          type="number"
+          step="0.1"
+          value={node.config.value || ""}
+          onChange={(event) => onChange({ ...node.config, value: event.target.value })}
+        />
+      </Field>
+      <label className="designer-field designer-field--inline">
+        <input type="checkbox" checked={Boolean(node.config.trailing)} onChange={handleToggle} />
+        <span className="designer-field__label">Activer le trailing stop</span>
+      </label>
+    </div>
+  );
+}
+
+function ClosePositionFields({ node, onChange }) {
+  return (
+    <Field label="Cible">
+      <select
+        value={node.config.side || "all"}
+        onChange={(event) => onChange({ ...node.config, side: event.target.value })}
+      >
+        <option value="all">Tout fermer</option>
+        <option value="long">Positions longues</option>
+        <option value="short">Positions courtes</option>
+      </select>
+    </Field>
+  );
+}
+
+function AlertFields({ node, onChange }) {
+  return (
+    <div className="designer-field-grid">
+      <Field label="Canal">
+        <select
+          value={node.config.channel || "email"}
+          onChange={(event) => onChange({ ...node.config, channel: event.target.value })}
+        >
+          <option value="email">E-mail</option>
+          <option value="sms">SMS</option>
+          <option value="webhook">Webhook</option>
+        </select>
+      </Field>
+      <Field label="Message">
+        <textarea
+          value={node.config.message || ""}
+          onChange={(event) => onChange({ ...node.config, message: event.target.value })}
+        />
+      </Field>
+    </div>
+  );
+}
+
 function DelayFields({ node, onChange }) {
   return (
     <Field label="Délai (secondes)">
@@ -136,12 +435,34 @@ function renderFields(node, onChange) {
   switch (node.type) {
     case "condition":
       return <ConditionFields node={node} onChange={onChange} />;
+    case "market_cross":
+      return <MarketCrossFields node={node} onChange={onChange} />;
+    case "market_volume":
+      return <MarketVolumeFields node={node} onChange={onChange} />;
     case "indicator":
       return <IndicatorFields node={node} onChange={onChange} />;
+    case "indicator_macd":
+      return <IndicatorMacdFields node={node} onChange={onChange} />;
+    case "indicator_bollinger":
+      return <IndicatorBollingerFields node={node} onChange={onChange} />;
+    case "indicator_atr":
+      return <IndicatorAtrFields node={node} onChange={onChange} />;
     case "logic":
       return <LogicFields node={node} onChange={onChange} />;
+    case "negation":
+      return <NegationFields node={node} onChange={onChange} />;
+    case "group":
+      return <GroupFields node={node} onChange={onChange} />;
     case "action":
       return <ActionFields node={node} onChange={onChange} />;
+    case "take_profit":
+      return <TakeProfitFields node={node} onChange={onChange} />;
+    case "stop_loss":
+      return <StopLossFields node={node} onChange={onChange} />;
+    case "close_position":
+      return <ClosePositionFields node={node} onChange={onChange} />;
+    case "alert":
+      return <AlertFields node={node} onChange={onChange} />;
     case "delay":
       return <DelayFields node={node} onChange={onChange} />;
     default:

--- a/services/web-dashboard/src/strategies/designer/StrategyDesigner.jsx
+++ b/services/web-dashboard/src/strategies/designer/StrategyDesigner.jsx
@@ -4,6 +4,373 @@ import DesignerCanvas from "./DesignerCanvas.jsx";
 import { BLOCK_DEFINITIONS, cloneDefaultConfig } from "./designerConstants.js";
 import { buildExports } from "./serializer.js";
 
+const INDICATOR_TYPES = new Set(
+  Object.keys(BLOCK_DEFINITIONS).filter((type) => type.startsWith("indicator"))
+);
+
+const OPERATOR_SIGNS = {
+  gt: ">",
+  gte: "≥",
+  lt: "<",
+  lte: "≤",
+  eq: "=",
+  neq: "≠",
+};
+
+function asNumber(value) {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? null : numeric;
+}
+
+function checkRequirements(node, definition, path, errors) {
+  const validation = definition?.validation || {};
+  const config = node?.config || {};
+  const children = Array.isArray(node?.children) ? node.children : [];
+
+  const requirements = Array.isArray(validation.required) ? validation.required : [];
+  for (const requirement of requirements) {
+    const field = typeof requirement === "string" ? requirement : requirement.field;
+    const label =
+      typeof requirement === "string"
+        ? requirement
+        : requirement.label || requirement.field || requirement.toString();
+    const value = config[field];
+    const isEmpty =
+      value === undefined ||
+      value === null ||
+      (typeof value === "string" && value.trim() === "");
+    if (isEmpty) {
+      errors.push(`${path} — ${definition.label}: le champ « ${label} » est requis.`);
+    }
+  }
+
+  if (
+    typeof validation.minChildren === "number" &&
+    children.length < validation.minChildren
+  ) {
+    errors.push(
+      `${path} — ${definition.label}: au moins ${validation.minChildren} bloc(s) enfant sont requis.`
+    );
+  }
+
+  if (
+    typeof validation.maxChildren === "number" &&
+    children.length > validation.maxChildren
+  ) {
+    errors.push(
+      `${path} — ${definition.label}: maximum ${validation.maxChildren} bloc(s) enfant autorisés.`
+    );
+  }
+
+  if (Array.isArray(definition.accepts)) {
+    if (definition.accepts.length === 0 && children.length) {
+      errors.push(`${path} — ${definition.label}: n'accepte pas de bloc enfant.`);
+    } else if (definition.accepts.length > 0) {
+      children.forEach((child, index) => {
+        if (!definition.accepts.includes(child.type)) {
+          const childLabel = BLOCK_DEFINITIONS[child.type]?.label || child.type;
+          errors.push(
+            `${path} — ${definition.label}: le bloc enfant #${index + 1} (${childLabel}) est incompatible.`
+          );
+        }
+      });
+    }
+  }
+
+  return children;
+}
+
+function validateIndicatorNode(node, path, errors) {
+  const definition = BLOCK_DEFINITIONS[node.type];
+  if (!definition) {
+    errors.push(`${path}: type d'indicateur inconnu (${node.type}).`);
+    return null;
+  }
+  checkRequirements(node, definition, path, errors);
+  const config = node.config || {};
+
+  switch (node.type) {
+    case "indicator": {
+      const kind = (config.kind || "sma").toUpperCase();
+      const source = config.source || "source";
+      const period = config.period || "?";
+      return `${kind}(${source}, ${period})`;
+    }
+    case "indicator_macd": {
+      const source = config.source || "source";
+      return `MACD(${source}, ${config.fastPeriod || "?"}, ${config.slowPeriod || "?"}, ${
+        config.signalPeriod || "?"
+      })`;
+    }
+    case "indicator_bollinger": {
+      const source = config.source || "source";
+      return `BOLL(${source}, ${config.period || "?"}, ${config.deviation || "?"})`;
+    }
+    case "indicator_atr": {
+      const source = config.source || "hlc3";
+      return `ATR(${source}, ${config.period || "?"}, ${config.smoothing || "?"})`;
+    }
+    default:
+      errors.push(`${path}: type d'indicateur non géré (${node.type}).`);
+      return null;
+  }
+}
+
+function validateConditionNode(node, path, errors) {
+  const definition = BLOCK_DEFINITIONS[node.type];
+  if (!definition) {
+    errors.push(`${path}: type de condition inconnu (${node.type}).`);
+    return null;
+  }
+  const children = checkRequirements(node, definition, path, errors);
+  const config = node.config || {};
+
+  switch (node.type) {
+    case "condition": {
+      let field = config.field || "champ";
+      const indicatorChild = children.find((child) => INDICATOR_TYPES.has(child.type));
+      if (indicatorChild) {
+        const indicatorExpression = validateIndicatorNode(
+          indicatorChild,
+          `${path} > ${BLOCK_DEFINITIONS[indicatorChild.type]?.label || indicatorChild.type}`,
+          errors
+        );
+        if (indicatorExpression) {
+          field = indicatorExpression;
+        }
+      }
+      const operator = OPERATOR_SIGNS[config.operator] || config.operator || "?";
+      const value = config.value ?? "?";
+      return `${field} ${operator} ${value}`;
+    }
+    case "market_cross": {
+      const lookback = asNumber(config.lookback);
+      if (lookback === null || lookback <= 0) {
+        errors.push(
+          `${path} — ${definition.label}: la fenêtre d'observation doit être un entier positif.`
+        );
+      }
+      const [leftChild, rightChild] = children;
+      if (leftChild && !INDICATOR_TYPES.has(leftChild.type)) {
+        errors.push(
+          `${path} — ${definition.label}: seuls des indicateurs peuvent être utilisés.`
+        );
+      }
+      if (rightChild && !INDICATOR_TYPES.has(rightChild.type)) {
+        errors.push(
+          `${path} — ${definition.label}: seuls des indicateurs peuvent être utilisés.`
+        );
+      }
+      const leftExpr =
+        leftChild && INDICATOR_TYPES.has(leftChild.type)
+          ? validateIndicatorNode(leftChild, `${path} > Indicateur #1`, errors)
+          : null;
+      const rightExpr =
+        rightChild && INDICATOR_TYPES.has(rightChild.type)
+          ? validateIndicatorNode(rightChild, `${path} > Indicateur #2`, errors)
+          : null;
+      if (!leftExpr || !rightExpr) {
+        return null;
+      }
+      const direction = config.direction === "below" ? "croise sous" : "croise au-dessus";
+      const lookbackLabel = config.lookback ? ` (fenêtre ${config.lookback})` : "";
+      return `${leftExpr} ${direction} ${rightExpr}${lookbackLabel}`;
+    }
+    case "market_volume": {
+      const numericValue = asNumber(config.value);
+      if (numericValue === null || numericValue < 0) {
+        errors.push(
+          `${path} — ${definition.label}: le seuil de volume doit être un nombre positif.`
+        );
+      }
+      const operator = OPERATOR_SIGNS[config.operator] || config.operator || "?";
+      const timeframe = config.timeframe ? ` (${config.timeframe})` : "";
+      return `Volume ${operator} ${config.value ?? "?"}${timeframe}`;
+    }
+    case "logic": {
+      const joiner = config.mode === "any" ? " OU " : " ET ";
+      const parts = children
+        .map((child, index) =>
+          validateConditionNode(child, `${path} > Bloc ${index + 1}`, errors)
+        )
+        .filter(Boolean);
+      if (!parts.length) {
+        return null;
+      }
+      return parts.map((part) => `(${part})`).join(joiner);
+    }
+    case "negation": {
+      const [child] = children;
+      if (!child) {
+        return null;
+      }
+      const target = validateConditionNode(
+        child,
+        `${path} > ${BLOCK_DEFINITIONS[child.type]?.label || child.type}`,
+        errors
+      );
+      return target ? `NON (${target})` : null;
+    }
+    case "group": {
+      const parts = children
+        .map((child, index) =>
+          validateConditionNode(child, `${path} > Bloc ${index + 1}`, errors)
+        )
+        .filter(Boolean);
+      if (!parts.length) {
+        return null;
+      }
+      return `(${parts.join(" ET ")})`;
+    }
+    default:
+      if (INDICATOR_TYPES.has(node.type)) {
+        return validateIndicatorNode(node, path, errors);
+      }
+      errors.push(`${path}: type de condition non géré (${node.type}).`);
+      return null;
+  }
+}
+
+function validateActionNode(node, path, errors, warnings) {
+  const definition = BLOCK_DEFINITIONS[node.type];
+  if (!definition) {
+    errors.push(`${path}: type d'action inconnu (${node.type}).`);
+    return null;
+  }
+  const children = checkRequirements(node, definition, path, errors);
+  if (children.length) {
+    warnings.push(
+      `${path} — ${definition.label}: les blocs enfants seront ignorés lors de l'exécution.`
+    );
+  }
+  const config = node.config || {};
+
+  switch (node.type) {
+    case "action": {
+      const action = (config.action || "").toUpperCase() || "ACTION";
+      return `${action} x${config.size || "?"}`;
+    }
+    case "take_profit": {
+      const valueNumber = asNumber(config.value);
+      if (valueNumber === null || valueNumber <= 0) {
+        errors.push(
+          `${path} — ${definition.label}: renseignez une valeur numérique strictement positive.`
+        );
+      }
+      if (config.size === "custom") {
+        const customValue = asNumber(config.customSize);
+        if (customValue === null || customValue <= 0) {
+          errors.push(
+            `${path} — ${definition.label}: la taille personnalisée doit être un nombre positif.`
+          );
+        }
+      }
+      const suffix = config.mode === "price" ? " (prix)" : "%";
+      let sizeLabel = "";
+      if (config.size === "half") {
+        sizeLabel = " (50 %)";
+      } else if (config.size === "custom") {
+        sizeLabel = ` (${config.customSize || "?"})`;
+      } else {
+        sizeLabel = " (100 %)";
+      }
+      return `Take-profit ${config.value || "?"}${suffix}${sizeLabel}`;
+    }
+    case "stop_loss": {
+      const valueNumber = asNumber(config.value);
+      if (valueNumber === null || valueNumber <= 0) {
+        errors.push(
+          `${path} — ${definition.label}: renseignez une valeur numérique strictement positive.`
+        );
+      }
+      const suffix = config.mode === "price" ? " (prix)" : "%";
+      const trailing = config.trailing ? " (trailing)" : "";
+      return `Stop-loss ${config.value || "?"}${suffix}${trailing}`;
+    }
+    case "close_position": {
+      const mapping = {
+        all: "Fermer toutes les positions",
+        long: "Fermer les positions longues",
+        short: "Fermer les positions courtes",
+      };
+      return mapping[config.side] || `Fermer (${config.side || "?"})`;
+    }
+    case "alert": {
+      return `Alerte ${config.channel || "?"}: ${config.message || "?"}`;
+    }
+    case "delay": {
+      const seconds = asNumber(config.seconds);
+      if (seconds === null || seconds < 0) {
+        errors.push(
+          `${path} — ${definition.label}: le délai doit être un nombre positif.`
+        );
+      }
+      return `Attendre ${config.seconds || "?"}s`;
+    }
+    default:
+      errors.push(`${path}: type d'action non géré (${node.type}).`);
+      return null;
+  }
+}
+
+export function validateStrategy(conditions, actions) {
+  const errors = [];
+  const warnings = [];
+
+  const conditionDescriptions = [];
+  if (!conditions || !conditions.length) {
+    errors.push("Ajoutez au moins une condition.");
+  } else {
+    conditions.forEach((node, index) => {
+      const description = validateConditionNode(node, `Condition #${index + 1}`, errors);
+      if (description) {
+        conditionDescriptions.push(description);
+      }
+    });
+  }
+
+  const actionDescriptions = [];
+  if (!actions || !actions.length) {
+    errors.push("Ajoutez au moins une action.");
+  } else {
+    actions.forEach((node, index) => {
+      const description = validateActionNode(node, `Action #${index + 1}`, errors, warnings);
+      if (description) {
+        actionDescriptions.push(description);
+      }
+    });
+  }
+
+  const conditionExpression =
+    conditionDescriptions.length === 0
+      ? null
+      : conditionDescriptions.length === 1
+      ? conditionDescriptions[0]
+      : conditionDescriptions.map((desc) => `(${desc})`).join(" ET ");
+
+  const actionSummary =
+    actionDescriptions.length === 0
+      ? null
+      : actionDescriptions.join(" puis ");
+
+  const rule =
+    conditionExpression && actionSummary
+      ? `${conditionExpression} ⇒ ${actionSummary}`
+      : null;
+
+  return {
+    errors,
+    warnings,
+    conditionExpression,
+    actionSummary,
+    rule,
+    isValid: errors.length === 0,
+  };
+}
+
 function createNode(type, idRef) {
   const definition = BLOCK_DEFINITIONS[type];
   return {
@@ -108,6 +475,10 @@ export default function StrategyDesigner({
     () => buildExports(name, conditions, actions),
     [name, conditions, actions]
   );
+  const validation = useMemo(
+    () => validateStrategy(conditions, actions),
+    [conditions, actions]
+  );
 
   const handleDrop = ({ section, targetId, type }) => {
     const definition = BLOCK_DEFINITIONS[type];
@@ -170,6 +541,13 @@ export default function StrategyDesigner({
       setStatus({ type: "error", message: "Le nom de la stratégie est obligatoire." });
       return;
     }
+    if (validation.errors.length) {
+      setStatus({
+        type: "error",
+        message: "Corrigez les erreurs de configuration avant de sauvegarder.",
+      });
+      return;
+    }
     setStatus({ type: "saving", message: "Enregistrement en cours…" });
     setLastResponse(null);
 
@@ -221,6 +599,12 @@ export default function StrategyDesigner({
       });
     }
   };
+
+  const validationState = validation.errors.length
+    ? "error"
+    : validation.warnings.length
+    ? "warning"
+    : "success";
 
   return (
     <form className="strategy-designer" onSubmit={handleSave} aria-labelledby="designer-title">
@@ -275,6 +659,67 @@ export default function StrategyDesigner({
           onConfigChange={handleConfigChange}
           onRemove={handleRemove}
         />
+        <section
+          className="designer-panel designer-panel--validation"
+          aria-labelledby="validation-title"
+        >
+          <div className="designer-panel__header">
+            <h2 id="validation-title" className="heading heading--md">
+              Validation temps réel
+            </h2>
+            <p className="text text--muted">
+              Contrôlez la cohérence de la règle lors de la composition.
+            </p>
+          </div>
+          <div className="designer-panel__body">
+            <div
+              className={`designer-validation designer-validation--${validationState}`}
+              data-testid="designer-validation"
+              role="region"
+              aria-live="polite"
+            >
+              {validation.errors.length ? (
+                <>
+                  <h3 className="heading heading--sm">Erreurs de configuration</h3>
+                  <ul>
+                    {validation.errors.map((error, index) => (
+                      <li key={index}>{error}</li>
+                    ))}
+                  </ul>
+                  {validation.warnings.length ? (
+                    <>
+                      <h4 className="heading heading--xs">Avertissements</h4>
+                      <ul>
+                        {validation.warnings.map((warning, index) => (
+                          <li key={`warning-${index}`}>{warning}</li>
+                        ))}
+                      </ul>
+                    </>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <p className="text">
+                    Règle valide : vous pouvez sauvegarder ou exporter la stratégie.
+                  </p>
+                  {validation.rule ? (
+                    <p className="text text--muted designer-validation__rule">{validation.rule}</p>
+                  ) : null}
+                  {validation.warnings.length ? (
+                    <>
+                      <h4 className="heading heading--xs">Avertissements</h4>
+                      <ul>
+                        {validation.warnings.map((warning, index) => (
+                          <li key={`warning-${index}`}>{warning}</li>
+                        ))}
+                      </ul>
+                    </>
+                  ) : null}
+                </>
+              )}
+            </div>
+          </div>
+        </section>
         <section className="designer-panel designer-panel--preview" aria-labelledby="preview-title">
           <div className="designer-panel__header">
             <h2 id="preview-title" className="heading heading--md">

--- a/services/web-dashboard/src/strategies/designer/__tests__/StrategyBlock.test.jsx
+++ b/services/web-dashboard/src/strategies/designer/__tests__/StrategyBlock.test.jsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import StrategyBlock from "../StrategyBlock.jsx";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+expect.extend(matchers.default ?? matchers);
+
+describe("StrategyBlock advanced fields", () => {
+  const baseActions = {
+    onDrop: vi.fn(),
+    onConfigChange: vi.fn(),
+    onRemove: vi.fn(),
+  };
+
+  it("renders MACD indicator specific inputs", () => {
+    render(
+      <StrategyBlock
+        node={{
+          id: "macd-1",
+          type: "indicator_macd",
+          config: {
+            source: "close",
+            fastPeriod: "12",
+            slowPeriod: "26",
+            signalPeriod: "9",
+          },
+          children: [],
+        }}
+        section="conditions"
+        {...baseActions}
+      />
+    );
+
+    expect(screen.getByLabelText("Période rapide")).toHaveValue(12);
+    expect(screen.getByLabelText("Période lente")).toHaveValue(26);
+    expect(screen.getByLabelText("Période signal")).toHaveValue(9);
+  });
+
+  it("displays take-profit configuration fields", () => {
+    render(
+      <StrategyBlock
+        node={{
+          id: "tp-1",
+          type: "take_profit",
+          config: { mode: "percent", value: "5", size: "half" },
+          children: [],
+        }}
+        section="actions"
+        {...baseActions}
+      />
+    );
+
+    expect(screen.getByLabelText("Type de cible")).toHaveValue("percent");
+    expect(screen.getByLabelText("Valeur")).toHaveValue(5);
+    expect(screen.getByLabelText("Part de la position")).toHaveValue("half");
+  });
+});

--- a/services/web-dashboard/src/strategies/designer/__tests__/StrategyValidation.test.jsx
+++ b/services/web-dashboard/src/strategies/designer/__tests__/StrategyValidation.test.jsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { validateStrategy } from "../StrategyDesigner.jsx";
+
+const indicator = (id, type, config) => ({ id, type, config, children: [] });
+
+const emptyNode = (id, type, config = {}, children = []) => ({ id, type, config, children });
+
+describe("validateStrategy", () => {
+  it("accepts a complex configuration", () => {
+    const conditions = [
+      emptyNode("logic-1", "logic", { mode: "all" }, [
+        emptyNode(
+          "cond-1",
+          "condition",
+          { field: "close", operator: "gt", value: "100" },
+          [indicator("ind-1", "indicator_macd", { source: "close", fastPeriod: "12", slowPeriod: "26", signalPeriod: "9" })]
+        ),
+        emptyNode(
+          "cross-1",
+          "market_cross",
+          { direction: "above", lookback: "5" },
+          [
+            indicator("ind-2", "indicator_bollinger", { source: "close", period: "20", deviation: "2" }),
+            indicator("ind-3", "indicator_atr", { source: "hlc3", period: "14", smoothing: "14" }),
+          ]
+        ),
+        emptyNode(
+          "neg-1",
+          "negation",
+          {},
+          [
+            emptyNode("vol-1", "market_volume", { operator: "gt", value: "100000", timeframe: "1h" }),
+          ]
+        ),
+      ]),
+    ];
+
+    const actions = [
+      emptyNode("act-1", "action", { action: "buy", size: "2" }),
+      emptyNode("tp-1", "take_profit", { mode: "percent", value: "5", size: "half" }),
+      emptyNode("sl-1", "stop_loss", { mode: "percent", value: "2", trailing: true }),
+      emptyNode("alert-1", "alert", { channel: "email", message: "Condition atteinte" }),
+    ];
+
+    const result = validateStrategy(conditions, actions);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.rule).toContain("MACD");
+    expect(result.rule).toContain("Take-profit");
+    expect(result.rule).toContain("Stop-loss");
+  });
+
+  it("highlights missing configuration", () => {
+    const conditions = [
+      emptyNode(
+        "cross-invalid",
+        "market_cross",
+        { direction: "above", lookback: "0" },
+        [indicator("ind-err", "indicator_macd", { source: "", fastPeriod: "", slowPeriod: "", signalPeriod: "" })]
+      ),
+    ];
+    const actions = [emptyNode("tp-invalid", "take_profit", { mode: "percent", value: "", size: "full" })];
+
+    const result = validateStrategy(conditions, actions);
+
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors.join(" ")).toMatch(/fenêtre d'observation/i);
+    expect(result.errors.join(" ")).toMatch(/Take-profit/i);
+  });
+});

--- a/services/web-dashboard/src/strategies/designer/designerConstants.js
+++ b/services/web-dashboard/src/strategies/designer/designerConstants.js
@@ -1,22 +1,68 @@
 export const DATA_TRANSFER_FORMAT = "application/x-strategy-block";
 
+const CONDITION_INDICATOR_TYPES = ["indicator", "indicator_macd", "indicator_bollinger", "indicator_atr"];
+
 export const BLOCK_DEFINITIONS = {
   condition: {
     type: "condition",
     label: "Condition",
     description:
       "Comparer un champ de marché à une valeur cible et définir le déclencheur d'une règle.",
-    accepts: ["indicator", "logic", "condition"],
+    accepts: CONDITION_INDICATOR_TYPES,
     category: "conditions",
     defaultConfig: {
       field: "close",
       operator: "gt",
       value: "100",
     },
+    validation: {
+      required: [
+        { field: "field", label: "Champ" },
+        { field: "operator", label: "Opérateur" },
+        { field: "value", label: "Valeur" },
+      ],
+      maxChildren: 1,
+    },
+  },
+  market_cross: {
+    type: "market_cross",
+    label: "Croisement",
+    description:
+      "Détecter le croisement de deux indicateurs (ex. MACD vs moyenne mobile).",
+    accepts: CONDITION_INDICATOR_TYPES,
+    category: "conditions",
+    defaultConfig: {
+      direction: "above",
+      lookback: "3",
+    },
+    validation: {
+      required: [{ field: "direction", label: "Direction" }],
+      minChildren: 2,
+      maxChildren: 2,
+    },
+  },
+  market_volume: {
+    type: "market_volume",
+    label: "Volume seuil",
+    description: "Vérifier si le volume respecte un seuil donné sur un intervalle.",
+    accepts: [],
+    category: "conditions",
+    defaultConfig: {
+      operator: "gt",
+      value: "100000",
+      timeframe: "1h",
+    },
+    validation: {
+      required: [
+        { field: "operator", label: "Opérateur" },
+        { field: "value", label: "Seuil" },
+        { field: "timeframe", label: "Intervalle" },
+      ],
+    },
   },
   indicator: {
     type: "indicator",
-    label: "Indicateur",
+    label: "Indicateur simple",
     description:
       "Calculer une mesure technique (SMA, RSI, VWAP…) afin de l'utiliser dans une condition.",
     accepts: [],
@@ -26,26 +72,198 @@ export const BLOCK_DEFINITIONS = {
       kind: "sma",
       period: "20",
     },
+    validation: {
+      required: [
+        { field: "source", label: "Source" },
+        { field: "kind", label: "Type" },
+        { field: "period", label: "Période" },
+      ],
+    },
+  },
+  indicator_macd: {
+    type: "indicator_macd",
+    label: "MACD",
+    description: "Oscillateur MACD avec périodes rapide/lente et signal configurable.",
+    accepts: [],
+    category: "conditions",
+    defaultConfig: {
+      source: "close",
+      fastPeriod: "12",
+      slowPeriod: "26",
+      signalPeriod: "9",
+    },
+    validation: {
+      required: [
+        { field: "source", label: "Source" },
+        { field: "fastPeriod", label: "Période rapide" },
+        { field: "slowPeriod", label: "Période lente" },
+        { field: "signalPeriod", label: "Période signal" },
+      ],
+    },
+  },
+  indicator_bollinger: {
+    type: "indicator_bollinger",
+    label: "Bandes de Bollinger",
+    description: "Bandes de volatilité basées sur une moyenne mobile et une déviation.",
+    accepts: [],
+    category: "conditions",
+    defaultConfig: {
+      source: "close",
+      period: "20",
+      deviation: "2",
+    },
+    validation: {
+      required: [
+        { field: "source", label: "Source" },
+        { field: "period", label: "Période" },
+        { field: "deviation", label: "Déviation" },
+      ],
+    },
+  },
+  indicator_atr: {
+    type: "indicator_atr",
+    label: "ATR",
+    description: "Average True Range permettant d'évaluer la volatilité.",
+    accepts: [],
+    category: "conditions",
+    defaultConfig: {
+      source: "hlc3",
+      period: "14",
+      smoothing: "14",
+    },
+    validation: {
+      required: [
+        { field: "source", label: "Source" },
+        { field: "period", label: "Période" },
+        { field: "smoothing", label: "Lissage" },
+      ],
+    },
   },
   logic: {
     type: "logic",
     label: "Opérateur logique",
     description: "Regrouper plusieurs conditions avec un ET/OU imbriqué.",
-    accepts: ["condition", "indicator", "logic"],
+    accepts: [
+      "condition",
+      "market_cross",
+      "market_volume",
+      "logic",
+      "negation",
+      "group",
+    ],
     category: "conditions",
     defaultConfig: {
       mode: "all",
+    },
+    validation: {
+      required: [{ field: "mode", label: "Mode" }],
+      minChildren: 2,
+    },
+  },
+  negation: {
+    type: "negation",
+    label: "Négation",
+    description: "Inverser le résultat d'une condition (NON / NOT).",
+    accepts: ["condition", "market_cross", "market_volume", "logic", "group"],
+    category: "conditions",
+    defaultConfig: {},
+    validation: {
+      minChildren: 1,
+      maxChildren: 1,
+    },
+  },
+  group: {
+    type: "group",
+    label: "Parenthèses",
+    description: "Créer un sous-groupe afin de prioriser certaines conditions.",
+    accepts: ["condition", "market_cross", "market_volume", "logic", "negation"],
+    category: "conditions",
+    defaultConfig: {},
+    validation: {
+      minChildren: 1,
     },
   },
   action: {
     type: "action",
     label: "Action d'exécution",
-    description: "Déclencher un ordre ou une alerte via le moteur d'exécution.",
+    description: "Déclencher un ordre via le moteur d'exécution.",
     accepts: [],
     category: "actions",
     defaultConfig: {
       action: "buy",
       size: "1",
+    },
+    validation: {
+      required: [
+        { field: "action", label: "Action" },
+        { field: "size", label: "Taille" },
+      ],
+    },
+  },
+  take_profit: {
+    type: "take_profit",
+    label: "Take-profit",
+    description: "Sécuriser les gains une fois qu'un objectif est atteint.",
+    accepts: [],
+    category: "actions",
+    defaultConfig: {
+      mode: "percent",
+      value: "5",
+      size: "full",
+    },
+    validation: {
+      required: [
+        { field: "mode", label: "Type de cible" },
+        { field: "value", label: "Valeur" },
+      ],
+    },
+  },
+  stop_loss: {
+    type: "stop_loss",
+    label: "Stop-loss",
+    description: "Limiter les pertes avec un seuil fixe ou suiveur.",
+    accepts: [],
+    category: "actions",
+    defaultConfig: {
+      mode: "percent",
+      value: "2",
+      trailing: false,
+    },
+    validation: {
+      required: [
+        { field: "mode", label: "Type de seuil" },
+        { field: "value", label: "Valeur" },
+      ],
+    },
+  },
+  close_position: {
+    type: "close_position",
+    label: "Fermer la position",
+    description: "Clôturer tout ou partie de la position ouverte.",
+    accepts: [],
+    category: "actions",
+    defaultConfig: {
+      side: "all",
+    },
+    validation: {
+      required: [{ field: "side", label: "Cible" }],
+    },
+  },
+  alert: {
+    type: "alert",
+    label: "Alerte",
+    description: "Notifier une équipe ou un canal externe lors du déclenchement.",
+    accepts: [],
+    category: "actions",
+    defaultConfig: {
+      channel: "email",
+      message: "Alerte stratégie",
+    },
+    validation: {
+      required: [
+        { field: "channel", label: "Canal" },
+        { field: "message", label: "Message" },
+      ],
     },
   },
   delay: {
@@ -56,6 +274,9 @@ export const BLOCK_DEFINITIONS = {
     category: "actions",
     defaultConfig: {
       seconds: "60",
+    },
+    validation: {
+      required: [{ field: "seconds", label: "Délai (secondes)" }],
     },
   },
 };

--- a/services/web-dashboard/tests/e2e/test_strategies_designer.py
+++ b/services/web-dashboard/tests/e2e/test_strategies_designer.py
@@ -42,3 +42,59 @@ async def test_strategy_designer_saves_strategy(page: Page, dashboard_base_url: 
 
         await expect(page.get_by_text("Stratégie enregistrée avec succès.")).to_be_visible()
         assert algo_route.called
+
+
+async def test_strategy_designer_validation_feedback(page: Page, dashboard_base_url: str):
+    await page.goto(f"{dashboard_base_url}/strategies", wait_until="networkidle")
+
+    await expect(page.get_by_role("heading", name="Éditeur visuel")).to_be_visible()
+
+    await page.get_by_test_id("palette-item-logic").drag_to(
+        page.get_by_test_id("designer-conditions-dropzone")
+    )
+    logic_dropzone = page.get_by_test_id("designer-dropzone-logic").first
+
+    await page.get_by_test_id("palette-item-condition").drag_to(logic_dropzone)
+    condition_dropzone = page.get_by_test_id("designer-dropzone-condition").first
+
+    await page.get_by_test_id("palette-item-indicator_macd").drag_to(condition_dropzone)
+
+    macd_block = page.locator("[data-node-type='indicator_macd']").first
+    await macd_block.get_by_label("Période rapide").fill("8")
+    await macd_block.get_by_label("Période lente").fill("21")
+    await macd_block.get_by_label("Période signal").fill("5")
+
+    await page.get_by_test_id("palette-item-market_cross").drag_to(logic_dropzone)
+    cross_dropzone = page.get_by_test_id("designer-dropzone-market_cross").first
+    await page.get_by_test_id("palette-item-indicator_bollinger").drag_to(cross_dropzone)
+    await page.get_by_test_id("palette-item-indicator_atr").drag_to(cross_dropzone)
+
+    await page.get_by_test_id("palette-item-market_volume").drag_to(logic_dropzone)
+    volume_block = page.locator("[data-node-type='market_volume']").first
+    await volume_block.get_by_label("Seuil").fill("250000")
+    await volume_block.get_by_label("Intervalle").fill("4h")
+
+    actions_dropzone = page.get_by_test_id("designer-actions-dropzone")
+    await page.get_by_test_id("palette-item-action").drag_to(actions_dropzone)
+    await page.get_by_test_id("palette-item-take_profit").drag_to(actions_dropzone)
+    await page.get_by_test_id("palette-item-stop_loss").drag_to(actions_dropzone)
+    await page.get_by_test_id("palette-item-alert").drag_to(actions_dropzone)
+
+    take_profit_block = page.locator("[data-node-type='take_profit']").first
+    await take_profit_block.get_by_label("Valeur").fill("4.5")
+    await take_profit_block.get_by_label("Part de la position").select_option("half")
+
+    stop_loss_block = page.locator("[data-node-type='stop_loss']").first
+    await stop_loss_block.get_by_label("Valeur").fill("1.5")
+    await stop_loss_block.get_by_label("Activer le trailing stop").check()
+
+    alert_block = page.locator("[data-node-type='alert']").first
+    await alert_block.get_by_label("Message").fill("Notifier l'équipe trading")
+
+    validation_panel = page.get_by_test_id("designer-validation")
+    await expect(validation_panel.get_by_text("Règle valide")).to_be_visible()
+    await expect(validation_panel.locator(".designer-validation__rule")).to_contain_text("MACD")
+
+    await take_profit_block.get_by_label("Valeur").fill("")
+    await expect(validation_panel.get_by_text("Erreurs de configuration")).to_be_visible()
+    await expect(validation_panel.locator("li")).to_contain_text("Take-profit")


### PR DESCRIPTION
## Summary
- add new indicator, condition, logic, and action block definitions with validation metadata for the strategy designer
- extend StrategyBlock and StrategyDesigner to surface the new fields and provide real-time validation feedback plus serializer support
- cover the new behavior with React unit tests and a Playwright scenario for complex strategies

## Testing
- npm --prefix services/web-dashboard test

------
https://chatgpt.com/codex/tasks/task_e_68ddda4e8c8c833286337985c84cdb65