### PR TITLE
Add dry-run simulation pipeline with streaming updates

### DIFF
--- a/infra/trading_models.py
+++ b/infra/trading_models.py
@@ -105,4 +105,34 @@ class Execution(TradingBase):
     )
 
 
-__all__ = ["TradingBase", "Order", "Execution"]
+class SimulatedExecution(TradingBase):
+    """Represents a simulated execution captured in dry-run mode."""
+
+    __tablename__ = "simulated_executions"
+
+    id: int = Column(SQLITE_BIGINT, primary_key=True, autoincrement=True)
+    simulation_id: str = Column(String(128), unique=True, nullable=False)
+    correlation_id: Optional[str] = Column(String(128), index=True)
+    account_id: str = Column(String(64), nullable=False, index=True)
+    broker: str = Column(String(32), nullable=False, index=True)
+    venue: str = Column(String(64), nullable=False, index=True)
+    symbol: str = Column(String(32), nullable=False, index=True)
+    side: str = Column(String(8), nullable=False)
+    quantity: Decimal = Column(Numeric(20, 8), nullable=False)
+    filled_quantity: Decimal = Column(Numeric(20, 8), nullable=False)
+    price: Decimal = Column(Numeric(20, 8), nullable=False)
+    status: str = Column(String(16), nullable=False, default="filled")
+    submitted_at: datetime = Column(DateTime(timezone=True), nullable=False)
+    created_at: datetime = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    notes: Optional[str] = Column(Text)
+    tags: list[str] = Column(JSON, nullable=False, default=list)
+
+    __table_args__ = (
+        Index("ix_simulated_executions_account_submitted", "account_id", "submitted_at"),
+        Index("ix_simulated_executions_symbol_submitted", "symbol", "submitted_at"),
+    )
+
+
+__all__ = ["TradingBase", "Order", "Execution", "SimulatedExecution"]

--- a/services/order-router/tests/conftest.py
+++ b/services/order-router/tests/conftest.py
@@ -12,7 +12,12 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from infra.trading_models import Execution as ExecutionModel, Order as OrderModel, TradingBase
+from infra.trading_models import (
+    Execution as ExecutionModel,
+    Order as OrderModel,
+    SimulatedExecution as SimulatedExecutionModel,
+    TradingBase,
+)
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 
@@ -98,6 +103,7 @@ def clean_database(db_module, router) -> Generator[None, None, None]:
     """Ensure each test starts from an empty persistence layer."""
     session = db_module.SessionLocal()
     try:
+        session.query(SimulatedExecutionModel).delete()
         session.query(ExecutionModel).delete()
         session.query(OrderModel).delete()
         session.commit()
@@ -112,6 +118,7 @@ def clean_database(db_module, router) -> Generator[None, None, None]:
 
     session = db_module.SessionLocal()
     try:
+        session.query(SimulatedExecutionModel).delete()
         session.query(ExecutionModel).delete()
         session.query(OrderModel).delete()
         session.commit()


### PR DESCRIPTION
## Summary
- add a simulated_executions table to persist dry-run fills independently from live orders
- extend the order router with a dry_run mode that records simulated fills, rebuilds virtual positions, and streams them
- publish dry-run portfolio snapshots and logs via the streaming publisher while validating the new mode through tests

## Testing
- pytest services/order-router/tests

------
https://chatgpt.com/codex/tasks/task_e_68ded23e2bbc83329202ac12723703ae