### PR TITLE
Add marketplace filters, reviews, and dashboard page

### DIFF
--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -12,6 +12,7 @@ from .entitlements_models import (
 from .marketplace_models import (
     Base as MarketplaceBase,
     Listing,
+    ListingReview,
     ListingVersion,
     MarketplaceSubscription,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "Subscription",
     "MarketplaceBase",
     "Listing",
+    "ListingReview",
     "ListingVersion",
     "MarketplaceSubscription",
     "ScreenerBase",

--- a/services/marketplace/app/schemas.py
+++ b/services/marketplace/app/schemas.py
@@ -19,6 +19,8 @@ class ListingCreate(BaseModel):
     price_cents: int = Field(ge=0)
     currency: str = Field(default="USD", max_length=3)
     connect_account_id: str = Field(max_length=64)
+    performance_score: Optional[float] = Field(default=None, ge=0)
+    risk_score: Optional[float] = Field(default=None, ge=0)
     initial_version: Optional[ListingVersionCreate] = None
 
 
@@ -42,6 +44,10 @@ class ListingOut(BaseModel):
     currency: str
     connect_account_id: str
     status: str
+    performance_score: Optional[float] = None
+    risk_score: Optional[float] = None
+    average_rating: Optional[float] = None
+    reviews_count: int = 0
     created_at: datetime
     updated_at: datetime
     versions: list[ListingVersionOut] = Field(default_factory=list)
@@ -69,5 +75,22 @@ class CopyResponse(BaseModel):
     payment_reference: Optional[str]
     status: str
     created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ListingReviewCreate(BaseModel):
+    rating: int = Field(ge=1, le=5)
+    comment: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ListingReviewOut(BaseModel):
+    id: int
+    listing_id: int
+    reviewer_id: str
+    rating: int
+    comment: Optional[str]
+    created_at: datetime
+    updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/services/web-dashboard/app/main.py
+++ b/services/web-dashboard/app/main.py
@@ -819,6 +819,19 @@ def render_dashboard(request: Request) -> HTMLResponse:
     )
 
 
+@app.get("/marketplace", response_class=HTMLResponse, name="render_marketplace")
+def render_marketplace(request: Request) -> HTMLResponse:
+    """Render the marketplace view that embeds the React catalogue."""
+
+    return templates.TemplateResponse(
+        "marketplace.html",
+        {
+            "request": request,
+            "active_page": "marketplace",
+        },
+    )
+
+
 def _render_strategies_page(
     request: Request, *, initial_strategy: dict[str, Any] | None = None
 ) -> HTMLResponse:

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -1532,3 +1532,204 @@ body {
     grid-template-columns: 1fr;
   }
 }
+
+.marketplace {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.marketplace__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.marketplace__filters {
+  background: var(--surface-elevated);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.marketplace-filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.marketplace-filters__row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-md);
+}
+
+.marketplace-filters__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.marketplace-filters__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.marketplace-filters__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.marketplace__results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.marketplace-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-lg);
+}
+
+.marketplace-card {
+  background: var(--surface-elevated);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.marketplace-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-md);
+}
+
+.marketplace-card__price {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.marketplace-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-md);
+  margin: 0;
+}
+
+.marketplace-card__metric {
+  background: var(--surface-base);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xxs);
+}
+
+.marketplace-card__metric dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.marketplace-card__metric dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.marketplace-card__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.marketplace-card__details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  border-top: 1px solid var(--border-subtle);
+  padding-top: var(--space-md);
+}
+
+.reviews {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.reviews__item {
+  background: var(--surface-base);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.reviews__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.reviews__rating {
+  font-weight: 700;
+}
+
+.review-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  background: var(--surface-base);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+}
+
+.review-form__fields {
+  display: flex;
+  gap: var(--space-md);
+}
+
+.review-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xxs);
+}
+
+.review-form__field--grow {
+  flex: 1 1 0;
+}
+
+.review-form__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.review-form__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+@media (max-width: 960px) {
+  .marketplace-filters__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .marketplace-card__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .review-form__fields {
+    flex-direction: column;
+  }
+}

