### PR TITLE
Weight merged target/stop metrics by sample size

### DIFF
--- a/services/reports/app/calculations.py
+++ b/services/reports/app/calculations.py
@@ -118,16 +118,8 @@ class ReportCalculator:
 
         probability = _weighted(first.probability, second.probability)
         expectancy = _weighted(first.expectancy, second.expectancy)
-
-        if first.sample_size > 0:
-            target = first.target
-            stop = first.stop
-        elif second.sample_size > 0:
-            target = second.target
-            stop = second.stop
-        else:
-            target = 0.0
-            stop = 0.0
+        target = _weighted(first.target, second.target)
+        stop = _weighted(first.stop, second.stop)
 
         return StrategyMetrics(
             strategy=first.strategy,

--- a/services/reports/tests/test_calculations.py
+++ b/services/reports/tests/test_calculations.py
@@ -1,0 +1,53 @@
+import pytest
+
+from schemas.report import StrategyMetrics, StrategyName
+
+from services.reports.app.calculations import ReportCalculator
+
+
+def test_merge_metrics_weights_target_and_stop() -> None:
+    first = StrategyMetrics(
+        strategy=StrategyName.ORB,
+        probability=0.25,
+        target=2.0,
+        stop=1.0,
+        expectancy=0.5,
+        sample_size=10,
+    )
+    second = StrategyMetrics(
+        strategy=StrategyName.ORB,
+        probability=0.75,
+        target=4.0,
+        stop=2.0,
+        expectancy=1.5,
+        sample_size=30,
+    )
+
+    merged = ReportCalculator._merge_metrics(first, second)
+
+    assert merged.target == pytest.approx(3.5)
+    assert merged.stop == pytest.approx(1.75)
+
+
+def test_merge_metrics_uses_present_dataset_when_other_empty() -> None:
+    first = StrategyMetrics(
+        strategy=StrategyName.ORB,
+        probability=0.0,
+        target=0.0,
+        stop=0.0,
+        expectancy=0.0,
+        sample_size=0,
+    )
+    second = StrategyMetrics(
+        strategy=StrategyName.ORB,
+        probability=0.75,
+        target=4.0,
+        stop=2.0,
+        expectancy=1.5,
+        sample_size=30,
+    )
+
+    merged = ReportCalculator._merge_metrics(first, second)
+
+    assert merged.target == pytest.approx(4.0)
+    assert merged.stop == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- weight merged strategy target and stop metrics using sample-size weighting during report merges
- cover metric merging behaviour with unit tests for weighted results and empty dataset fallbacks

## Testing
- pytest services/reports/tests/test_calculations.py

------
https://chatgpt.com/codex/tasks/task_e_68deb5debd388332961e226dcefa7c1a