### PR TITLE
feat: allow closing positions from dashboard

### DIFF
--- a/libs/portfolio/__init__.py
+++ b/libs/portfolio/__init__.py
@@ -1,0 +1,15 @@
+"""Utilities shared across services to manipulate portfolio identifiers."""
+
+from .identifiers import (
+    decode_portfolio_key,
+    decode_position_key,
+    encode_portfolio_key,
+    encode_position_key,
+)
+
+__all__ = [
+    "encode_position_key",
+    "decode_position_key",
+    "encode_portfolio_key",
+    "decode_portfolio_key",
+]

--- a/libs/portfolio/identifiers.py
+++ b/libs/portfolio/identifiers.py
@@ -1,0 +1,65 @@
+"""Encoding helpers for portfolio and position identifiers."""
+from __future__ import annotations
+
+import base64
+from typing import Tuple
+
+_SEPARATOR = "\0"
+_PREFIX_POSITION = "position"
+_PREFIX_PORTFOLIO = "portfolio"
+
+
+def _encode_parts(*parts: str) -> str:
+    normalised = [str(part or "").strip() for part in parts]
+    raw = _SEPARATOR.join(normalised).encode("utf-8")
+    encoded = base64.urlsafe_b64encode(raw).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def _decode_parts(value: str) -> Tuple[str, ...]:
+    cleaned = (value or "").strip()
+    if not cleaned:
+        raise ValueError("identifier cannot be empty")
+    padding = "=" * (-len(cleaned) % 4)
+    decoded = base64.urlsafe_b64decode(cleaned + padding).decode("utf-8")
+    return tuple(decoded.split(_SEPARATOR))
+
+
+def encode_position_key(account_id: str, symbol: str) -> str:
+    """Return an opaque identifier uniquely mapping an account/symbol pair."""
+
+    if not symbol:
+        raise ValueError("symbol is required to encode a position key")
+    return _encode_parts(_PREFIX_POSITION, account_id, symbol)
+
+
+def decode_position_key(identifier: str) -> Tuple[str, str]:
+    """Decode a position identifier back into (account_id, symbol)."""
+
+    prefix, account_id, symbol = _decode_parts(identifier)
+    if prefix != _PREFIX_POSITION:
+        raise ValueError("identifier is not a position key")
+    return account_id, symbol
+
+
+def encode_portfolio_key(account_id: str) -> str:
+    """Return an opaque identifier for a portfolio owner."""
+
+    return _encode_parts(_PREFIX_PORTFOLIO, account_id)
+
+
+def decode_portfolio_key(identifier: str) -> str:
+    """Return the account identifier encoded in a portfolio key."""
+
+    prefix, account_id = _decode_parts(identifier)
+    if prefix != _PREFIX_PORTFOLIO:
+        raise ValueError("identifier is not a portfolio key")
+    return account_id
+
+
+__all__ = [
+    "encode_position_key",
+    "decode_position_key",
+    "encode_portfolio_key",
+    "decode_portfolio_key",
+]

--- a/schemas/order_router.py
+++ b/schemas/order_router.py
@@ -7,6 +7,8 @@ from typing import List
 
 from pydantic import BaseModel, Field, field_validator
 
