### PR TITLE
feat(algo-engine): persist strategy catalog to Postgres

### DIFF
--- a/infra/migrations/env.py
+++ b/infra/migrations/env.py
@@ -21,6 +21,7 @@ from infra.marketplace_models import Base as MarketplaceBase
 from infra.social_models import Base as SocialBase
 from infra.screener_models import ScreenerBase
 from infra.trading_models import TradingBase
+from infra.strategy_models import StrategyBase
 
 config = context.config
 
@@ -99,6 +100,7 @@ def _collect_target_metadata() -> tuple[MetaData, ...]:
         SocialBase.metadata,
         ScreenerBase.metadata,
         TradingBase.metadata,
+        StrategyBase.metadata,
     ]
 
     service_modules = [

--- a/infra/migrations/versions/1b70b7cb0c53_add_strategy_tables.py
+++ b/infra/migrations/versions/1b70b7cb0c53_add_strategy_tables.py
@@ -1,0 +1,148 @@
+"""Create strategy management tables"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "1b70b7cb0c53"
+down_revision = "9c4f7f5f7b2a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "strategies",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("strategy_type", sa.String(length=64), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("parameters", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("source_format", sa.String(length=16), nullable=True),
+        sa.Column("source", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default=sa.text("'PENDING'")),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("last_backtest", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("TIMEZONE('utc', now())"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("TIMEZONE('utc', now())"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_strategies_strategy_type"), "strategies", ["strategy_type"], unique=False
+    )
+    op.create_index(op.f("ix_strategies_enabled"), "strategies", ["enabled"], unique=False)
+    op.create_index(op.f("ix_strategies_status"), "strategies", ["status"], unique=False)
+
+    op.create_table(
+        "strategy_versions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("strategy_id", sa.String(length=36), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("strategy_type", sa.String(length=64), nullable=False),
+        sa.Column("parameters", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("source_format", sa.String(length=16), nullable=True),
+        sa.Column("source", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("TIMEZONE('utc', now())"),
+        ),
+        sa.Column("created_by", sa.String(length=128), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["strategy_id"], ["strategies.id"], ondelete="CASCADE", name="fk_versions_strategy"
+        ),
+        sa.UniqueConstraint(
+            "strategy_id", "version", name="uq_strategy_versions_strategy_version"
+        ),
+    )
+    op.create_index(
+        op.f("ix_strategy_versions_strategy_id"),
+        "strategy_versions",
+        ["strategy_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "strategy_executions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("strategy_id", sa.String(length=36), nullable=False),
+        sa.Column("order_id", sa.String(length=128), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("broker", sa.String(length=64), nullable=False),
+        sa.Column("venue", sa.String(length=64), nullable=False),
+        sa.Column("symbol", sa.String(length=64), nullable=False),
+        sa.Column("side", sa.String(length=16), nullable=False),
+        sa.Column("quantity", sa.Float(), nullable=False),
+        sa.Column("filled_quantity", sa.Float(), nullable=False),
+        sa.Column("avg_price", sa.Float(), nullable=True),
+        sa.Column(
+            "submitted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("TIMEZONE('utc', now())"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["strategy_id"], ["strategies.id"], ondelete="CASCADE", name="fk_exec_strategy"
+        ),
+    )
+    op.create_index(
+        op.f("ix_strategy_executions_strategy_id"),
+        "strategy_executions",
+        ["strategy_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_strategy_executions_strategy_submitted_at",
+        "strategy_executions",
+        ["strategy_id", "submitted_at"],
+        unique=False,
+    )
+
+    op.alter_column("strategies", "version", server_default=None)
+    op.alter_column("strategies", "enabled", server_default=None)
+    op.alter_column("strategies", "status", server_default=None)
+    op.alter_column("strategies", "created_at", server_default=None)
+    op.alter_column("strategies", "updated_at", server_default=None)
+    op.alter_column("strategy_versions", "created_at", server_default=None)
+    op.alter_column("strategy_executions", "created_at", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_strategy_executions_strategy_submitted_at",
+        table_name="strategy_executions",
+    )
+    op.drop_index(op.f("ix_strategy_executions_strategy_id"), table_name="strategy_executions")
+    op.drop_table("strategy_executions")
+
+    op.drop_index(op.f("ix_strategy_versions_strategy_id"), table_name="strategy_versions")
+    op.drop_table("strategy_versions")
+
+    op.drop_index(op.f("ix_strategies_status"), table_name="strategies")
+    op.drop_index(op.f("ix_strategies_enabled"), table_name="strategies")
+    op.drop_index(op.f("ix_strategies_strategy_type"), table_name="strategies")
+    op.drop_table("strategies")

--- a/infra/strategy_models.py
+++ b/infra/strategy_models.py
@@ -1,0 +1,145 @@
+"""SQLAlchemy models backing strategy management for the algo engine."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import declarative_base, relationship
+
+
+StrategyBase = declarative_base()
+
+
+class Strategy(StrategyBase):
+    """Primary table storing the latest state for a trading strategy."""
+
+    __tablename__ = "strategies"
+
+    id: str = Column(String(36), primary_key=True)
+    name: str = Column(String(255), nullable=False)
+    strategy_type: str = Column(String(64), nullable=False, index=True)
+    version: int = Column(Integer, nullable=False, default=1)
+    parameters: dict | None = Column(JSON, nullable=False, default=dict)
+    enabled: bool = Column(Boolean, nullable=False, default=False, index=True)
+    tags: list[str] | None = Column(JSON, nullable=False, default=list)
+    metadata_: dict | None = Column("metadata", JSON, nullable=True)
+    source_format: str | None = Column(String(16), nullable=True)
+    source: str | None = Column(Text, nullable=True)
+    status: str = Column(String(16), nullable=False, default="PENDING", index=True)
+    last_error: str | None = Column(Text, nullable=True)
+    last_backtest: dict | None = Column(JSON, nullable=True)
+    created_at: datetime = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: datetime = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    versions = relationship(
+        "StrategyVersion",
+        back_populates="strategy",
+        cascade="all, delete-orphan",
+        order_by="StrategyVersion.version.desc()",
+    )
+    executions = relationship(
+        "StrategyExecution",
+        back_populates="strategy",
+        cascade="all, delete-orphan",
+        order_by="StrategyExecution.submitted_at.desc()",
+    )
+
+
+class StrategyVersion(StrategyBase):
+    """Immutable snapshot recorded every time a strategy is updated."""
+
+    __tablename__ = "strategy_versions"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    strategy_id: str = Column(
+        String(36),
+        ForeignKey("strategies.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    version: int = Column(Integer, nullable=False)
+    name: str = Column(String(255), nullable=False)
+    strategy_type: str = Column(String(64), nullable=False)
+    parameters: dict | None = Column(JSON, nullable=False, default=dict)
+    metadata_: dict | None = Column("metadata", JSON, nullable=True)
+    tags: list[str] | None = Column(JSON, nullable=False, default=list)
+    source_format: str | None = Column(String(16), nullable=True)
+    source: str | None = Column(Text, nullable=True)
+    created_at: datetime = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    created_by: str | None = Column(String(128), nullable=True)
+
+    strategy = relationship("Strategy", back_populates="versions")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "strategy_id", "version", name="uq_strategy_versions_strategy_version"
+        ),
+    )
+
+
+class StrategyExecution(StrategyBase):
+    """Historical record of executions routed on behalf of a strategy."""
+
+    __tablename__ = "strategy_executions"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    strategy_id: str = Column(
+        String(36),
+        ForeignKey("strategies.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    order_id: str = Column(String(128), nullable=False)
+    status: str = Column(String(32), nullable=False)
+    broker: str = Column(String(64), nullable=False)
+    venue: str = Column(String(64), nullable=False)
+    symbol: str = Column(String(64), nullable=False)
+    side: str = Column(String(16), nullable=False)
+    quantity: float = Column(Float, nullable=False)
+    filled_quantity: float = Column(Float, nullable=False)
+    avg_price: float | None = Column(Float, nullable=True)
+    submitted_at: datetime = Column(DateTime(timezone=True), nullable=False, index=True)
+    payload: dict = Column(JSON, nullable=False)
+    created_at: datetime = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    strategy = relationship("Strategy", back_populates="executions")
+
+    __table_args__ = (
+        Index(
+            "ix_strategy_executions_strategy_submitted_at",
+            "strategy_id",
+            "submitted_at",
+        ),
+    )
+
+
+__all__ = [
+    "StrategyBase",
+    "Strategy",
+    "StrategyVersion",
+    "StrategyExecution",
+]

--- a/services/algo-engine/app/repository.py
+++ b/services/algo-engine/app/repository.py
@@ -1,0 +1,360 @@
+"""Persistence layer for strategies backed by PostgreSQL."""
+from __future__ import annotations
+
+import copy
+import threading
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable, Dict, Iterable, List, MutableMapping
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from infra.strategy_models import (
+    Strategy,
+    StrategyBase,
+    StrategyExecution,
+    StrategyVersion,
+)
+
+
+class StrategyStatus(str, Enum):
+    PENDING = "PENDING"
+    ACTIVE = "ACTIVE"
+    ERROR = "ERROR"
+
+
+@dataclass
+class StrategyRecord:
+    id: str
+    name: str
+    strategy_type: str
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    enabled: bool = False
+    tags: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    source_format: str | None = None
+    source: str | None = None
+    last_backtest: Dict[str, Any] | None = None
+    status: StrategyStatus = StrategyStatus.PENDING
+    last_error: str | None = None
+    version: int = 1
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["status"] = self.status.value
+        return payload
+
+
+class StrategyRepository:
+    """Thread-safe repository caching strategy metadata in memory."""
+
+    def __init__(
+        self,
+        session_factory: Callable[[], Session],
+        *,
+        max_execution_history: int = 50,
+    ) -> None:
+        self._session_factory = session_factory
+        self._lock = threading.RLock()
+        self._strategies: MutableMapping[str, StrategyRecord] = {}
+        self._max_execution_history = max_execution_history
+        self._allowed_transitions: Dict[StrategyStatus, List[StrategyStatus]] = {
+            StrategyStatus.PENDING: [StrategyStatus.ACTIVE, StrategyStatus.ERROR],
+            StrategyStatus.ACTIVE: [StrategyStatus.ERROR],
+            StrategyStatus.ERROR: [StrategyStatus.ACTIVE],
+        }
+        self._ensure_schema()
+        self._refresh_cache()
+
+    def _ensure_schema(self) -> None:
+        with self._session_factory() as session:
+            bind = session.get_bind()
+            if bind is not None:
+                StrategyBase.metadata.create_all(bind=bind)  # pragma: no cover - schema bootstrap
+
+    def _refresh_cache(self) -> None:
+        with self._session_factory() as session:
+            records = session.execute(select(Strategy)).scalars().all()
+        cache: MutableMapping[str, StrategyRecord] = {}
+        for model in records:
+            record = self._to_record(model)
+            cache[record.id] = record
+        with self._lock:
+            self._strategies = cache
+
+    def refresh(self) -> None:
+        """Reload the in-memory cache from the database."""
+
+        self._refresh_cache()
+
+    def _ensure_metadata(self, metadata: Dict[str, Any] | None, strategy_id: str) -> Dict[str, Any]:
+        data = dict(metadata or {})
+        data.setdefault("strategy_id", strategy_id)
+        return data
+
+    def _to_record(self, model: Strategy) -> StrategyRecord:
+        metadata = self._ensure_metadata(model.metadata_, model.id)
+        parameters = dict(model.parameters or {})
+        tags = list(model.tags or [])
+        last_backtest = model.last_backtest if isinstance(model.last_backtest, dict) else None
+        status = StrategyStatus(model.status)
+        return StrategyRecord(
+            id=model.id,
+            name=model.name,
+            strategy_type=model.strategy_type,
+            parameters=parameters,
+            enabled=bool(model.enabled),
+            tags=tags,
+            metadata=metadata,
+            source_format=model.source_format,
+            source=model.source,
+            last_backtest=last_backtest,
+            status=status,
+            last_error=model.last_error,
+            version=model.version or 1,
+        )
+
+    def _copy(self, record: StrategyRecord) -> StrategyRecord:
+        return copy.deepcopy(record)
+
+    def list(self) -> List[StrategyRecord]:
+        with self._lock:
+            return [self._copy(record) for record in self._strategies.values()]
+
+    def get(self, strategy_id: str) -> StrategyRecord:
+        with self._lock:
+            record = self._strategies.get(strategy_id)
+        if record is not None:
+            return self._copy(record)
+        loaded = self._load_strategy(strategy_id)
+        if loaded is None:
+            raise KeyError("strategy not found")
+        return self._copy(loaded)
+
+    def _load_strategy(self, strategy_id: str) -> StrategyRecord | None:
+        with self._session_factory() as session:
+            model = session.get(Strategy, strategy_id)
+        if model is None:
+            return None
+        record = self._to_record(model)
+        with self._lock:
+            self._strategies[strategy_id] = record
+        return record
+
+    def create(self, record: StrategyRecord) -> StrategyRecord:
+        metadata = self._ensure_metadata(record.metadata, record.id)
+        with self._session_factory() as session:
+            model = Strategy(
+                id=record.id,
+                name=record.name,
+                strategy_type=record.strategy_type,
+                version=record.version,
+                parameters=dict(record.parameters or {}),
+                enabled=bool(record.enabled),
+                tags=list(record.tags or []),
+                metadata_=metadata,
+                source_format=record.source_format,
+                source=record.source,
+                status=record.status.value,
+                last_error=record.last_error,
+                last_backtest=record.last_backtest,
+            )
+            session.add(model)
+            session.flush()
+            session.add(
+                StrategyVersion(
+                    strategy_id=model.id,
+                    version=model.version or 1,
+                    name=model.name,
+                    strategy_type=model.strategy_type,
+                    parameters=model.parameters,
+                    metadata_=model.metadata_,
+                    tags=model.tags,
+                    source_format=model.source_format,
+                    source=model.source,
+                )
+            )
+            session.commit()
+            session.refresh(model)
+        stored = self._to_record(model)
+        with self._lock:
+            self._strategies[stored.id] = stored
+        return self._copy(stored)
+
+    def update(self, strategy_id: str, **updates: Any) -> StrategyRecord:
+        with self._lock:
+            current = self._strategies.get(strategy_id)
+        if current is None:
+            current = self._load_strategy(strategy_id)
+            if current is None:
+                raise KeyError("strategy not found")
+
+        status_update = updates.pop("status", None)
+        error_update = updates.pop("last_error", None)
+
+        if status_update is not None and not isinstance(status_update, StrategyStatus):
+            status_update = StrategyStatus(status_update)
+
+        if status_update is not None and status_update != current.status:
+            allowed = self._allowed_transitions.get(current.status, [])
+            if status_update not in allowed:
+                raise ValueError(
+                    f"Invalid status transition from {current.status.value} to {status_update.value}"
+                )
+        else:
+            status_update = status_update or current.status
+
+        create_version = self._should_snapshot(updates)
+
+        with self._session_factory() as session:
+            model = session.get(Strategy, strategy_id)
+            if model is None:
+                raise KeyError("strategy not found")
+
+            if "name" in updates and updates["name"] is not None:
+                model.name = updates["name"]
+            if "parameters" in updates:
+                model.parameters = dict(updates["parameters"] or {})
+            if "tags" in updates:
+                model.tags = list(updates["tags"] or [])
+            if "metadata" in updates:
+                model.metadata_ = dict(updates["metadata"] or {})
+            if "source_format" in updates:
+                model.source_format = updates["source_format"]
+            if "source" in updates:
+                model.source = updates["source"]
+            if "enabled" in updates and updates["enabled"] is not None:
+                model.enabled = bool(updates["enabled"])
+            if "last_backtest" in updates:
+                model.last_backtest = updates["last_backtest"]
+
+            model.metadata_ = self._ensure_metadata(model.metadata_, strategy_id)
+
+            if status_update is not None:
+                model.status = status_update.value
+                if status_update == StrategyStatus.ERROR:
+                    if error_update is not None:
+                        model.last_error = error_update
+                elif status_update == StrategyStatus.ACTIVE:
+                    model.last_error = None
+                elif error_update is not None:
+                    model.last_error = error_update
+            elif error_update is not None:
+                model.last_error = error_update
+
+            if create_version:
+                model.version = (model.version or 1) + 1
+                session.add(
+                    StrategyVersion(
+                        strategy_id=model.id,
+                        version=model.version,
+                        name=model.name,
+                        strategy_type=model.strategy_type,
+                        parameters=model.parameters,
+                        metadata_=model.metadata_,
+                        tags=model.tags,
+                        source_format=model.source_format,
+                        source=model.source,
+                    )
+                )
+
+            session.add(model)
+            session.commit()
+            session.refresh(model)
+
+        stored = self._to_record(model)
+        with self._lock:
+            self._strategies[stored.id] = stored
+        return self._copy(stored)
+
+    def _should_snapshot(self, updates: Dict[str, Any]) -> bool:
+        tracked: Iterable[str] = (
+            "name",
+            "parameters",
+            "metadata",
+            "tags",
+            "source_format",
+            "source",
+            "enabled",
+        )
+        return any(key in updates for key in tracked)
+
+    def delete(self, strategy_id: str) -> None:
+        with self._session_factory() as session:
+            model = session.get(Strategy, strategy_id)
+            if model is None:
+                raise KeyError("strategy not found")
+            session.delete(model)
+            session.commit()
+        with self._lock:
+            self._strategies.pop(strategy_id, None)
+
+    def active_count(self) -> int:
+        with self._lock:
+            return sum(1 for record in self._strategies.values() if record.enabled)
+
+    def clear(self) -> None:
+        """Remove all strategies and executions. Intended for tests."""
+
+        with self._session_factory() as session:
+            session.execute(delete(StrategyExecution))
+            session.execute(delete(StrategyVersion))
+            session.execute(delete(Strategy))
+            session.commit()
+        with self._lock:
+            self._strategies.clear()
+
+    def record_execution(self, strategy_id: str, payload: Dict[str, Any]) -> None:
+        submitted_at = self._parse_timestamp(payload.get("submitted_at"))
+        with self._session_factory() as session:
+            session.add(
+                StrategyExecution(
+                    strategy_id=strategy_id,
+                    order_id=str(payload.get("order_id")),
+                    status=str(payload.get("status")),
+                    broker=str(payload.get("broker")),
+                    venue=str(payload.get("venue")),
+                    symbol=str(payload.get("symbol")),
+                    side=str(payload.get("side")),
+                    quantity=float(payload.get("quantity", 0.0) or 0.0),
+                    filled_quantity=float(payload.get("filled_quantity", 0.0) or 0.0),
+                    avg_price=(
+                        float(payload.get("avg_price"))
+                        if payload.get("avg_price") is not None
+                        else None
+                    ),
+                    submitted_at=submitted_at,
+                    payload=payload,
+                )
+            )
+            session.commit()
+
+    def get_recent_executions(
+        self, *, limit: int | None = None, strategy_id: str | None = None
+    ) -> List[Dict[str, Any]]:
+        limit = limit or self._max_execution_history
+        stmt = select(StrategyExecution).order_by(StrategyExecution.submitted_at.desc())
+        if strategy_id is not None:
+            stmt = stmt.where(StrategyExecution.strategy_id == strategy_id)
+        stmt = stmt.limit(limit)
+        with self._session_factory() as session:
+            executions = session.execute(stmt).scalars().all()
+        return [dict(exec.payload) for exec in executions if isinstance(exec.payload, dict)]
+
+    def _parse_timestamp(self, value: Any) -> datetime:
+        if isinstance(value, datetime):
+            return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str):
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                parsed = datetime.now(tz=timezone.utc)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed
+        return datetime.now(tz=timezone.utc)
+
+
+__all__ = ["StrategyRecord", "StrategyRepository", "StrategyStatus"]

--- a/services/algo-engine/tests/conftest.py
+++ b/services/algo-engine/tests/conftest.py
@@ -15,6 +15,11 @@ if ASSISTANT_SRC.exists():
 
 os.environ.setdefault("ENTITLEMENTS_BYPASS", "1")
 
+TEST_DB_PATH = Path(__file__).resolve().parent / "test_algo_engine.sqlite"
+os.environ.setdefault("DATABASE_URL", f"sqlite:///{TEST_DB_PATH}")
+if TEST_DB_PATH.exists():
+    TEST_DB_PATH.unlink()
+
 prometheus_stub = types.ModuleType("prometheus_client")
 
 
@@ -79,13 +84,13 @@ def main_module() -> types.ModuleType:
 
 @pytest.fixture(autouse=True)
 def reset_state(main_module: types.ModuleType) -> None:
-    store = main_module.store
+    repository = main_module.strategy_repository
     orchestrator = main_module.orchestrator
-    store._strategies.clear()  # type: ignore[attr-defined]
+    repository.clear()
+    orchestrator.restore_recent_executions([])
     orchestrator.update_daily_limit(trades_submitted=0)
     orchestrator.set_mode("paper")
     orchestrator._state.last_simulation = None  # type: ignore[attr-defined]
-    orchestrator._state.recent_executions.clear()  # type: ignore[attr-defined]
     orchestrator.set_order_router_client(DEFAULT_ORDER_ROUTER_CLIENT)
 
 

--- a/services/algo-engine/tests/test_strategies.py
+++ b/services/algo-engine/tests/test_strategies.py
@@ -11,7 +11,7 @@ from algo_engine.app.main import (
     _enforce_entitlements,
     app,
     orchestrator,
-    store,
+    strategy_repository,
 )
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
@@ -78,7 +78,7 @@ def test_enforce_entitlements_respects_limit():
         quotas={"max_active_strategies": 1},
     )
 
-    store.create(
+    strategy_repository.create(
         StrategyRecord(
             id="existing",
             name="Existing",

--- a/services/tests/test_backtest_reporting.py
+++ b/services/tests/test_backtest_reporting.py
@@ -96,8 +96,9 @@ def test_backtest_results_are_published_and_visible(
     publisher = ALGO_MAIN.ReportsPublisher(client=publisher_client, base_url=str(reports_client.base_url))
     monkeypatch.setattr(ALGO_MAIN, "reports_publisher", publisher, raising=False)
 
-    # Reset strategy store for isolation
-    ALGO_MAIN.store._strategies.clear()  # type: ignore[attr-defined]
+    # Reset strategy repository for isolation
+    ALGO_MAIN.strategy_repository.clear()
+    ALGO_MAIN.orchestrator.restore_recent_executions([])
 
     with TestClient(ALGO_MAIN.app) as algo_client:
         create_payload = {


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and an Alembic migration for strategies, versions, and execution history
- replace the in-memory strategy store with a PostgreSQL-backed repository and wire the orchestrator to persist and restore executions
- update API endpoints and tests to exercise CRUD persistence and restart resilience

## Testing
- pytest services/algo-engine/tests -q
- pytest services/tests/test_backtest_reporting.py -q --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68de2f66d2bc8332b58dd633c41fa102