### PR TITLE
Add copy-trading replication worker and follower dashboard

### DIFF
--- a/services/copy_trading_worker/app/events.py
+++ b/services/copy_trading_worker/app/events.py
@@ -1,0 +1,35 @@
+"""Domain events consumed by the copy-trading worker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from schemas.market import ExecutionReport
+
+
+@dataclass(slots=True)
+class LeaderExecutionEvent:
+    """Execution emitted by a leader strategy that should be replicated."""
+
+    leader_id: str
+    strategy: str
+    report: ExecutionReport
+    fees: Optional[float] = None
+
+    def leader_notional(self) -> float:
+        """Return the executed notional for the leader order."""
+
+        price = self.report.avg_price or self._last_fill_price()
+        if not price or self.report.filled_quantity <= 0:
+            return 0.0
+        return price * self.report.filled_quantity
+
+    def _last_fill_price(self) -> float:
+        for fill in reversed(self.report.fills):
+            if fill.price > 0:
+                return fill.price
+        return 0.0
+
+
+__all__ = ["LeaderExecutionEvent"]

--- a/services/copy_trading_worker/app/messaging.py
+++ b/services/copy_trading_worker/app/messaging.py
@@ -1,0 +1,49 @@
+"""Async primitives used to propagate leader executions to the worker."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+from .events import LeaderExecutionEvent
+
+
+class LeaderExecutionPublisher(Protocol):
+    """Publisher interface forwarding leader executions to the worker."""
+
+    async def publish(self, event: LeaderExecutionEvent) -> None:
+        raise NotImplementedError
+
+
+class LeaderExecutionConsumer(Protocol):
+    """Consumer interface implemented by the worker event loop."""
+
+    async def get(self) -> LeaderExecutionEvent | None:
+        raise NotImplementedError
+
+
+class InMemoryLeaderExecutionBroker(LeaderExecutionPublisher, LeaderExecutionConsumer):
+    """Simple asyncio queue used for development and testing."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[LeaderExecutionEvent | None] = asyncio.Queue()
+
+    async def publish(self, event: LeaderExecutionEvent) -> None:
+        await self._queue.put(event)
+
+    async def get(self) -> LeaderExecutionEvent | None:
+        event = await self._queue.get()
+        self._queue.task_done()
+        return event
+
+    async def close(self) -> None:
+        """Unblock pending consumers and signal shutdown."""
+
+        await self._queue.put(None)
+
+
+__all__ = [
+    "LeaderExecutionPublisher",
+    "LeaderExecutionConsumer",
+    "InMemoryLeaderExecutionBroker",
+]

--- a/services/copy_trading_worker/app/repository.py
+++ b/services/copy_trading_worker/app/repository.py
@@ -1,0 +1,119 @@
+"""Database access layer for copy-trading subscriptions."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Iterator, List
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from infra import Listing, MarketplaceSubscription
+from libs.db.db import SessionLocal
+
+
+@dataclass(slots=True)
+class CopySubscription:
+    """Projection of a copy-trading subscription used by the worker."""
+
+    id: int
+    follower_id: str
+    leader_id: str
+    strategy_name: str
+    leverage: float
+    allocated_capital: float | None
+    risk_limits: Dict[str, Any]
+
+
+class CopySubscriptionRepository:
+    """Repository retrieving subscriptions and recording replication outcomes."""
+
+    def __init__(self, session_factory: Callable[[], Session] = SessionLocal) -> None:
+        self._session_factory = session_factory
+
+    @contextmanager
+    def _session(self) -> Iterator[Session]:
+        session = self._session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def list_active_for_leader(
+        self, leader_id: str, *, strategy: str | None = None
+    ) -> List[CopySubscription]:
+        stmt: Select = (
+            select(MarketplaceSubscription, Listing)
+            .join(Listing, MarketplaceSubscription.listing_id == Listing.id)
+            .where(MarketplaceSubscription.status == "active", Listing.owner_id == leader_id)
+        )
+        if strategy:
+            stmt = stmt.where(Listing.strategy_name == strategy)
+
+        subscriptions: List[CopySubscription] = []
+        with self._session() as session:
+            for subscription, listing in session.execute(stmt).all():
+                subscriptions.append(
+                    CopySubscription(
+                        id=subscription.id,
+                        follower_id=subscription.subscriber_id,
+                        leader_id=listing.owner_id,
+                        strategy_name=listing.strategy_name,
+                        leverage=float(subscription.leverage or 1.0),
+                        allocated_capital=subscription.allocated_capital,
+                        risk_limits=dict(subscription.risk_limits or {}),
+                    )
+                )
+        return subscriptions
+
+    def record_success(
+        self,
+        subscription_id: int,
+        *,
+        divergence_bps: float | None,
+        fees: float,
+        status: str,
+        executed_at: datetime,
+    ) -> None:
+        with self._session() as session:
+            subscription = session.get(MarketplaceSubscription, subscription_id)
+            if not subscription:
+                return
+            subscription.replication_status = status
+            subscription.divergence_bps = divergence_bps
+            raw_previous = subscription.total_fees_paid or 0.0
+            try:
+                previous_fees = float(raw_previous)
+            except (TypeError, ValueError):
+                previous_fees = 0.0
+            subscription.total_fees_paid = max(0.0, previous_fees + max(fees, 0.0))
+            if executed_at.tzinfo is None:
+                executed_at = executed_at.replace(tzinfo=timezone.utc)
+            else:
+                executed_at = executed_at.astimezone(timezone.utc)
+            subscription.last_synced_at = executed_at
+            session.commit()
+
+    def record_failure(
+        self,
+        subscription_id: int,
+        *,
+        executed_at: datetime | None = None,
+    ) -> None:
+        with self._session() as session:
+            subscription = session.get(MarketplaceSubscription, subscription_id)
+            if not subscription:
+                return
+            subscription.replication_status = "error"
+            if executed_at:
+                if executed_at.tzinfo is None:
+                    executed_at = executed_at.replace(tzinfo=timezone.utc)
+                else:
+                    executed_at = executed_at.astimezone(timezone.utc)
+                subscription.last_synced_at = executed_at
+            session.commit()
+
+
+__all__ = ["CopySubscription", "CopySubscriptionRepository"]