--- a/services/web-dashboard/app/templates/account.html
+++ b/services/web-dashboard/app/templates/account.html
@@ -17,6 +17,13 @@
           Tableau de bord
         </a>
         <a
+          href="{{ request.url_for('render_marketplace') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'marketplace' else '' }}"
+          aria-current="{{ 'page' if active_page == 'marketplace' else 'false' }}"
+        >
+          Marketplace
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -17,6 +17,13 @@
           Tableau de bord
         </a>
         <a
+          href="{{ request.url_for('render_marketplace') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'marketplace' else '' }}"
+          aria-current="{{ 'page' if active_page == 'marketplace' else 'false' }}"
+        >
+          Marketplace
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/app/templates/marketplace.html
+++ b/services/web-dashboard/app/templates/marketplace.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Marketplace</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="layout__header">
+      <nav class="app-nav" aria-label="Navigation principale">
+        <a
+          href="{{ request.url_for('render_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'dashboard' else '' }}"
+          aria-current="{{ 'page' if active_page == 'dashboard' else 'false' }}"
+        >
+          Tableau de bord
+        </a>
+        <a
+          href="{{ request.url_for('render_marketplace') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'marketplace' else '' }}"
+          aria-current="{{ 'page' if active_page == 'marketplace' else 'false' }}"
+        >
+          Marketplace
+        </a>
+        <a
+          href="{{ request.url_for('render_strategies') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
+          aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"
+        >
+          Stratégies
+        </a>
+        <a
+          href="{{ request.url_for('render_strategy_documentation') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategy-docs' else '' }}"
+          aria-current="{{ 'page' if active_page == 'strategy-docs' else 'false' }}"
+        >
+          Documentation stratégies
+        </a>
+        <a
+          href="{{ request.url_for('render_account') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
+          aria-current="{{ 'page' if active_page == 'account' else 'false' }}"
+        >
+          Compte &amp; API
+        </a>
+      </nav>
+      <h1 class="heading heading--xl">Marketplace de stratégies</h1>
+      <p class="text text--muted">
+        Explorez les stratégies partagées par la communauté, filtrez selon vos critères et laissez un avis.
+      </p>
+    </header>
+    <main class="layout__main layout__main--wide">
+      <section class="card" aria-labelledby="marketplace-card-title">
+        <div class="card__header">
+          <h2 id="marketplace-card-title" class="heading heading--lg">Catalogue des stratégies</h2>
+          <p class="text text--muted">
+            Visualisez les métriques clés (performance, risque, prix) et consultez les avis avant de copier une stratégie.
+          </p>
+        </div>
+        <div class="card__body">
+          <div
+            id="marketplace-root"
+            data-endpoint="/marketplace/listings"
+            data-reviews-endpoint-template="/marketplace/listings/__id__/reviews"
+            role="region"
+            aria-label="Catalogue de la marketplace"
+          >
+            <noscript>
+              <p class="text text--muted">Activez JavaScript pour explorer la marketplace et publier des avis.</p>
+            </noscript>
+          </div>
+        </div>
+      </section>
+    </main>
+    <script type="module" src="/static/main.js"></script>
+  </body>
+</html>

--- a/services/web-dashboard/app/templates/strategies.html
+++ b/services/web-dashboard/app/templates/strategies.html
@@ -17,6 +17,13 @@
           Tableau de bord
         </a>
         <a
+          href="{{ request.url_for('render_marketplace') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'marketplace' else '' }}"
+          aria-current="{{ 'page' if active_page == 'marketplace' else 'false' }}"
+        >
+          Marketplace
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/app/templates/strategy_documentation.html
+++ b/services/web-dashboard/app/templates/strategy_documentation.html
@@ -17,6 +17,13 @@
           Tableau de bord
         </a>
         <a
+          href="{{ request.url_for('render_marketplace') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'marketplace' else '' }}"
+          aria-current="{{ 'page' if active_page == 'marketplace' else 'false' }}"
+        >
+          Marketplace
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/src/main.jsx
+++ b/services/web-dashboard/src/main.jsx
@@ -7,6 +7,7 @@ import ReportsList from "./reports/ReportsList.jsx";
 import { AIStrategyAssistant } from "./strategies/assistant/index.js";
 import { StrategyDesigner, STRATEGY_PRESETS } from "./strategies/designer/index.js";
 import { StrategyBacktestConsole } from "./strategies/backtest/index.js";
