### PR TITLE
Pin external deps and centralize workflow installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ jobs:
         run: pre-commit run -a
       - name: Install test deps
         run: |
-          python -m pip install -r services/config-service/requirements-dev.txt
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -r requirements/services.txt
+          pip install -r requirements/services-dev.txt
+
+      - name: Install Playwright browsers
+        run: python -m playwright install --with-deps chromium
       - name: Run tests
         run: pytest -q
       - name: Build config-service Docker image

--- a/.github/workflows/metrics-dashboard.yml
+++ b/.github/workflows/metrics-dashboard.yml
@@ -28,8 +28,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          pip install -r services/codex_gateway/requirements-dev.txt
-          pip install -r services/codex_worker/requirements-dev.txt
+          pip install -r requirements/services.txt
+          pip install -r requirements/services-dev.txt
+
+      - name: Install Playwright browsers
+        run: python -m playwright install --with-deps chromium
 
       - name: Run unit tests with coverage
         id: unit-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          pip install -r services/codex_gateway/requirements-dev.txt
-          pip install -r services/codex_worker/requirements-dev.txt
-          pip install -r services/web-dashboard/requirements-dev.txt
+          pip install -r requirements/services.txt
+          pip install -r requirements/services-dev.txt
       - name: Install Playwright browsers
         run: python -m playwright install --with-deps chromium
       - name: Run test suite

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ lint:
 
 test:
 	python -m pip install -r requirements-dev.txt
-	python -m pip install -r services/auth-service/requirements-dev.txt
-	python -m pip install -r services/config-service/requirements-dev.txt
+	python -m pip install -r requirements/services.txt
+	python -m pip install -r requirements/services-dev.txt
 	python -m coverage erase
 	python -m coverage run -m pytest
 	python -m coverage xml

--- a/requirements/services-dev.txt
+++ b/requirements/services-dev.txt
@@ -1,0 +1,13 @@
+# Consolidated development/test dependencies for Python services.
+-r ../services/auth-service/requirements-dev.txt
+-r ../services/billing-service/requirements-dev.txt
+-r ../services/codex_gateway/requirements-dev.txt
+-r ../services/codex_worker/requirements-dev.txt
+-r ../services/config-service/requirements-dev.txt
+-r ../services/entitlements-service/requirements-dev.txt
+-r ../services/notification-service/requirements-dev.txt
+-r ../services/screener/requirements-dev.txt
+-r ../services/streaming/requirements-dev.txt
+-r ../services/streaming_gateway/requirements-dev.txt
+-r ../services/user-service/requirements-dev.txt
+-r ../services/web-dashboard/requirements-dev.txt

--- a/requirements/services.txt
+++ b/requirements/services.txt
@@ -1,0 +1,23 @@
+# Consolidated runtime dependencies for all Python services.
+# Each entry references the service-specific requirements file to ensure
+# GitHub workflows and local automation install a consistent set of
+# third-party packages before running tests.
+-r ../services/alert_engine/requirements.txt
+-r ../services/algo-engine/requirements.txt
+-r ../services/ai-strategy-assistant/requirements.txt
+-r ../services/auth-service/requirements.txt
+-r ../services/billing-service/requirements.txt
+-r ../services/codex_gateway/requirements.txt
+-r ../services/codex_worker/requirements.txt
+-r ../services/config-service/requirements.txt
+-r ../services/entitlements-service/requirements.txt
+-r ../services/inplay/requirements.txt
+-r ../services/market_data/requirements.txt
+-r ../services/notification-service/requirements.txt
+-r ../services/order-router/requirements.txt
+-r ../services/reports/requirements.txt
+-r ../services/screener/requirements.txt
+-r ../services/streaming/requirements.txt
+-r ../services/streaming_gateway/requirements.txt
+-r ../services/user-service/requirements.txt
+-r ../services/web-dashboard/requirements.txt

--- a/services/ai-strategy-assistant/requirements.txt
+++ b/services/ai-strategy-assistant/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.109
 uvicorn[standard]>=0.24
-langchain>=0.2
-langchain-openai>=0.1.8
+langchain==0.2.11
+langchain-openai==0.1.20
 openai>=1.12
 pydantic>=2.5

--- a/services/algo-engine/requirements.txt
+++ b/services/algo-engine/requirements.txt
@@ -5,6 +5,6 @@ pydantic>=2
 prometheus-client>=0.20
 
 # Optional AI strategy assistant runtime
-langchain>=0.2
-langchain-openai>=0.1.8
+langchain==0.2.11
+langchain-openai==0.1.20
 openai>=1.12

--- a/services/market_data/requirements.txt
+++ b/services/market_data/requirements.txt
@@ -2,7 +2,7 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.30.0
 sqlalchemy>=2.0.0
 psycopg2-binary>=2.9.0
-binance-connector>=3.12.0
+binance-connector==3.12.0
 ib-async>=2.0.1
 pydantic>=1.10,<3
 pydantic-settings>=2.2

--- a/services/web-dashboard/requirements-dev.txt
+++ b/services/web-dashboard/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 pytest
 httpx
-pytest-playwright
-playwright
+pytest-playwright==0.5.1
+playwright==1.49.0

--- a/services/web-dashboard/requirements.txt
+++ b/services/web-dashboard/requirements.txt
@@ -2,4 +2,4 @@ fastapi>=0.110,<1.0
 uvicorn[standard]>=0.27
 jinja2>=3.1
 httpx>=0.26
-markdown>=3.5
+markdown==3.5.2


### PR DESCRIPTION
## Summary
- pin langchain, langchain-openai, binance-connector, markdown, and Playwright dependencies where they are used
- add consolidated service requirements files and update the Makefile and GitHub workflows to install them
- ensure CI workflows install Playwright browsers before executing tests

## Testing
- make test *(fails: ModuleNotFoundError: No module named 'app.rendering')*

------
https://chatgpt.com/codex/tasks/task_e_68deb5d3766883328364fbbcba4951b5