--- a/services/copy_trading_worker/app/sizing.py
+++ b/services/copy_trading_worker/app/sizing.py
@@ -1,0 +1,67 @@
+"""Helpers used to scale leader executions to follower allocations."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from schemas.market import ExecutionReport
+
+
+def _coerce_positive(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric <= 0:
+        return None
+    return numeric
+
+
+def leader_reference_price(report: ExecutionReport) -> float:
+    if report.avg_price:
+        return report.avg_price
+    for fill in reversed(report.fills):
+        if fill.price > 0:
+            return fill.price
+    return 0.0
+
+
+def compute_scaled_quantity(
+    report: ExecutionReport,
+    *,
+    leverage: float,
+    allocated_capital: float | None,
+    risk_limits: Dict[str, object],
+) -> Tuple[float, float, float]:
+    """Return (quantity, price, notional) for the follower order."""
+
+    price = leader_reference_price(report)
+    if price <= 0 or report.filled_quantity <= 0:
+        return 0.0, price, 0.0
+
+    base_notional = report.filled_quantity * price
+    target_notional = base_notional * max(leverage, 0.0)
+
+    if allocated_capital is not None and allocated_capital >= 0:
+        target_notional = min(target_notional, allocated_capital)
+
+    max_notional = _coerce_positive(risk_limits.get("max_notional"))
+    if max_notional is not None:
+        target_notional = min(target_notional, max_notional)
+
+    if target_notional <= 0:
+        return 0.0, price, 0.0
+
+    quantity = target_notional / price
+
+    max_position = _coerce_positive(risk_limits.get("max_position"))
+    if max_position is not None and quantity > max_position:
+        quantity = max_position
+        target_notional = quantity * price
+
+    return quantity, price, target_notional
+
+
+__all__ = ["compute_scaled_quantity", "leader_reference_price"]

--- a/services/copy_trading_worker/app/worker.py
+++ b/services/copy_trading_worker/app/worker.py
@@ -1,0 +1,190 @@
+"""Asynchronous worker replicating leader executions for followers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Callable, Iterable, List, Protocol, Sequence
+
+from schemas.market import ExecutionReport, OrderType
+from schemas.order_router import ExecutionIntent
+
+from .events import LeaderExecutionEvent
+from .messaging import LeaderExecutionConsumer
+from .repository import CopySubscription, CopySubscriptionRepository
+from .sizing import compute_scaled_quantity, leader_reference_price
+
+LOGGER = logging.getLogger("copy_trading.worker")
+
+
+class OrderExecutionClient(Protocol):
+    """Protocol describing the order router dependency used by the worker."""
+
+    async def submit_order(self, intent: ExecutionIntent) -> ExecutionReport:
+        raise NotImplementedError
+
+
+class CopyTradingWorker:
+    """Consume leader executions and replicate them for follower accounts."""
+
+    def __init__(
+        self,
+        *,
+        consumer: LeaderExecutionConsumer,
+        order_executor: OrderExecutionClient,
+        repository: CopySubscriptionRepository,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._consumer = consumer
+        self._order_executor = order_executor
+        self._repository = repository
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._stopped = asyncio.Event()
+
+    async def stop(self) -> None:
+        """Request the worker loop to stop."""
+
+        self._stopped.set()
+        close = getattr(self._consumer, "close", None)
+        if callable(close):
+            result = close()
+            if asyncio.iscoroutine(result):
+                await result
+
+    async def run_forever(self) -> None:
+        """Continuously consume leader executions and replicate them."""
+
+        while not self._stopped.is_set():
+            event = await self._consumer.get()
+            if event is None:
+                if self._stopped.is_set():
+                    break
+                continue
+            if self._is_copy_event(event.report.tags):
+                continue
+            await self._handle_event(event)
+
+    async def _handle_event(self, event: LeaderExecutionEvent) -> None:
+        subscriptions = self._repository.list_active_for_leader(
+            event.leader_id, strategy=event.strategy
+        )
+        if not subscriptions:
+            LOGGER.debug("No active followers for leader %s", event.leader_id)
+            return
+
+        leader_price = leader_reference_price(event.report)
+        leader_notional = event.leader_notional()
+        executed_at = self._clock()
+
+        for subscription in subscriptions:
+            if self._should_suspend(subscription):
+                LOGGER.info(
+                    "Subscription %s paused by risk limits", subscription.id
+                )
+                continue
+
+            quantity, _, _ = compute_scaled_quantity(
+                event.report,
+                leverage=subscription.leverage,
+                allocated_capital=subscription.allocated_capital,
+                risk_limits=subscription.risk_limits,
+            )
+            if quantity <= 0:
+                LOGGER.debug(
+                    "Skipping follower %s due to zero target quantity", subscription.follower_id
+                )
+                continue
+
+            intent = ExecutionIntent(
+                broker=event.report.broker,
+                venue=event.report.venue,
+                symbol=event.report.symbol,
+                side=event.report.side,
+                quantity=quantity,
+                order_type=OrderType.MARKET,
+                account_id=subscription.follower_id,
+                tags=self._build_tags(event.report.tags, subscription),
+            )
+
+            try:
+                follower_report = await self._order_executor.submit_order(intent)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                LOGGER.warning(
+                    "Failed to replicate order for follower %s: %s",
+                    subscription.follower_id,
+                    exc,
+                )
+                self._repository.record_failure(
+                    subscription.id, executed_at=self._clock()
+                )
+                continue
+
+            divergence = self._compute_divergence(leader_price, follower_report)
+            follower_price = follower_report.avg_price or leader_reference_price(
+                follower_report
+            )
+            follower_notional = (
+                follower_price * follower_report.filled_quantity
+                if follower_price and follower_report.filled_quantity > 0
+                else 0.0
+            )
+            fees = self._estimate_fees(
+                leader_notional=leader_notional,
+                follower_notional=follower_notional,
+                leader_fees=event.fees,
+            )
+            status = follower_report.status.value
+            self._repository.record_success(
+                subscription.id,
+                divergence_bps=divergence,
+                fees=fees,
+                status=status,
+                executed_at=executed_at,
+            )
+
+    @staticmethod
+    def _is_copy_event(tags: Iterable[str]) -> bool:
+        for tag in tags or []:
+            if isinstance(tag, str) and tag.lower() == "copy:follower":
+                return True
+        return False
+
+    @staticmethod
+    def _should_suspend(subscription: CopySubscription) -> bool:
+        suspend = subscription.risk_limits.get("suspend")
+        return bool(suspend)
+
+    @staticmethod
+    def _build_tags(base_tags: Sequence[str], subscription: CopySubscription) -> List[str]:
+        tags = [tag for tag in base_tags or [] if isinstance(tag, str)]
+        tags.append("copy:follower")
+        tags.append(f"copy:subscription:{subscription.id}")
+        tags.append(f"copy:leader:{subscription.leader_id}")
+        return tags
+
+    @staticmethod
+    def _compute_divergence(
+        leader_price: float, follower_report: ExecutionReport
+    ) -> float | None:
+        follower_price = follower_report.avg_price or leader_reference_price(
+            follower_report
+        )
+        if leader_price <= 0 or follower_price <= 0:
+            return None
+        return ((follower_price - leader_price) / leader_price) * 10_000
+
+    @staticmethod
+    def _estimate_fees(
+        *,
+        leader_notional: float,
+        follower_notional: float,
+        leader_fees: float | None,
+    ) -> float:
+        if not leader_fees or leader_notional <= 0 or follower_notional <= 0:
+            return 0.0
+        scale = follower_notional / leader_notional
+        return max(0.0, leader_fees * scale)
+
+
+__all__ = ["CopyTradingWorker", "OrderExecutionClient"]

--- a/services/copy_trading_worker/tests/test_worker.py
+++ b/services/copy_trading_worker/tests/test_worker.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from infra import Listing, MarketplaceBase, MarketplaceSubscription
+from schemas.market import ExecutionFill, ExecutionReport, ExecutionStatus, ExecutionVenue, OrderSide
+from schemas.order_router import ExecutionIntent
+
+from services.copy_trading_worker.app.events import LeaderExecutionEvent
+from services.copy_trading_worker.app.messaging import InMemoryLeaderExecutionBroker
+from services.copy_trading_worker.app.repository import CopySubscriptionRepository
+from services.copy_trading_worker.app.worker import CopyTradingWorker, OrderExecutionClient
+
+
+@pytest.fixture()
+def database(tmp_path: Any) -> Session:
+    engine = create_engine(
+        f"sqlite+pysqlite:///{tmp_path}/copy_trading.db",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    MarketplaceBase.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    try:
+        yield SessionLocal
+    finally:
+        MarketplaceBase.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+class DummyOrderExecutor(OrderExecutionClient):
+    def __init__(self, report: ExecutionReport) -> None:
+        self._report = report
+        self.submitted: list[ExecutionIntent] = []
+        self.invocations = asyncio.Event()
+
+    async def submit_order(self, intent: ExecutionIntent) -> ExecutionReport:
+        self.submitted.append(intent)
+        self.invocations.set()
+        return self._report
+
+
+class FailingOrderExecutor(OrderExecutionClient):
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+        self.submitted: list[ExecutionIntent] = []
+        self.invocations = asyncio.Event()
+
+    async def submit_order(self, intent: ExecutionIntent) -> ExecutionReport:  # type: ignore[override]
+        self.submitted.append(intent)
+        self.invocations.set()
+        raise self.error
+
+
+def _seed_subscription(
+    session_factory: sessionmaker,
+    *,
+    listing_id: int = 1,
+    owner_id: str = "leader-1",
+    strategy_name: str = "Momentum Edge",
+    follower_id: str = "follower-1",
+    leverage: float = 2.0,
+    allocated_capital: float | None = 5_000.0,
+    risk_limits: dict[str, Any] | None = None,
+) -> int:
+    with session_factory() as session:
+        listing = Listing(
+            id=listing_id,
+            owner_id=owner_id,
+            strategy_name=strategy_name,
+            description="",
+            price_cents=10000,
+            currency="USD",
+            connect_account_id="acct_leader",
+            status="approved",
+        )
+        session.add(listing)
+        subscription = MarketplaceSubscription(
+            listing=listing,
+            subscriber_id=follower_id,
+            status="active",
+            leverage=leverage,
+            allocated_capital=allocated_capital,
+            risk_limits=risk_limits or {},
+            replication_status="idle",
+        )
+        session.add(subscription)
+        session.commit()
+        return subscription.id
+
+
+def _build_execution_report(quantity: float, price: float) -> ExecutionReport:
+    timestamp = datetime.now(timezone.utc)
+    return ExecutionReport(
+        order_id="ORD-1",
+        status=ExecutionStatus.FILLED,
+        broker="ib",
+        venue=ExecutionVenue.IBKR_PAPER,
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        quantity=quantity,
+        filled_quantity=quantity,
+        avg_price=price,
+        submitted_at=timestamp,
+        fills=[ExecutionFill(quantity=quantity, price=price, timestamp=timestamp)],
+        tags=["strategy:Momentum Edge"],
+    )
+
+
+def test_replication_nominal_flow(database: sessionmaker) -> None:
+    async def _run() -> None:
+        subscription_id = _seed_subscription(
+            database,
+            risk_limits={"max_notional": 4_000},
+        )
+        broker = InMemoryLeaderExecutionBroker()
+        follower_report = _build_execution_report(quantity=20, price=101.0)
+        executor = DummyOrderExecutor(follower_report)
+        repository = CopySubscriptionRepository(session_factory=database)
+        worker = CopyTradingWorker(
+            consumer=broker,
+            order_executor=executor,
+            repository=repository,
+            clock=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+
+        leader_report = _build_execution_report(quantity=10, price=100.0)
+        event = LeaderExecutionEvent(
+            leader_id="leader-1",
+            strategy="Momentum Edge",
+            report=leader_report,
+            fees=12.5,
+        )
+
+        task = asyncio.create_task(worker.run_forever())
+        await broker.publish(event)
+        await asyncio.wait_for(executor.invocations.wait(), timeout=2)
+        await worker.stop()
+        await asyncio.wait_for(task, timeout=2)
+
+        assert executor.submitted, "expected follower order to be routed"
+        submitted_intent = executor.submitted[0]
+        assert submitted_intent.account_id == "follower-1"
+        assert pytest.approx(submitted_intent.quantity, rel=1e-6) == 20.0
+        assert "copy:follower" in submitted_intent.tags
+        assert f"copy:subscription:{subscription_id}" in submitted_intent.tags
+
+        with database() as session:
+            stored = session.get(MarketplaceSubscription, subscription_id)
+            assert stored is not None
+            assert stored.replication_status == ExecutionStatus.FILLED.value
+            assert stored.last_synced_at == datetime(2024, 1, 1, tzinfo=timezone.utc)
+            assert stored.divergence_bps is not None
+            assert stored.divergence_bps == pytest.approx(100.0)
+            assert stored.total_fees_paid == pytest.approx(25.25, rel=1e-6)
+
+    asyncio.run(_run())
+
+
+def test_replication_error_updates_status(database: sessionmaker) -> None:
+    async def _run() -> None:
+        subscription_id = _seed_subscription(database)
+        broker = InMemoryLeaderExecutionBroker()
+        executor = FailingOrderExecutor(RuntimeError("router down"))
+        repository = CopySubscriptionRepository(session_factory=database)
+        worker = CopyTradingWorker(
+            consumer=broker,
+            order_executor=executor,
+            repository=repository,
+            clock=lambda: datetime(2024, 2, 1, tzinfo=timezone.utc),
+        )
+
+        event = LeaderExecutionEvent(
+            leader_id="leader-1",
+            strategy="Momentum Edge",
+            report=_build_execution_report(quantity=5, price=50.0),
+        )
+
+        task = asyncio.create_task(worker.run_forever())
+        await broker.publish(event)
+        await asyncio.wait_for(executor.invocations.wait(), timeout=2)
+        await worker.stop()
+        await asyncio.wait_for(task, timeout=2)
+
+        with database() as session:
+            stored = session.get(MarketplaceSubscription, subscription_id)
+            assert stored is not None
+            assert stored.replication_status == "error"
+            assert stored.total_fees_paid == pytest.approx(0.0)
+
+    asyncio.run(_run())
+
+
+def test_worker_stops_without_events(database: sessionmaker) -> None:
+    async def _run() -> None:
+        _seed_subscription(database)
+        broker = InMemoryLeaderExecutionBroker()
+        executor = DummyOrderExecutor(_build_execution_report(quantity=1, price=1.0))
+        repository = CopySubscriptionRepository(session_factory=database)
+        worker = CopyTradingWorker(
+            consumer=broker,
+            order_executor=executor,
+            repository=repository,
+        )
+
+        task = asyncio.create_task(worker.run_forever())
+        await worker.stop()
+        await asyncio.wait_for(task, timeout=2)
+
+        assert not executor.submitted
+
+    asyncio.run(_run())

--- a/services/marketplace/app/schemas.py
+++ b/services/marketplace/app/schemas.py
@@ -67,6 +67,9 @@ class CopyRequest(BaseModel):
     listing_id: int
     version_id: Optional[int] = None
     payment_reference: Optional[str] = Field(default=None, max_length=128)
+    leverage: float = Field(default=1.0, ge=0.1, le=10.0)
+    allocated_capital: Optional[float] = Field(default=None, ge=0)
+    risk_limits: Dict[str, Any] = Field(default_factory=dict)
 
 
 class CopyResponse(BaseModel):
@@ -77,6 +80,15 @@ class CopyResponse(BaseModel):
     payment_reference: Optional[str]
     connect_transfer_reference: Optional[str]
     status: str
+    leverage: float
+    allocated_capital: Optional[float]
+    risk_limits: Dict[str, Any]
+    replication_status: str
+    divergence_bps: Optional[float]
+    total_fees_paid: float
+    last_synced_at: Optional[datetime]
+    strategy_name: Optional[str] = None
+    leader_id: Optional[str] = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/services/web-dashboard/app/main.py
+++ b/services/web-dashboard/app/main.py
@@ -36,6 +36,7 @@ from .data import (
     ORDER_ROUTER_BASE_URL,
     ORDER_ROUTER_TIMEOUT_SECONDS,
     load_dashboard_context,
+    load_follower_dashboard,
     load_portfolio_history,
     load_tradingview_config,
     save_tradingview_config,
@@ -76,6 +77,7 @@ AI_ASSISTANT_BASE_URL = os.getenv(
     "http://ai-strategy-assistant:8085/",
 )
 AI_ASSISTANT_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AI_ASSISTANT_TIMEOUT", "10.0"))
+DEFAULT_FOLLOWER_ID = os.getenv("WEB_DASHBOARD_DEFAULT_FOLLOWER_ID", "demo-investor")
 
 security = HTTPBearer(auto_error=False)
 
@@ -817,6 +819,23 @@ def render_dashboard(request: Request) -> HTMLResponse:
             },
             "active_page": "dashboard",
             "annotation_status": request.query_params.get("annotation"),
+        },
+    )
+
+
+@app.get("/dashboard/followers", response_class=HTMLResponse)
+def render_follower_dashboard(request: Request) -> HTMLResponse:
+    """Render the follower dashboard summarising copy-trading allocations."""
+
+    viewer_id = request.headers.get("x-user-id") or request.query_params.get("viewer_id")
+    viewer_id = viewer_id or DEFAULT_FOLLOWER_ID
+    context = load_follower_dashboard(viewer_id)
+    return templates.TemplateResponse(
+        "follower.html",
+        {
+            "request": request,
+            "context": context,
+            "active_page": "followers",
         },
     )
 

--- a/services/web-dashboard/app/schemas.py
+++ b/services/web-dashboard/app/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
 
 from enum import Enum
 
@@ -434,6 +434,30 @@ class TradingViewConfigUpdate(BaseModel):
     default_symbol: str | None = Field(default=None)
     symbol_map: Dict[str, str] | None = Field(default=None)
     overlays: List[TradingViewOverlay] | None = Field(default=None)
+
+
+class FollowerCopySnapshot(BaseModel):
+    """State of a copy-trading subscription from the follower perspective."""
+
+    listing_id: int
+    strategy_name: str | None = None
+    leader_id: str | None = None
+    leverage: float
+    allocated_capital: float | None = None
+    risk_limits: Dict[str, Any] = Field(default_factory=dict)
+    divergence_bps: float | None = None
+    estimated_fees: float = 0.0
+    replication_status: str = "idle"
+    last_synced_at: datetime | None = None
+
+
+class FollowerDashboardContext(BaseModel):
+    """Aggregated view rendered by the follower dashboard."""
+
+    copies: List[FollowerCopySnapshot] = Field(default_factory=list)
+    source: Literal["live", "fallback"] = "live"
+    viewer_id: str
+    fallback_reason: str | None = None
 
 
 class DashboardContext(BaseModel):

--- a/services/web-dashboard/app/templates/account.html
+++ b/services/web-dashboard/app/templates/account.html
@@ -24,6 +24,13 @@
           Marketplace
         </a>
         <a
+          href="{{ request.url_for('render_follower_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'followers' else '' }}"
+          aria-current="{{ 'page' if active_page == 'followers' else 'false' }}"
+        >
+          Suivi copies
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -24,6 +24,13 @@
           Marketplace
         </a>
         <a
+          href="{{ request.url_for('render_follower_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'followers' else '' }}"
+          aria-current="{{ 'page' if active_page == 'followers' else 'false' }}"
+        >
+          Suivi copies
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/app/templates/follower.html
+++ b/services/web-dashboard/app/templates/follower.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Suivi des copies</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="layout__header">
+      <nav class="app-nav" aria-label="Navigation principale">
+        <a
+          href="{{ request.url_for('render_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'dashboard' else '' }}"
+          aria-current="{{ 'page' if active_page == 'dashboard' else 'false' }}"
+        >
+          Tableau de bord
+        </a>
+        <a
+          href="{{ request.url_for('render_marketplace') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'marketplace' else '' }}"
+          aria-current="{{ 'page' if active_page == 'marketplace' else 'false' }}"
+        >
+          Marketplace
+        </a>
+        <a
+          href="{{ request.url_for('render_follower_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'followers' else '' }}"
+          aria-current="{{ 'page' if active_page == 'followers' else 'false' }}"
+        >
+          Suivi copies
+        </a>
+        <a
+          href="{{ request.url_for('render_strategies') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
+          aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"
+        >
+          Stratégies
+        </a>
+        <a
+          href="{{ request.url_for('render_strategy_documentation') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategy-docs' else '' }}"
+          aria-current="{{ 'page' if active_page == 'strategy-docs' else 'false' }}"
+        >
+          Documentation stratégies
+        </a>
+        <a
+          href="{{ request.url_for('render_account') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
+          aria-current="{{ 'page' if active_page == 'account' else 'false' }}"
+        >
+          Compte &amp; API
+        </a>
+      </nav>
+      <h1 class="heading heading--xl">Suivi des copies</h1>
+      <p class="text text--muted">
+        Visualisez l'état de vos abonnements copy-trading : niveaux de levier, divergence d'exécution et frais estimés.
+      </p>
+    </header>
+    <main class="layout__main">
+      {% if context.source != 'live' %}
+      <section class="card" aria-live="polite">
+        <div class="card__body">
+          <p class="text text--muted">{{ context.fallback_reason or 'Les données en temps réel ne sont pas disponibles pour le moment.' }}</p>
+        </div>
+      </section>
+      {% endif %}
+      <section class="card" aria-labelledby="copies-title">
+        <div class="card__header">
+          <h2 id="copies-title" class="heading heading--lg">Copies actives</h2>
+          <p class="text text--muted">Identifiant suiveur : {{ context.viewer_id }}</p>
+        </div>
+        <div class="card__body">
+          {% if context.copies %}
+          <div class="table-responsive">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th scope="col">Stratégie</th>
+                  <th scope="col">Leader</th>
+                  <th scope="col">Levier</th>
+                  <th scope="col">Capital alloué</th>
+                  <th scope="col">Divergence (bps)</th>
+                  <th scope="col">Frais estimés</th>
+                  <th scope="col">Statut</th>
+                  <th scope="col">Dernière synchro</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for copy in context.copies %}
+                <tr>
+                  <td data-label="Stratégie">{{ copy.strategy_name or 'N/A' }}</td>
+                  <td data-label="Leader">{{ copy.leader_id or '—' }}</td>
+                  <td data-label="Levier">{{ '%.2f' | format(copy.leverage) }}</td>
+                  <td data-label="Capital alloué">
+                    {% if copy.allocated_capital is not none %}
+                    {{ '%.2f' | format(copy.allocated_capital) }}
+                    {% else %}
+                    —
+                    {% endif %}
+                  </td>
+                  <td data-label="Divergence (bps)">
+                    {% if copy.divergence_bps is not none %}
+                    {{ '%.2f' | format(copy.divergence_bps) }}
+                    {% else %}
+                    —
+                    {% endif %}
+                  </td>
+                  <td data-label="Frais estimés">{{ '%.2f' | format(copy.estimated_fees) }}</td>
+                  <td data-label="Statut">
+                    <span class="badge {{ 'badge--success' if copy.replication_status == 'filled' else 'badge--info' if copy.replication_status == 'active' else 'badge--warning' if copy.replication_status == 'pending' else 'badge--critical' if copy.replication_status == 'error' else 'badge--neutral' }}">
+                      {{ copy.replication_status | capitalize }}
+                    </span>
+                  </td>
+                  <td data-label="Dernière synchro">
+                    {% if copy.last_synced_at %}
+                    {{ copy.last_synced_at.strftime('%d/%m/%Y %H:%M') }}
+                    {% else %}
+                    —
+                    {% endif %}
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <p class="text text--muted">
+            Aucun abonnement actif n'a été trouvé pour votre profil. Abonnez-vous depuis la marketplace pour activer la réplication.
+          </p>
+          {% endif %}
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/services/web-dashboard/app/templates/marketplace.html
+++ b/services/web-dashboard/app/templates/marketplace.html
@@ -24,6 +24,13 @@
           Marketplace
         </a>
         <a
