### PR TITLE
Add strategy clone endpoint and surface lineage in dashboard

### DIFF
--- a/infra/strategy_models.py
+++ b/infra/strategy_models.py
@@ -38,6 +38,9 @@ class Strategy(StrategyBase):
     metadata_: dict | None = Column("metadata", JSON, nullable=True)
     source_format: str | None = Column(String(16), nullable=True)
     source: str | None = Column(Text, nullable=True)
+    derived_from: str | None = Column(
+        String(36), ForeignKey("strategies.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     status: str = Column(String(16), nullable=False, default="PENDING", index=True)
     last_error: str | None = Column(Text, nullable=True)
     last_backtest: dict | None = Column(JSON, nullable=True)
@@ -91,6 +94,7 @@ class StrategyVersion(StrategyBase):
     tags: list[str] | None = Column(JSON, nullable=False, default=list)
     source_format: str | None = Column(String(16), nullable=True)
     source: str | None = Column(Text, nullable=True)
+    derived_from: str | None = Column(String(36), nullable=True, index=True)
     created_at: datetime = Column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/services/algo-engine/app/repository.py
+++ b/services/algo-engine/app/repository.py
@@ -37,6 +37,7 @@ class StrategyRecord:
     metadata: Dict[str, Any] = field(default_factory=dict)
     source_format: str | None = None
     source: str | None = None
+    derived_from: str | None = None
     last_backtest: Dict[str, Any] | None = None
     status: StrategyStatus = StrategyStatus.PENDING
     last_error: str | None = None
@@ -111,6 +112,7 @@ class StrategyRepository:
             metadata=metadata,
             source_format=model.source_format,
             source=model.source,
+            derived_from=model.derived_from,
             last_backtest=last_backtest,
             status=status,
             last_error=model.last_error,
@@ -158,6 +160,7 @@ class StrategyRepository:
                 metadata_=metadata,
                 source_format=record.source_format,
                 source=record.source,
+                derived_from=record.derived_from,
                 status=record.status.value,
                 last_error=record.last_error,
                 last_backtest=record.last_backtest,
@@ -175,6 +178,7 @@ class StrategyRepository:
                     tags=model.tags,
                     source_format=model.source_format,
                     source=model.source,
+                    derived_from=model.derived_from,
                 )
             )
             session.commit()
@@ -226,6 +230,8 @@ class StrategyRepository:
                 model.source_format = updates["source_format"]
             if "source" in updates:
                 model.source = updates["source"]
+            if "derived_from" in updates:
+                model.derived_from = updates["derived_from"]
             if "enabled" in updates and updates["enabled"] is not None:
                 model.enabled = bool(updates["enabled"])
             if "last_backtest" in updates:
@@ -258,6 +264,7 @@ class StrategyRepository:
                         tags=model.tags,
                         source_format=model.source_format,
                         source=model.source,
+                        derived_from=model.derived_from,
                     )
                 )
 
@@ -279,6 +286,7 @@ class StrategyRepository:
             "source_format",
             "source",
             "enabled",
+            "derived_from",
         )
         return any(key in updates for key in tracked)
 

--- a/services/web-dashboard/app/schemas.py
+++ b/services/web-dashboard/app/schemas.py
@@ -234,6 +234,14 @@ class StrategyStatus(BaseModel):
         default_factory=dict,
         description="Additional metadata propagated from the orchestrator store",
     )
+    derived_from: str | None = Field(
+        default=None,
+        description="Identifier of the strategy this entry was cloned from when applicable",
+    )
+    derived_from_name: str | None = Field(
+        default=None,
+        description="Human readable name of the parent strategy when available",
+    )
 
 
 class LiveLogEntry(BaseModel):

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -786,6 +786,21 @@ body {
   gap: var(--space-sm);
 }
 
