### PR TITLE
Add order annotations with notes and tags

### DIFF
--- a/docs/order-router.md
+++ b/docs/order-router.md
@@ -27,7 +27,8 @@ Le module `risk_rules.py` expose :
 | GET | `/brokers` | Liste des brokers disponibles |
 | POST | `/orders` | Routage d'un ordre après validation du risque |
 | POST | `/orders/{broker}/cancel` | Annulation d'un ordre |
-| GET | `/orders/log` | Journal des ordres soumis |
+| GET | `/orders/log` | Journal des ordres soumis (filtres par compte, symbole, date, tag, stratégie) |
+| POST | `/orders/{id}/notes` | Ajout d'une note et de tags manuels sur un ordre |
 | GET | `/executions` | Exécutions agrégées |
 | GET | `/state` | Etat (mode paper/live, consommation de notionnel) |
 | PUT | `/state` | Mise à jour du mode et de la limite journalière |

--- a/infra/migrations/versions/2a0f9a0cb742_add_notes_and_tags_columns.py
+++ b/infra/migrations/versions/2a0f9a0cb742_add_notes_and_tags_columns.py
@@ -1,0 +1,48 @@
+"""Add notes and tags columns to trading tables."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "2a0f9a0cb742"
+down_revision = "6efde1f16e9f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "trading_orders",
+        "notes",
+        existing_type=sa.String(length=255),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+    op.add_column(
+        "trading_orders",
+        sa.Column("tags", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column(
+        "trading_executions",
+        sa.Column("notes", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "trading_executions",
+        sa.Column("tags", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.alter_column("trading_orders", "tags", server_default=None)
+    op.alter_column("trading_executions", "tags", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("trading_executions", "tags")
+    op.drop_column("trading_executions", "notes")
+    op.drop_column("trading_orders", "tags")
+    op.alter_column(
+        "trading_orders",
+        "notes",
+        existing_type=sa.Text(),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )

--- a/infra/trading_models.py
+++ b/infra/trading_models.py
@@ -12,8 +12,10 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    JSON,
     Numeric,
     String,
+    Text,
     func,
 )
 from sqlalchemy.orm import declarative_base, relationship
@@ -46,7 +48,8 @@ class Order(TradingBase):
     time_in_force: Optional[str] = Column(String(16))
     submitted_at: Optional[datetime] = Column(DateTime(timezone=True))
     expires_at: Optional[datetime] = Column(DateTime(timezone=True))
-    notes: Optional[str] = Column(String(255))
+    notes: Optional[str] = Column(Text)
+    tags: list[str] = Column(JSON, nullable=False, default=list)
     created_at: datetime = Column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -91,6 +94,8 @@ class Execution(TradingBase):
     created_at: datetime = Column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+    notes: Optional[str] = Column(Text)
+    tags: list[str] = Column(JSON, nullable=False, default=list)
 
     order = relationship("Order", back_populates="executions")
 

--- a/services/web-dashboard/app/main.py
+++ b/services/web-dashboard/app/main.py
@@ -22,7 +22,7 @@ from fastapi import (
     UploadFile,
     status,
 )
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -815,8 +815,31 @@ def render_dashboard(request: Request) -> HTMLResponse:
                 "token": alerts_token,
             },
             "active_page": "dashboard",
+            "annotation_status": request.query_params.get("annotation"),
         },
     )
+
+
+@app.post("/dashboard/annotate")
+def annotate_dashboard_order(
+    request: Request,
+    order_id: int = Form(..., ge=1),
+    note: str = Form(..., min_length=1),
+    tags: str = Form(default=""),
+) -> Response:
+    tag_list = [part.strip() for part in tags.split(",") if part.strip()]
+    base_url = ORDER_ROUTER_BASE_URL.rstrip("/") + "/"
+    status_flag = "success"
+    try:
+        with OrderRouterClient(
+            base_url=base_url, timeout=ORDER_ROUTER_TIMEOUT_SECONDS
+        ) as client:
+            client.annotate_order(order_id, notes=note, tags=tag_list)
+    except (httpx.HTTPError, OrderRouterError):
+        status_flag = "error"
+    redirect_target = request.url_for("render_dashboard")
+    redirect_url = redirect_target.include_query_params(annotation=status_flag)
+    return RedirectResponse(str(redirect_url), status_code=status.HTTP_303_SEE_OTHER)
 
 
 def _render_strategies_page(

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -1518,6 +1518,97 @@ body {
   margin-bottom: 0.4rem;
 }
 
+.annotation-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.annotation-form__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.annotation-form__field {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.annotation-form__field--full {
+  flex-basis: 100%;
+}
+
+.annotation-form__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+}
+
+.annotation-form__input,
+.annotation-form__textarea {
+  border: 1px solid var(--color-border-strong);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.85rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.annotation-form__input:focus,
+.annotation-form__textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.annotation-form__textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.annotation-form__hint {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.annotation-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.annotation-form__feedback {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+.annotation-form__feedback--success {
+  color: var(--color-success);
+}
+
+.annotation-form__feedback--error {
+  color: var(--color-critical);
+}
+
+@media (max-width: 768px) {
+  .annotation-form__row {
+    flex-direction: column;
+  }
+
+  .annotation-form__field,
+  .annotation-form__field--full {
+    flex-basis: 100%;
+  }
+}
+
 @media (max-width: 1024px) {
   .strategy-designer__layout {
     grid-template-columns: 1fr;

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -576,6 +576,74 @@
         </div>
       </section>
 
+      <section class="card" aria-labelledby="annotations-title">
+        <div class="card__header">
+          <h2 id="annotations-title" class="heading heading--lg">Annoter un ordre</h2>
+          <p class="text text--muted">Ajoutez du contexte aux exécutions directement depuis le tableau de bord.</p>
+        </div>
+        <div class="card__body">
+          {% if annotation_status == 'success' %}
+          <p class="annotation-form__feedback annotation-form__feedback--success">
+            <span class="badge badge--success">Note enregistrée</span>
+            Votre annotation a été sauvegardée avec succès.
+          </p>
+          {% elif annotation_status == 'error' %}
+          <p class="annotation-form__feedback annotation-form__feedback--error">
+            <span class="badge badge--critical">Échec</span>
+            Impossible d'enregistrer la note pour le moment. Veuillez réessayer.
+          </p>
+          {% endif %}
+          <form
+            class="annotation-form"
+            method="post"
+            action="{{ request.url_for('annotate_dashboard_order') }}"
+          >
+            <div class="annotation-form__row">
+              <label class="annotation-form__field">
+                <span class="annotation-form__label">Identifiant d'ordre</span>
+                <input
+                  class="annotation-form__input"
+                  type="number"
+                  name="order_id"
+                  min="1"
+                  required
+                  aria-describedby="annotation-order-hint"
+                />
+                <span id="annotation-order-hint" class="annotation-form__hint"
+                  >Retrouvez l'identifiant dans le journal des ordres.</span
+                >
+              </label>
+              <label class="annotation-form__field">
+                <span class="annotation-form__label">Tags</span>
+                <input
+                  class="annotation-form__input"
+                  type="text"
+                  name="tags"
+                  placeholder="alpha, hedging, stratégie:momentum"
+                  aria-describedby="annotation-tags-hint"
+                />
+                <span id="annotation-tags-hint" class="annotation-form__hint"
+                  >Séparez les tags par des virgules.</span
+                >
+              </label>
+            </div>
+            <label class="annotation-form__field annotation-form__field--full">
+              <span class="annotation-form__label">Note</span>
+              <textarea
+                class="annotation-form__textarea"
+                name="note"
+                rows="3"
+                required
+                aria-label="Saisissez votre annotation"
+              ></textarea>
+            </label>
+            <div class="annotation-form__actions">
+              <button type="submit" class="button button--primary">Enregistrer la note</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
       <section class="card" aria-labelledby="alerts-title">
         <div class="card__header">
           <h2 id="alerts-title" class="heading heading--lg">Alertes</h2>


### PR DESCRIPTION
## Summary
- extend the trading models with text notes and JSON tag support plus a migration
- expose an order annotation API with tag/strategy filters and regression coverage
- surface an annotation form in the dashboard along with client helpers and styling

## Testing
- pytest services/order-router/tests -q
- pytest services/web-dashboard/tests/test_dashboard_data_sources.py services/web-dashboard/tests/test_portfolio_history.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de963145c48332bacafa64e8fa9400