+          href="{{ request.url_for('render_follower_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'followers' else '' }}"
+          aria-current="{{ 'page' if active_page == 'followers' else 'false' }}"
+        >
+          Suivi copies
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/app/templates/strategies.html
+++ b/services/web-dashboard/app/templates/strategies.html
@@ -24,6 +24,13 @@
           Marketplace
         </a>
         <a
+          href="{{ request.url_for('render_follower_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'followers' else '' }}"
+          aria-current="{{ 'page' if active_page == 'followers' else 'false' }}"
+        >
+          Suivi copies
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/app/templates/strategy_documentation.html
+++ b/services/web-dashboard/app/templates/strategy_documentation.html
@@ -24,6 +24,13 @@
           Marketplace
         </a>
         <a
+          href="{{ request.url_for('render_follower_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'followers' else '' }}"
+          aria-current="{{ 'page' if active_page == 'followers' else 'false' }}"
+        >
+          Suivi copies
+        </a>
+        <a
           href="{{ request.url_for('render_strategies') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"

--- a/services/web-dashboard/tests/test_follower_page.py
+++ b/services/web-dashboard/tests/test_follower_page.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from web_dashboard.app import data
+from web_dashboard.app.schemas import FollowerCopySnapshot, FollowerDashboardContext
+
+from .utils import load_dashboard_app
+
+
+def test_follower_dashboard_renders_table(monkeypatch) -> None:
+    context = FollowerDashboardContext(
+        copies=[
+            FollowerCopySnapshot(
+                listing_id=1,
+                strategy_name="Momentum Edge",
+                leader_id="creator-1",
+                leverage=1.2,
+                allocated_capital=1000.0,
+                divergence_bps=42.0,
+                estimated_fees=5.0,
+                replication_status="filled",
+            )
+        ],
+        viewer_id="investor-1",
+    )
+    load_dashboard_app.cache_clear()
+    app = load_dashboard_app()
+    from web_dashboard.app import main as dashboard_main
+
+    monkeypatch.setattr(data, "load_follower_dashboard", lambda viewer_id: context)
+    monkeypatch.setattr(dashboard_main, "load_follower_dashboard", lambda viewer_id: context)
+    client = TestClient(app)
+    response = client.get("/dashboard/followers")
+    assert response.status_code == 200
+    html = response.text
+    assert "Suivi des copies" in html
+    assert "Momentum Edge" in html
+    assert "creator-1" in html
+    assert "1.20" in html
+
+
+def test_follower_dashboard_uses_fallback_message(monkeypatch) -> None:
+    context = FollowerDashboardContext(
+        copies=[],
+        viewer_id="investor-9",
+        source="fallback",
+        fallback_reason="Marketplace indisponible",
+    )
+    load_dashboard_app.cache_clear()
+    app = load_dashboard_app()
+    from web_dashboard.app import main as dashboard_main
+
+    monkeypatch.setattr(data, "load_follower_dashboard", lambda viewer_id: context)
+    monkeypatch.setattr(dashboard_main, "load_follower_dashboard", lambda viewer_id: context)
+    client = TestClient(app)
+    response = client.get("/dashboard/followers")
+    assert response.status_code == 200
+    assert "Marketplace indisponible" in response.text

