### PR TITLE
feat: add undo history and layout guides to strategy designer

### DIFF
--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -18,6 +18,7 @@
   --space-md: 1rem;
   --space-lg: 1.5rem;
   --space-xl: 2.5rem;
+  --designer-grid-step: 160px;
   --font-size-sm: 0.875rem;
   --font-size-md: 1rem;
   --font-size-lg: 1.25rem;
@@ -1033,11 +1034,34 @@ body {
 }
 
 .designer-canvas {
+  position: relative;
   padding: var(--space-md);
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
   min-height: 320px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background-color: rgba(15, 23, 42, 0.35);
+  background-image: repeating-linear-gradient(
+      to right,
+      rgba(56, 189, 248, 0.12) 0,
+      rgba(56, 189, 248, 0.12) 1px,
+      transparent 1px,
+      transparent var(--designer-grid-step)
+    ),
+    linear-gradient(to bottom, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-size: calc(var(--layout-columns, 1) * var(--designer-grid-step)) 100%,
+    100% 48px;
+  background-position: left top, left top;
+  background-repeat: repeat;
+  outline: none;
+}
+
+.designer-canvas:focus,
+.designer-canvas--active {
+  border-color: rgba(56, 189, 248, 0.5);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
 }
 
 .designer-canvas__empty {
@@ -1117,11 +1141,24 @@ body {
 .designer-block {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: rgba(15, 23, 42, 0.5);
+  background: rgba(15, 23, 42, 0.55);
   padding: var(--space-md);
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+  margin-left: calc(var(--layout-column, 0) * var(--designer-grid-step));
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.designer-block:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+}
+
+.designer-block--selected {
+  border-color: rgba(56, 189, 248, 0.7);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
 }
 
 .designer-block__header {
@@ -1129,6 +1166,24 @@ body {
   justify-content: space-between;
   align-items: center;
   gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.designer-block__title {
+  flex: 1 1 auto;
+}
+
+.designer-block__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.designer-block__actions .button {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: 0.75rem;
 }
 
 .designer-block__body {
@@ -1141,8 +1196,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
-  padding-left: var(--space-md);
-  border-left: 2px solid rgba(56, 189, 248, 0.25);
+  padding-left: var(--space-sm);
+  border-left: 2px dashed rgba(56, 189, 248, 0.25);
 }
 
 .designer-dropzone {

--- a/services/web-dashboard/src/strategies/designer/DesignerCanvas.jsx
+++ b/services/web-dashboard/src/strategies/designer/DesignerCanvas.jsx
@@ -8,9 +8,18 @@ function Section({
   emptyMessage,
   nodes,
   section,
+  layout,
+  selection,
+  clipboardAvailable,
   onDrop,
   onConfigChange,
   onRemove,
+  onSelect,
+  onSectionFocus,
+  onCopy,
+  onPaste,
+  onDuplicate,
+  onClearSelection,
   dropTestId,
 }) {
   const handleDrop = (event) => {
@@ -27,6 +36,30 @@ function Section({
     event.dataTransfer.dropEffect = "copy";
   };
 
+  const isSectionSelected = selection?.section === section && !selection?.nodeId;
+  const maxColumn = Math.max(
+    0,
+    ...Object.values(layout || {}).map((entry) =>
+      typeof entry.column === "number" ? entry.column : 0
+    )
+  );
+
+  const handleCanvasClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onSectionFocus?.(section);
+    }
+  };
+
+  const handleCanvasFocus = () => {
+    onSectionFocus?.(section);
+  };
+
+  const handleCanvasBlur = (event) => {
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      onClearSelection?.();
+    }
+  };
+
   return (
     <section className="designer-panel designer-panel--canvas" aria-labelledby={`${dropTestId}-title`}>
       <div className="designer-panel__header">
@@ -36,10 +69,16 @@ function Section({
         <p className="text text--muted">{description}</p>
       </div>
       <div
-        className="designer-canvas"
+        className={`designer-canvas${isSectionSelected ? " designer-canvas--active" : ""}`}
         onDragOver={handleDragOver}
         onDrop={handleDrop}
+        onClick={handleCanvasClick}
+        onFocus={handleCanvasFocus}
+        onBlur={handleCanvasBlur}
         data-testid={dropTestId}
+        tabIndex={0}
+        aria-selected={isSectionSelected}
+        style={{ "--layout-columns": maxColumn + 1 }}
       >
         {nodes.length ? (
           nodes.map((node) => (
@@ -47,9 +86,16 @@ function Section({
               key={node.id}
               node={node}
               section={section}
+              layout={layout}
+              selection={selection}
+              clipboardAvailable={clipboardAvailable}
               onDrop={onDrop}
               onConfigChange={onConfigChange}
               onRemove={onRemove}
+              onSelect={onSelect}
+              onCopy={onCopy}
+              onPaste={onPaste}
+              onDuplicate={onDuplicate}
             />
           ))
         ) : (
@@ -63,21 +109,43 @@ function Section({
 export default function DesignerCanvas({
   conditions,
   actions,
+  layout,
+  selection,
+  clipboardAvailable,
   onDrop,
   onConfigChange,
   onRemove,
+  onSelect,
+  onSectionFocus,
+  onCopy,
+  onPaste,
+  onDuplicate,
+  onClearSelection,
 }) {
   return (
-    <div className="designer-canvas-grid">
+    <div className="designer-canvas-grid" onClick={(event) => {
+      if (event.target === event.currentTarget) {
+        onClearSelection?.();
+      }
+    }}>
       <Section
         title="Conditions"
         description="Construisez l'arbre logique déclenchant la stratégie."
         emptyMessage="Glissez une condition, un opérateur logique ou un indicateur pour démarrer."
         nodes={conditions}
         section="conditions"
+        layout={layout}
+        selection={selection}
+        clipboardAvailable={clipboardAvailable}
         onDrop={onDrop}
         onConfigChange={onConfigChange}
         onRemove={onRemove}
+        onSelect={onSelect}
+        onSectionFocus={onSectionFocus}
+        onCopy={onCopy}
+        onPaste={onPaste}
+        onDuplicate={onDuplicate}
+        onClearSelection={onClearSelection}
         dropTestId="designer-conditions-dropzone"
       />
       <Section
@@ -86,9 +154,18 @@ export default function DesignerCanvas({
         emptyMessage="Ajoutez une action d'exécution ou une temporisation."
         nodes={actions}
         section="actions"
+        layout={layout}
+        selection={selection}
+        clipboardAvailable={clipboardAvailable}
         onDrop={onDrop}
         onConfigChange={onConfigChange}
         onRemove={onRemove}
+        onSelect={onSelect}
+        onSectionFocus={onSectionFocus}
+        onCopy={onCopy}
+        onPaste={onPaste}
+        onDuplicate={onDuplicate}
+        onClearSelection={onClearSelection}
         dropTestId="designer-actions-dropzone"
       />
     </div>

--- a/services/web-dashboard/test/strategy-designer.test.jsx
+++ b/services/web-dashboard/test/strategy-designer.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrategyDesigner } from "../src/strategies/designer/index.js";
 
@@ -68,4 +68,60 @@ test("génère un export Python après ajout d'une action", async () => {
   expect(preview.value).toContain("STRATEGY = ");
   expect(preview.value).toContain("\"name\": \"Breakout\"");
   expect(preview.value).toContain("\"steps\"");
+});
+
+test("supporte undo et redo via les raccourcis clavier", () => {
+  render(<StrategyDesigner defaultName="Test" saveEndpoint="/noop" />);
+
+  const conditionsZone = screen.getByTestId("designer-conditions-dropzone");
+  const conditionItem = screen.getByTestId("palette-item-condition");
+  dragAndDrop(conditionItem, conditionsZone);
+
+  expect(document.querySelectorAll(".designer-block[data-node-type='condition']")).toHaveLength(1);
+
+  fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+  expect(document.querySelectorAll(".designer-block[data-node-type='condition']")).toHaveLength(0);
+
+  fireEvent.keyDown(window, { key: "z", ctrlKey: true, shiftKey: true });
+  expect(document.querySelectorAll(".designer-block[data-node-type='condition']")).toHaveLength(1);
+});
+
+test("permet de coller un bloc condition imbriqué depuis le presse-papiers interne", async () => {
+  render(<StrategyDesigner defaultName="Test" saveEndpoint="/noop" />);
+
+  const conditionsZone = screen.getByTestId("designer-conditions-dropzone");
+  const conditionItem = screen.getByTestId("palette-item-condition");
+  dragAndDrop(conditionItem, conditionsZone);
+
+  const indicatorItem = screen.getByTestId("palette-item-indicator");
+  const conditionDropzones = screen.getAllByTestId("designer-dropzone-condition");
+  dragAndDrop(indicatorItem, conditionDropzones[0]);
+
+  const logicItem = screen.getByTestId("palette-item-logic");
+  dragAndDrop(logicItem, conditionsZone);
+
+  const conditionBlock = document.querySelector(".designer-block[data-node-type='condition']");
+  expect(conditionBlock).not.toBeNull();
+  conditionBlock.click();
+
+  fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+
+  const logicBlock = document.querySelector(".designer-block[data-node-type='logic']");
+  expect(logicBlock).not.toBeNull();
+  logicBlock.click();
+
+  await waitFor(() => expect(logicBlock).toHaveClass("designer-block--selected"));
+
+  fireEvent.keyDown(window, { key: "v", ctrlKey: true });
+
+  await waitFor(() => {
+    const nestedConditions = logicBlock.querySelectorAll(
+      ".designer-block[data-node-type='condition']"
+    );
+    const nestedIndicators = logicBlock.querySelectorAll(
+      ".designer-block[data-node-type='indicator']"
+    );
+    expect(nestedConditions.length).toBeGreaterThanOrEqual(1);
+    expect(nestedIndicators.length).toBeGreaterThanOrEqual(1);
+  });
 });


### PR DESCRIPTION
## Summary
- replace designer state management with a reducer that tracks past/present/future history to support undo/redo
- add internal clipboard copy/paste/duplicate actions with keyboard shortcuts and toolbar buttons
- refresh canvas layout with alignment guides and block-level actions, plus new tests for undo/redo and nested pasting

## Testing
- npm test -- strategy-designer

------
https://chatgpt.com/codex/tasks/task_e_68de2ed5d3508332b801190f0b9c42e4