+from datetime import datetime
+
 from schemas.market import (
     ExecutionReport as MarketExecutionReport,
     OrderRequest,
@@ -33,6 +35,53 @@ class ExecutionReport(MarketExecutionReport):
     """Execution acknowledgment returned by the order router."""
 
     pass
+
+
+class PositionHolding(BaseModel):
+    """Describe an aggregated position for a given portfolio."""
+
+    id: str
+    portfolio_id: str
+    portfolio: str
+    account_id: str
+    symbol: str
+    quantity: float
+    average_price: float
+    current_price: float
+    market_value: float
+
+
+class PortfolioSnapshot(BaseModel):
+    """Collection of holdings representing the exposure of an account."""
+
+    id: str
+    name: str
+    owner: str
+    total_value: float
+    holdings: List[PositionHolding] = Field(default_factory=list)
+
+
+class PositionsResponse(BaseModel):
+    """Payload returned when listing current positions."""
+
+    items: List[PortfolioSnapshot]
+    as_of: datetime | None = None
+
+
+class PositionCloseRequest(BaseModel):
+    """Optional target quantity when closing or resizing a position."""
+
+    target_quantity: float | None = Field(
+        default=None,
+        description="Target net quantity after the adjustment. Defaults to 0 (full close).",
+    )
+
+
+class PositionCloseResponse(BaseModel):
+    """Execution report returned after requesting a close/adjustment."""
+
+    order: ExecutionReport
+    positions: PositionsResponse
 
 
 class ExecutionRecord(BaseModel):
@@ -140,4 +189,9 @@ __all__ = [
     "ExecutionsMetadata",
     "PaginatedExecutions",
     "PaginatedOrders",
+    "PositionHolding",
+    "PortfolioSnapshot",
+    "PositionsResponse",
+    "PositionCloseRequest",
+    "PositionCloseResponse",
 ]

--- a/services/web-dashboard/app/schemas.py
+++ b/services/web-dashboard/app/schemas.py
@@ -20,10 +20,15 @@ class RiskLevel(str, Enum):
 class Holding(BaseModel):
     """Represent an asset position within a portfolio."""
 
+    id: str | None = Field(default=None, description="Opaque identifier of the position")
     symbol: str = Field(..., description="Ticker or symbol of the asset")
     quantity: float = Field(..., description="Number of units held")
     average_price: float = Field(..., description="Average fill price of the position")
     current_price: float = Field(..., description="Last traded price for the asset")
+    portfolio: str | None = Field(default=None, description="Owner of the position")
+    portfolio_id: str | None = Field(
+        default=None, description="Opaque identifier of the parent portfolio"
+    )
 
     @property
     def market_value(self) -> float:
@@ -35,6 +40,7 @@ class Holding(BaseModel):
 class Portfolio(BaseModel):
     """Snapshot of a portfolio."""
 
+    id: str | None = Field(default=None, description="Opaque identifier of the portfolio")
     name: str
     owner: str
     holdings: List[Holding]

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -329,6 +329,21 @@ body {
   font-weight: 600;
 }
 
+.portfolio-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.portfolio-actions__button {
+  flex: 0 0 auto;
+}
+
+.portfolio-actions__button[data-loading="true"] {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 .alert-list__item {
   padding: var(--space-md);
   border-radius: var(--radius-sm);

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -495,6 +495,7 @@
                     <th scope="col">Px. moyen</th>
                     <th scope="col">Px. actuel</th>
                     <th scope="col">Valeur</th>
+                    <th scope="col">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -505,6 +506,32 @@
                     <td data-label="Prix moyen">{{ '%.2f' | format(holding.average_price) }} $</td>
                     <td data-label="Prix actuel">{{ '%.2f' | format(holding.current_price) }} $</td>
                     <td data-label="Valeur">{{ '%.2f' | format(holding.market_value) }} $</td>
+                    <td data-label="Actions">
+                      <div class="portfolio-actions">
+                        <button
+                          type="button"
+                          class="button button--ghost portfolio-actions__button"
+                          data-action="close"
+                          data-position-id="{{ (holding.id or (holding.portfolio or portfolio.owner) ~ ':' ~ holding.symbol)|e }}"
+                          data-portfolio="{{ (holding.portfolio or portfolio.owner)|e }}"
+                          data-quantity="{{ holding.quantity }}"
+                          data-symbol="{{ holding.symbol|e }}"
+                        >
+                          Fermer
+                        </button>
+                        <button
+                          type="button"
+                          class="button button--ghost portfolio-actions__button"
+                          data-action="adjust"
+                          data-position-id="{{ (holding.id or (holding.portfolio or portfolio.owner) ~ ':' ~ holding.symbol)|e }}"
+                          data-portfolio="{{ (holding.portfolio or portfolio.owner)|e }}"
+                          data-quantity="{{ holding.quantity }}"
+                          data-symbol="{{ holding.symbol|e }}"
+                        >
+                          Ajuster
+                        </button>
+                      </div>
+                    </td>
                   </tr>
                   {% endfor %}
                 </tbody>

--- a/services/web-dashboard/tests/e2e/test_dashboard_e2e.py
+++ b/services/web-dashboard/tests/e2e/test_dashboard_e2e.py
@@ -6,6 +6,8 @@ import re
 import pytest
 from playwright.async_api import Page, expect
 
+from libs.portfolio import encode_portfolio_key, encode_position_key
+
 
 pytestmark = pytest.mark.asyncio
 
@@ -118,4 +120,101 @@ async def test_dashboard_exposes_accessible_landmarks(page: Page, dashboard_base
     await expect(page.get_by_role("grid", name="Transactions récentes")).to_have_attribute(
         "aria-describedby", "transactions-title"
     )
+
+
+async def test_dashboard_updates_positions_after_closing(page: Page, dashboard_base_url: str, mock_streaming):
+    growth_id = encode_portfolio_key("alice")
+    income_id = encode_portfolio_key("bob")
+    msft_id = encode_position_key("alice", "MSFT")
+    tlt_id = encode_position_key("bob", "TLT")
+    xom_id = encode_position_key("bob", "XOM")
+
+    async def _handle_close(route, request):
+        body = await request.json()
+        assert body.get("target_quantity") == 0
+        payload = {
+            "order": {
+                "order_id": "close-1",
+                "status": "filled",
+                "broker": "binance",
+                "venue": "binance.spot",
+                "symbol": "AAPL",
+                "side": "sell",
+                "quantity": 12,
+                "filled_quantity": 12,
+                "avg_price": 178.4,
+                "submitted_at": "2024-05-01T12:00:00Z",
+            },
+            "positions": {
+                "items": [
+                    {
+                        "id": growth_id,
+                        "name": "Growth",
+                        "owner": "alice",
+                        "total_value": 5 * 310.6,
+                        "holdings": [
+                            {
+                                "id": msft_id,
+                                "portfolio_id": growth_id,
+                                "portfolio": "alice",
+                                "account_id": "alice",
+                                "symbol": "MSFT",
+                                "quantity": 5,
+                                "average_price": 298.1,
+                                "current_price": 310.6,
+                                "market_value": 5 * 310.6,
+                            }
+                        ],
+                    },
+                    {
+                        "id": income_id,
+                        "name": "Income",
+                        "owner": "bob",
+                        "total_value": 20 * 98.2 + 15 * 105.7,
+                        "holdings": [
+                            {
+                                "id": tlt_id,
+                                "portfolio_id": income_id,
+                                "portfolio": "bob",
+                                "account_id": "bob",
+                                "symbol": "TLT",
+                                "quantity": 20,
+                                "average_price": 100.5,
+                                "current_price": 98.2,
+                                "market_value": 20 * 98.2,
+                            },
+                            {
+                                "id": xom_id,
+                                "portfolio_id": income_id,
+                                "portfolio": "bob",
+                                "account_id": "bob",
+                                "symbol": "XOM",
+                                "quantity": 15,
+                                "average_price": 88.5,
+                                "current_price": 105.7,
+                                "market_value": 15 * 105.7,
+                            },
+                        ],
+                    },
+                ],
+                "as_of": "2024-05-01T12:00:00Z",
+            },
+        }
+        await route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    await page.route("**/positions/**/close", _handle_close)
+
+    await page.goto(f"{dashboard_base_url}/dashboard", wait_until="networkidle")
+
+    close_button = page.get_by_role("button", name="Fermer").first
+    async with page.expect_response("**/positions/**/close"):
+        await close_button.click()
+
+    await expect(
+        page.locator("td[data-label='Symbole']").filter(has_text="AAPL")
+    ).to_have_count(0)
 

--- a/services/web-dashboard/tests/test_positions_api.py
+++ b/services/web-dashboard/tests/test_positions_api.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from schemas.market import ExecutionStatus, ExecutionVenue, OrderSide
+from schemas.order_router import ExecutionReport, PositionCloseResponse, PositionsResponse
+
+from .utils import load_dashboard_app
+
+
+@pytest.fixture()
+def client():
+    app = load_dashboard_app()
+    return TestClient(app)
+
+
+def _build_close_response(symbol: str = "ADAUSDT", side: OrderSide = OrderSide.SELL) -> PositionCloseResponse:
+    report = ExecutionReport(
+        order_id="close-1",
+        status=ExecutionStatus.FILLED,
+        broker="binance",
+        venue=ExecutionVenue.BINANCE_SPOT,
+        symbol=symbol,
+        side=side,
+        quantity=3.0,
+        filled_quantity=3.0,
+        avg_price=1.5,
+        submitted_at=datetime.now(timezone.utc),
+    )
+    return PositionCloseResponse(order=report, positions=PositionsResponse(items=[], as_of=datetime.now(timezone.utc)))
+
+
+def test_close_position_endpoint_proxies_order_router(client, monkeypatch):
+    responses = []
+
+    class DummyOrderRouterClient:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "DummyOrderRouterClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def close_position(self, position_id: str, *, target_quantity: float | None = None) -> PositionCloseResponse:
+            responses.append((position_id, target_quantity))
+            return _build_close_response(symbol="SOLUSDT")
+
+    monkeypatch.setattr("web_dashboard.app.main.OrderRouterClient", DummyOrderRouterClient)
+
+    payload = {"target_quantity": 1.0}
+    response = client.post("/positions/position-alpha/close", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["order"]["symbol"] == "SOLUSDT"
+    assert responses == [("position-alpha", 1.0)]
+
+
+def test_close_position_endpoint_handles_router_errors(client, monkeypatch):
+    class FailingOrderRouterClient:
+        def __enter__(self) -> "FailingOrderRouterClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def close_position(self, position_id: str, *, target_quantity: float | None = None) -> PositionCloseResponse:
+            raise httpx.HTTPError("unreachable")
+
+    monkeypatch.setattr("web_dashboard.app.main.OrderRouterClient", FailingOrderRouterClient)
+
+    response = client.post("/positions/test-id/close")
+
+    assert response.status_code == 502
+    assert "routeur" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- expose the order-router `/positions` listing and `/positions/{id}/close` workflow backed by shared portfolio identifier helpers
- update the web dashboard backend/frontend to drive the new position actions and refresh portfolios immediately from REST and streaming updates
- add API, data-source, and Playwright UI coverage for closing a position from the dashboard

## Testing
- pytest services/order-router/tests -q
- pytest services/web-dashboard/tests -q *(fails: ModuleNotFoundError: playwright, markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68de5726e91c8332b8b8115f9021fddf