--- a/services/web-dashboard/tests/utils.py
+++ b/services/web-dashboard/tests/utils.py
@@ -17,6 +17,11 @@ PACKAGE_NAME = "web_dashboard"
 def load_dashboard_app():
     """Return the FastAPI application exposed by the dashboard service."""
 
+    if "python_multipart" not in sys.modules:
+        python_multipart_module = types.ModuleType("python_multipart")
+        python_multipart_module.__version__ = "0.0.20"
+        sys.modules.setdefault("python_multipart", python_multipart_module)
+
     package = types.ModuleType(PACKAGE_NAME)
     package.__path__ = [str(MODULE_PATH.parents[1])]
     sys.modules.setdefault(PACKAGE_NAME, package)


### PR DESCRIPTION
## Summary
- add a copy-trading worker service that consumes leader executions and routes scaled follower orders
- extend marketplace subscription models and APIs to capture replication configuration and metrics
- introduce a follower dashboard in the web UI showing subscription health, divergence, and fees

## Testing
- pytest services/copy_trading_worker/tests/test_worker.py
- pytest services/marketplace/tests/test_marketplace_service.py
- pytest services/web-dashboard/tests/test_dashboard_data_sources.py services/web-dashboard/tests/test_follower_page.py

------
https://chatgpt.com/codex/tasks/task_e_68deb18399a08332916eb82511211490