+.strategy-name__parent {
+  margin: 0;
+  font-size: var(--font-size-sm);
+}
+
+.strategy-actions__form {
+  display: inline-block;
+  margin: 0;
+}
+
+.button--small {
+  padding: calc(var(--space-xs) * 0.75) var(--space-sm);
+  font-size: var(--font-size-sm);
+}
+
 .text--critical {
   color: var(--color-critical);
   font-weight: 500;

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -329,9 +329,13 @@
                 <th scope="col">Dernière exécution</th>
                 <th scope="col">Détails</th>
                 <th scope="col">Erreur récente</th>
+                <th scope="col">Actions</th>
               </tr>
             </thead>
-            <tbody class="strategy-table__body">
+            <tbody
+              class="strategy-table__body"
+              data-clone-endpoint="{{ request.url_for('clone_strategy_action') }}"
+            >
               {% if context.strategies %}
               {% for strategy in context.strategies %}
               <tr>
@@ -340,6 +344,11 @@
                     <span class="heading heading--md">{{ strategy.name }}</span>
                     {% if strategy.strategy_type %}
                     <span class="badge badge--neutral">{{ strategy.strategy_type }}</span>
+                    {% endif %}
+                    {% if strategy.derived_from_name or strategy.derived_from %}
+                    <p class="text text--muted strategy-name__parent">
+                      Clone de {{ strategy.derived_from_name or strategy.derived_from }}
+                    </p>
                     {% endif %}
                   </div>
                 </td>
@@ -387,11 +396,23 @@
                   <span class="text text--muted">—</span>
                   {% endif %}
                 </td>
+                <td data-label="Actions">
+                  <form
+                    method="post"
+                    action="{{ request.url_for('clone_strategy_action') }}"
+                    class="strategy-actions__form"
+                  >
+                    <input type="hidden" name="strategy_id" value="{{ strategy.id }}" />
+                    <button type="submit" class="button button--ghost button--small">
+                      Cloner
+                    </button>
+                  </form>
+                </td>
               </tr>
               {% endfor %}
               {% else %}
               <tr>
-                <td colspan="5">
+                <td colspan="6">
                   <p class="text text--muted">Aucune stratégie enregistrée pour le moment.</p>
                 </td>
               </tr>

--- a/services/web-dashboard/app/templates/strategies.html
+++ b/services/web-dashboard/app/templates/strategies.html
@@ -51,6 +51,9 @@
             data-default-name="Nouvelle stratégie"
             data-default-format="yaml"
             data-presets='{{ presets | tojson }}'
+            {% if initial_strategy %}
+            data-initial-strategy='{{ initial_strategy | tojson }}'
+            {% endif %}
           >
             <noscript>
               <p class="text text--muted">

--- a/services/web-dashboard/src/main.jsx
+++ b/services/web-dashboard/src/main.jsx
@@ -162,6 +162,17 @@ if (strategyDesignerRoot) {
       console.error("Impossible de parser les modèles de stratégies", error);
     }
   }
+  let initialStrategy = null;
+  if (dataset.initialStrategy) {
+    try {
+      const parsed = JSON.parse(dataset.initialStrategy);
+      if (parsed && typeof parsed === "object") {
+        initialStrategy = parsed;
+      }
+    } catch (error) {
+      console.error("Impossible de parser la stratégie initiale", error);
+    }
+  }
   const root = createRoot(strategyDesignerRoot);
   root.render(
     <StrictMode>
@@ -170,6 +181,7 @@ if (strategyDesignerRoot) {
         defaultName={defaultName}
         defaultFormat={initialFormat}
         presets={presetCatalog}
+        initialStrategy={initialStrategy}
       />
     </StrictMode>
   );

--- a/services/web-dashboard/tests/test_dashboard_template.py
+++ b/services/web-dashboard/tests/test_dashboard_template.py
@@ -1,5 +1,8 @@
 from fastapi.testclient import TestClient
 
+from web_dashboard.app import data
+from web_dashboard.app.schemas import DashboardContext, StrategyRuntimeStatus, StrategyStatus
+
 from .utils import load_dashboard_app
 
 
@@ -17,3 +20,41 @@ def test_dashboard_template_includes_inplay_section(monkeypatch):
     assert "Voir le rapport" in html
     assert "Rapports" in html
     assert "reports-center" in html
+
+
+def test_dashboard_template_shows_clone_action(monkeypatch):
+    context = DashboardContext(
+        portfolios=[],
+        transactions=[],
+        alerts=[],
+        metrics=None,
+        reports=[],
+        strategies=[
+            StrategyStatus(
+                id="clone-1",
+                name="Stratégie clonée",
+                status=StrategyRuntimeStatus.PENDING,
+                enabled=False,
+                strategy_type="orb",
+                tags=[],
+                last_error=None,
+                last_execution=None,
+                metadata={},
+                derived_from="original-1",
+                derived_from_name="Stratégie source",
+            )
+        ],
+        logs=[],
+        setups=None,
+        data_sources={},
+    )
+    monkeypatch.setattr(data, "load_dashboard_context", lambda: context)
+
+    client = TestClient(load_dashboard_app())
+    response = client.get("/dashboard")
+
+    assert response.status_code == 200
+    html = response.text
+    assert "Clone de Stratégie source" in html
+    assert "strategy-actions__form" in html
+    assert ">Cloner<" in html


### PR DESCRIPTION
## Summary
- add a clone endpoint to the algo-engine, persist strategy lineage, and expose it through list/get responses
- extend the repository, SQL models, and tests to snapshot `derived_from` metadata and verify cloning
- surface the "Cloner" action and lineage details in the dashboard, wiring a new route to prefill the strategy designer

## Testing
- pytest services/algo-engine/tests
- pytest services/web-dashboard/tests *(fails: missing optional test dependencies such as python-multipart, respx, and playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68de451f3bf08332b158438b53a31784