+import MarketplaceApp from "./marketplace/MarketplaceApp.jsx";
 
 function loadBootstrapData() {
   const bootstrapNode = document.getElementById("dashboard-bootstrap");
@@ -182,6 +183,22 @@ if (strategyDesignerRoot) {
         defaultFormat={initialFormat}
         presets={presetCatalog}
         initialStrategy={initialStrategy}
+      />
+    </StrictMode>
+  );
+}
+
+const marketplaceRoot = document.getElementById("marketplace-root");
+if (marketplaceRoot) {
+  const dataset = marketplaceRoot.dataset || {};
+  const root = createRoot(marketplaceRoot);
+  root.render(
+    <StrictMode>
+      <MarketplaceApp
+        listingsEndpoint={dataset.endpoint || "/marketplace/listings"}
+        reviewsEndpointTemplate={
+          dataset.reviewsEndpointTemplate || "/marketplace/listings/__id__/reviews"
+        }
       />
     </StrictMode>
   );

--- a/services/web-dashboard/src/marketplace/ListingCard.jsx
+++ b/services/web-dashboard/src/marketplace/ListingCard.jsx
@@ -1,0 +1,177 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import ReviewForm from "./ReviewForm.jsx";
+
+function formatPrice(priceCents, currency) {
+  const amount = Number(priceCents || 0) / 100;
+  try {
+    return new Intl.NumberFormat("fr-FR", { style: "currency", currency }).format(amount);
+  } catch (error) {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+function formatScore(value) {
+  if (value === null || value === undefined) {
+    return "ND";
+  }
+  return Number.parseFloat(value).toFixed(1);
+}
+
+function ListingCard({ listing, reviewsEndpoint }) {
+  const [expanded, setExpanded] = useState(false);
+  const [listingSummary, setListingSummary] = useState(listing);
+  const [reviews, setReviews] = useState([]);
+  const [reviewsStatus, setReviewsStatus] = useState("idle");
+  const [formStatus, setFormStatus] = useState("idle");
+  const [formError, setFormError] = useState(null);
+
+  useEffect(() => {
+    setListingSummary(listing);
+  }, [listing]);
+
+  const loadReviews = useCallback(async () => {
+    setReviewsStatus("loading");
+    try {
+      const response = await fetch(reviewsEndpoint, { headers: { Accept: "application/json" } });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const payload = await response.json();
+      const items = Array.isArray(payload) ? payload : [];
+      setReviews(items);
+      const totalRatings = items.reduce((sum, item) => sum + Number(item.rating || 0), 0);
+      setListingSummary((prev) => ({
+        ...prev,
+        reviews_count: items.length,
+        average_rating: items.length ? Number((totalRatings / items.length).toFixed(2)) : null,
+      }));
+      setReviewsStatus("ready");
+    } catch (error) {
+      console.error("Impossible de charger les avis", error);
+      setReviewsStatus("error");
+    }
+  }, [reviewsEndpoint]);
+
+  useEffect(() => {
+    if (expanded && (reviewsStatus === "idle" || reviewsStatus === "error")) {
+      loadReviews();
+    }
+  }, [expanded, reviewsStatus, loadReviews]);
+
+  useEffect(() => {
+    if (formStatus === "success") {
+      const timeout = setTimeout(() => setFormStatus("idle"), 2000);
+      return () => clearTimeout(timeout);
+    }
+    return undefined;
+  }, [formStatus]);
+
+  const averageLabel = useMemo(() => {
+    if (!listingSummary || listingSummary.average_rating === null || listingSummary.average_rating === undefined) {
+      return "Non notée";
+    }
+    return `${Number.parseFloat(listingSummary.average_rating).toFixed(1)} / 5`;
+  }, [listingSummary]);
+
+  const handleSubmitReview = useCallback(
+    async ({ rating, comment }) => {
+      setFormStatus("submitting");
+      setFormError(null);
+      try {
+        const response = await fetch(reviewsEndpoint, {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ rating, comment: comment || null }),
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        await loadReviews();
+        setFormStatus("success");
+        return true;
+      } catch (error) {
+        console.error("Impossible d'enregistrer l'avis", error);
+        setFormStatus("error");
+        setFormError("Impossible d'enregistrer l'avis");
+        return false;
+      }
+    },
+    [loadReviews, reviewsEndpoint]
+  );
+
+  return (
+    <article className="marketplace-card" role="listitem">
+      <header className="marketplace-card__header">
+        <div>
+          <h2 className="heading heading--md marketplace-card__title">{listingSummary.strategy_name}</h2>
+          <p className="text text--muted marketplace-card__owner">Créateur #{listingSummary.owner_id}</p>
+        </div>
+        <div className="marketplace-card__price" aria-label="Prix">
+          {formatPrice(listingSummary.price_cents, listingSummary.currency)}
+        </div>
+      </header>
+
+      {listingSummary.description && <p className="text marketplace-card__description">{listingSummary.description}</p>}
+
+      <dl className="marketplace-card__metrics">
+        <div className="marketplace-card__metric">
+          <dt>Performance</dt>
+          <dd>{formatScore(listingSummary.performance_score)}</dd>
+        </div>
+        <div className="marketplace-card__metric">
+          <dt>Risque</dt>
+          <dd>{formatScore(listingSummary.risk_score)}</dd>
+        </div>
+        <div className="marketplace-card__metric">
+          <dt>Notes</dt>
+          <dd>{averageLabel}</dd>
+        </div>
+        <div className="marketplace-card__metric">
+          <dt>Avis</dt>
+          <dd>{listingSummary.reviews_count || 0}</dd>
+        </div>
+      </dl>
+
+      <div className="marketplace-card__actions">
+        <button type="button" className="button button--ghost" onClick={() => setExpanded((prev) => !prev)}>
+          {expanded ? "Masquer les détails" : "Voir les détails"}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="marketplace-card__details">
+          <section className="marketplace-card__reviews" aria-label="Avis des utilisateurs">
+            {reviewsStatus === "loading" && <p className="text">Chargement des avis…</p>}
+            {reviewsStatus === "error" && (
+              <p className="text text--critical">Impossible de récupérer les avis pour le moment.</p>
+            )}
+            {reviewsStatus === "ready" && reviews.length === 0 && (
+              <p className="text text--muted">Aucun avis pour le moment.</p>
+            )}
+            {reviewsStatus === "ready" && reviews.length > 0 && (
+              <ul className="reviews" role="list">
+                {reviews.map((review) => (
+                  <li key={review.id} className="reviews__item" role="listitem">
+                    <div className="reviews__header">
+                      <span className="reviews__rating">{review.rating} / 5</span>
+                      <time dateTime={review.created_at} className="text text--muted">
+                        {new Date(review.created_at).toLocaleDateString("fr-FR")}
+                      </time>
+                    </div>
+                    {review.comment && <p className="text reviews__comment">{review.comment}</p>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+          <ReviewForm onSubmit={handleSubmitReview} status={formStatus} errorMessage={formError} />
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default ListingCard;

--- a/services/web-dashboard/src/marketplace/MarketplaceApp.jsx
+++ b/services/web-dashboard/src/marketplace/MarketplaceApp.jsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useMemo, useState } from "react";
+import ListingCard from "./ListingCard.jsx";
+
+const SORT_OPTIONS = [
+  { value: "created_desc", label: "Plus récents" },
+  { value: "price_asc", label: "Prix croissant" },
+  { value: "price_desc", label: "Prix décroissant" },
+  { value: "performance_desc", label: "Performance décroissante" },
+  { value: "performance_asc", label: "Performance croissante" },
+  { value: "risk_asc", label: "Risque croissant" },
+  { value: "risk_desc", label: "Risque décroissant" },
+  { value: "rating_desc", label: "Mieux notées" },
+];
+
+function buildQuery(filters) {
+  const params = new URLSearchParams();
+  if (filters.search) {
+    params.set("search", filters.search);
+  }
+  if (filters.minPerformance) {
+    params.set("min_performance", filters.minPerformance);
+  }
+  if (filters.maxRisk) {
+    params.set("max_risk", filters.maxRisk);
+  }
+  if (filters.maxPrice) {
+    params.set("max_price", filters.maxPrice);
+  }
+  if (filters.sort) {
+    params.set("sort", filters.sort);
+  }
+  return params.toString();
+}
+
+function MarketplaceApp({ listingsEndpoint, reviewsEndpointTemplate }) {
+  const [filters, setFilters] = useState({
+    search: "",
+    minPerformance: "",
+    maxRisk: "",
+    maxPrice: "",
+    sort: "created_desc",
+  });
+  const [state, setState] = useState({ status: "idle", items: [], error: null });
+
+  useEffect(() => {
+    const abort = new AbortController();
+    async function load() {
+      setState((prev) => ({ ...prev, status: "loading", error: null }));
+      try {
+        const query = buildQuery(filters);
+        const response = await fetch(
+          query ? `${listingsEndpoint}?${query}` : listingsEndpoint,
+          {
+            headers: { Accept: "application/json" },
+            signal: abort.signal,
+          }
+        );
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json();
+        if (!abort.signal.aborted) {
+          setState({ status: "ready", items: payload || [], error: null });
+        }
+      } catch (error) {
+        if (!abort.signal.aborted) {
+          console.error("Impossible de charger les listings", error);
+          setState({ status: "error", items: [], error });
+        }
+      }
+    }
+    load();
+    return () => abort.abort();
+  }, [filters, listingsEndpoint]);
+
+  const hasActiveFilters = useMemo(
+    () =>
+      Boolean(
+        filters.search || filters.minPerformance || filters.maxRisk || filters.maxPrice || filters.sort !== "created_desc"
+      ),
+    [filters]
+  );
+
+  function handleInputChange(event) {
+    const { name, value } = event.target;
+    setFilters((prev) => ({ ...prev, [name]: value }));
+  }
+
+  function resetFilters() {
+    setFilters({ search: "", minPerformance: "", maxRisk: "", maxPrice: "", sort: "created_desc" });
+  }
+
+  return (
+    <div className="marketplace">
+      <header className="marketplace__header">
+        <h1 className="heading heading--xl">Marketplace de stratégies</h1>
+        <p className="text text--muted">
+          Comparez les stratégies publiées selon la performance, le profil de risque et le budget.
+        </p>
+      </header>
+
+      <section className="marketplace__filters" aria-label="Filtres de recherche">
+        <form
+          className="marketplace-filters"
+          onSubmit={(event) => {
+            event.preventDefault();
+          }}
+        >
+          <div className="marketplace-filters__row">
+            <label className="marketplace-filters__field">
+              <span className="marketplace-filters__label">Rechercher</span>
+              <input
+                type="search"
+                name="search"
+                value={filters.search}
+                onChange={handleInputChange}
+                placeholder="Nom de stratégie"
+                className="input"
+              />
+            </label>
+            <label className="marketplace-filters__field">
+              <span className="marketplace-filters__label">Performance min.</span>
+              <input
+                type="number"
+                step="0.1"
+                min="0"
+                name="minPerformance"
+                value={filters.minPerformance}
+                onChange={handleInputChange}
+                className="input"
+              />
+            </label>
+            <label className="marketplace-filters__field">
+              <span className="marketplace-filters__label">Risque max.</span>
+              <input
+                type="number"
+                step="0.1"
+                min="0"
+                name="maxRisk"
+                value={filters.maxRisk}
+                onChange={handleInputChange}
+                className="input"
+              />
+            </label>
+            <label className="marketplace-filters__field">
+              <span className="marketplace-filters__label">Prix max. (USD)</span>
+              <input
+                type="number"
+                min="0"
+                name="maxPrice"
+                value={filters.maxPrice}
+                onChange={handleInputChange}
+                className="input"
+              />
+            </label>
+            <label className="marketplace-filters__field">
+              <span className="marketplace-filters__label">Tri</span>
+              <select name="sort" value={filters.sort} onChange={handleInputChange} className="input">
+                {SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <div className="marketplace-filters__actions">
+            <button type="button" className="button button--ghost" onClick={resetFilters} disabled={!hasActiveFilters}>
+              Réinitialiser
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="marketplace__results" aria-live="polite">
+        {state.status === "loading" && <p className="text">Chargement des listings…</p>}
+        {state.status === "error" && (
+          <p className="text text--critical">Impossible de récupérer les listings pour le moment.</p>
+        )}
+        {state.status === "ready" && state.items.length === 0 && (
+          <p className="text text--muted">Aucune stratégie ne correspond à vos filtres.</p>
+        )}
+        {state.status === "ready" && state.items.length > 0 && (
+          <div className="marketplace-grid" role="list">
+            {state.items.map((listing) => (
+              <ListingCard
+                key={listing.id}
+                listing={listing}
+                reviewsEndpoint={reviewsEndpointTemplate.replace("__id__", String(listing.id))}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default MarketplaceApp;

--- a/services/web-dashboard/src/marketplace/ReviewForm.jsx
+++ b/services/web-dashboard/src/marketplace/ReviewForm.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+
+function ReviewForm({ onSubmit, status, errorMessage }) {
+  const [rating, setRating] = useState(5);
+  const [comment, setComment] = useState("");
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    const success = await onSubmit({ rating: Number(rating), comment: comment.trim() });
+    if (success) {
+      setComment("");
+    }
+  }
+
+  return (
+    <form className="review-form" onSubmit={handleSubmit}>
+      <h3 className="heading heading--sm">Partager un avis</h3>
+      <div className="review-form__fields">
+        <label className="review-form__field">
+          <span className="review-form__label">Note</span>
+          <select value={rating} onChange={(event) => setRating(event.target.value)} className="input">
+            {[1, 2, 3, 4, 5].map((value) => (
+              <option key={value} value={value}>
+                {value} / 5
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="review-form__field review-form__field--grow">
+          <span className="review-form__label">Commentaire</span>
+          <textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            className="input"
+            rows={3}
+            placeholder="Décrivez votre expérience"
+          />
+        </label>
+      </div>
+      <div className="review-form__actions">
+        <button type="submit" className="button" disabled={status === "submitting"}>
+          {status === "submitting" ? "Envoi…" : "Envoyer"}
+        </button>
+        {status === "success" && <span className="text text--success">Avis enregistré</span>}
+        {status === "error" && <span className="text text--critical">{errorMessage || "Erreur lors de l'envoi"}</span>}
+      </div>
+    </form>
+  );
+}
+
+export default ReviewForm;

--- a/services/web-dashboard/tests/test_marketplace_page.py
+++ b/services/web-dashboard/tests/test_marketplace_page.py
@@ -1,0 +1,23 @@
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+from .utils import load_dashboard_app
+
+
+def test_marketplace_template_contains_mount_point(monkeypatch):
+    monkeypatch.setitem(sys.modules, "markdown", types.ModuleType("markdown"))
+    multipart_stub = types.ModuleType("python_multipart")
+    multipart_stub.__version__ = "0.0.16"
+    monkeypatch.setitem(sys.modules, "python_multipart", multipart_stub)
+    app = load_dashboard_app()
+    client = TestClient(app)
+
+    response = client.get("/marketplace")
+    assert response.status_code == 200
+    html = response.text
+
+    assert "marketplace-root" in html
+    assert "data-endpoint=\"/marketplace/listings\"" in html
+    assert "Marketplace de stratégies" in html


### PR DESCRIPTION
## Summary
- extend marketplace listings API with sorting/filtering and expose review endpoints backed by a new ListingReview model
- add ratings metadata to listing schemas and tests covering filter behaviour and review updates
- introduce a marketplace dashboard page with React components for filters, cards, and review submission plus related styling

## Testing
- `pytest services/marketplace/tests/test_marketplace_service.py`
- `pytest services/web-dashboard/tests/test_marketplace_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68de96b4f8bc833282150e76744dce60