### PR TITLE
feat: add help center knowledge base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage.xml
 # OS
 .DS_Store
 Thumbs.db
+alert_events.db

--- a/docs/help/catalog.json
+++ b/docs/help/catalog.json
@@ -1,0 +1,42 @@
+[
+  {
+    "slug": "faq-api-access",
+    "title": "Comment connecter mes clés API broker ?",
+    "summary": "Procédure pas à pas pour générer, vérifier et enregistrer vos clés API.",
+    "resource_type": "faq",
+    "category": "Configuration",
+    "body_path": "faq/api-access.md",
+    "resource_link": null,
+    "tags": ["api", "sécurité", "onboarding"]
+  },
+  {
+    "slug": "guide-onboarding",
+    "title": "Parcours d'onboarding du tableau de bord",
+    "summary": "Découvrez les modules essentiels et les bonnes pratiques pour démarrer.",
+    "resource_type": "guide",
+    "category": "Guides",
+    "body_path": "guides/getting-started.md",
+    "resource_link": "https://github.com/decarvalhoe/trading-bot-open-source/blob/main/docs/ui/README.md",
+    "tags": ["tableau de bord", "formation"]
+  },
+  {
+    "slug": "webinar-automation",
+    "title": "Webinar — Automatiser ses stratégies",
+    "summary": "Session enregistrée présentant la configuration complète d'une stratégie algorithmique.",
+    "resource_type": "webinar",
+    "category": "Webinars",
+    "body_path": "webinars/automation-webinar.md",
+    "resource_link": "https://example.com/webinars/automation",
+    "tags": ["automation", "stratégies"]
+  },
+  {
+    "slug": "notebook-risk-checklist",
+    "title": "Notebook — Checklist de contrôle des risques",
+    "summary": "Analyse interactive des limites de risque et calculs d'exposition quotidienne.",
+    "resource_type": "notebook",
+    "category": "Notebooks",
+    "body_path": "notebooks/risk-checklist.md",
+    "resource_link": "https://nbviewer.org/github/decarvalhoe/trading-bot-open-source/blob/main/docs/tutorials/risk-checklist.ipynb",
+    "tags": ["risque", "monitoring"]
+  }
+]

--- a/docs/help/faq/api-access.md
+++ b/docs/help/faq/api-access.md
@@ -1,0 +1,12 @@
+### Étapes recommandées
+
+1. Connectez-vous à l'espace client de votre broker et générez une paire de clés API en lecture/écriture.
+2. Restreignez l'adresse IP aux plages utilisées par le routeur d'ordres, puis téléchargez le fichier de sauvegarde.
+3. Dans le tableau de bord, ouvrez la page « Compte & API » et collez les clés dans les champs prévus.
+4. Validez : un test de latence et de permissions sera lancé automatiquement.
+
+### Bonnes pratiques
+
+- Renouvelez vos clés tous les 90 jours.
+- Limitez les permissions au strict nécessaire (trading au comptant ou dérivés).
+- Surveillez l'historique des connexions dans le tableau de bord sécurité du broker.

--- a/docs/help/guides/getting-started.md
+++ b/docs/help/guides/getting-started.md
@@ -1,0 +1,14 @@
+## Objectifs du parcours
+
+- Comprendre la structure du tableau de bord et la navigation multi-modules.
+- Configurer les flux de données (market data, alertes, streaming).
+- Déployer votre première stratégie algorithmique via le concepteur visuel.
+
+## Plan d'action
+
+1. **Préparation** — Vérifiez les dépendances dans `requirements.txt` et créez votre `.env`.
+2. **Découverte** — Parcourez le tableau de bord, puis ouvrez la marketplace pour activer une stratégie de démonstration.
+3. **Personnalisation** — Utilisez le module de backtest pour valider les paramètres et générer un rapport.
+4. **Suivi** — Activez les notifications et configurez les alertes critiques pour surveiller les dérives.
+
+> 💡 Astuce : associez ce guide au webinar « Automatiser ses stratégies » pour voir la configuration complète en direct.

--- a/docs/help/notebooks/risk-checklist.md
+++ b/docs/help/notebooks/risk-checklist.md
@@ -1,0 +1,11 @@
+### Métriques analysées
+
+- **Value-at-Risk journalier** avec rééchantillonnage à 95 %.
+- **Exposition par classe d'actifs** avec seuils configurables.
+- **Stress tests** basés sur les pires sessions historiques agrégées.
+
+### Comment l'utiliser ?
+
+1. Ouvrez le notebook dans `nbviewer` puis exécutez la cellule d'initialisation.
+2. Importez vos historiques en CSV ou via l'API `reports-service`.
+3. Exportez la synthèse en Markdown pour l'ajouter à la base de connaissances.

--- a/docs/help/webinars/automation-webinar.md
+++ b/docs/help/webinars/automation-webinar.md
@@ -1,0 +1,10 @@
+### Agenda
+
+- Architecture cible : orchestrateur, moteur d'alertes et streaming en temps réel.
+- Démonstration de configuration : création d'une stratégie et planification des backtests.
+- Session de questions / réponses : bonnes pratiques de supervision.
+
+### Ressources complémentaires
+
+- Slides PDF disponibles dans l'espace communauté.
+- Exemple de configuration YAML partagé dans le dépôt (`docs/strategies/examples`).

--- a/services/web-dashboard/app/data.py
+++ b/services/web-dashboard/app/data.py
@@ -22,6 +22,7 @@ from libs.portfolio import encode_portfolio_key, encode_position_key
 from .order_router_client import OrderRouterClient, OrderRouterError
 from .schemas import (
     Alert,
+    AlertRuleDefinition,
     DashboardContext,
     FollowerCopySnapshot,
     FollowerDashboardContext,
@@ -397,6 +398,7 @@ def _fallback_alerts() -> List[Alert]:
             detail="Portfolio Growth is at 82% of the allowed maintenance margin.",
             risk=RiskLevel.warning,
             created_at=base_time - timedelta(minutes=35),
+            rule=AlertRuleDefinition(symbol="Growth", timeframe="1h"),
         ),
         Alert(
             id="drawdown",
@@ -404,6 +406,7 @@ def _fallback_alerts() -> List[Alert]:
             detail="Income portfolio dropped 6% over the last trading session.",
             risk=RiskLevel.critical,
             created_at=base_time - timedelta(hours=7),
+            rule=AlertRuleDefinition(symbol="Income", timeframe="1d"),
         ),
         Alert(
             id="news",
@@ -412,6 +415,7 @@ def _fallback_alerts() -> List[Alert]:
             risk=RiskLevel.info,
             created_at=base_time - timedelta(hours=1, minutes=10),
             acknowledged=True,
+            rule=AlertRuleDefinition(symbol="AAPL", timeframe="1h"),
         ),
     ]
 

--- a/services/web-dashboard/app/help_progress.py
+++ b/services/web-dashboard/app/help_progress.py
@@ -1,0 +1,134 @@
+"""In-memory tracker for learning activity inside the help center."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Deque, Dict, Set
+
+
+@dataclass(slots=True)
+class LearningResourceVisit:
+    """Represents a resource recently consulted by the user."""
+
+    slug: str
+    title: str
+    resource_type: str
+    viewed_at: datetime
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "slug": self.slug,
+            "title": self.title,
+            "resource_type": self.resource_type,
+            "viewed_at": self.viewed_at.isoformat(timespec="seconds"),
+        }
+
+
+@dataclass(slots=True)
+class LearningProgress:
+    """Aggregated progress metrics for rendering in the UI."""
+
+    user_id: str
+    completion_rate: int
+    completed_resources: int
+    total_resources: int
+    recent_resources: list[LearningResourceVisit]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "user_id": self.user_id,
+            "completion_rate": self.completion_rate,
+            "completed_resources": self.completed_resources,
+            "total_resources": self.total_resources,
+            "recent_resources": [visit.to_payload() for visit in self.recent_resources],
+        }
+
+
+class LearningTracker:
+    """Minimal tracker storing learning activity per user in memory."""
+
+    def __init__(self, max_recent: int = 5):
+        self._max_recent = max_recent
+        self._recent: Dict[str, Deque[LearningResourceVisit]] = {}
+        self._visited: Dict[str, Set[str]] = {}
+
+    def _ensure_user(self, user_id: str) -> Deque[LearningResourceVisit]:
+        if user_id not in self._recent:
+            now = datetime.now(UTC)
+            seed_history = deque(maxlen=self._max_recent)
+            seed_history.append(
+                LearningResourceVisit(
+                    slug="guide-onboarding",
+                    title="Parcours d'onboarding du tableau de bord",
+                    resource_type="guide",
+                    viewed_at=now - timedelta(days=2, hours=5),
+                )
+            )
+            seed_history.append(
+                LearningResourceVisit(
+                    slug="faq-api-access",
+                    title="Comment connecter mes clés API broker ?",
+                    resource_type="faq",
+                    viewed_at=now - timedelta(days=1, hours=3),
+                )
+            )
+            self._recent[user_id] = seed_history
+            self._visited[user_id] = {visit.slug for visit in seed_history}
+        return self._recent[user_id]
+
+    def record_visit(self, user_id: str, slug: str, title: str, resource_type: str) -> None:
+        history = self._ensure_user(user_id)
+        visited = self._visited.setdefault(user_id, set())
+
+        visited.add(slug)
+        history.appendleft(
+            LearningResourceVisit(
+                slug=slug,
+                title=title,
+                resource_type=resource_type,
+                viewed_at=datetime.now(UTC),
+            )
+        )
+
+    def get_progress(self, user_id: str, total_resources: int) -> LearningProgress:
+        history = list(self._ensure_user(user_id))
+        visited = self._visited.setdefault(user_id, set())
+        completed = len(visited)
+        completion_rate = 0
+        if total_resources > 0:
+            completion_rate = round((completed / total_resources) * 100)
+            if completion_rate > 100:
+                completion_rate = 100
+        return LearningProgress(
+            user_id=user_id,
+            completion_rate=completion_rate,
+            completed_resources=completed,
+            total_resources=total_resources,
+            recent_resources=history[: self._max_recent],
+        )
+
+
+_tracker = LearningTracker()
+
+
+def record_learning_activity(user_id: str, slug: str, title: str, resource_type: str) -> None:
+    """Record that a user has consulted a resource."""
+
+    if not user_id or not slug:
+        return
+    _tracker.record_visit(user_id=user_id, slug=slug, title=title, resource_type=resource_type)
+
+
+def get_learning_progress(user_id: str, total_resources: int) -> LearningProgress:
+    """Return the aggregated learning progress for the given user."""
+
+    return _tracker.get_progress(user_id=user_id, total_resources=total_resources)
+
+
+__all__ = [
+    "LearningProgress",
+    "LearningResourceVisit",
+    "get_learning_progress",
+    "record_learning_activity",
+]

--- a/services/web-dashboard/app/helpcenter.py
+++ b/services/web-dashboard/app/helpcenter.py
@@ -1,0 +1,193 @@
+"""Helpers for exposing the help & training knowledge base."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterable, Literal
+
+import markdown
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELP_ROOT = REPO_ROOT / "docs" / "help"
+CATALOG_PATH = HELP_ROOT / "catalog.json"
+
+HelpArticleType = Literal["faq", "guide", "webinar", "notebook"]
+
+
+@dataclass(slots=True)
+class HelpArticle:
+    """Single article rendered for the help center UI."""
+
+    slug: str
+    title: str
+    summary: str
+    resource_type: HelpArticleType
+    category: str
+    body_html: str
+    resource_link: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "slug": self.slug,
+            "title": self.title,
+            "summary": self.summary,
+            "resource_type": self.resource_type,
+            "category": self.category,
+            "body_html": self.body_html,
+            "resource_link": self.resource_link,
+            "tags": list(self.tags),
+        }
+
+
+@dataclass(slots=True)
+class HelpCenterContent:
+    """Bundle of articles grouped by resource type."""
+
+    articles: list[HelpArticle]
+    sections: dict[HelpArticleType, list[HelpArticle]]
+
+    def get_section(self, resource_type: HelpArticleType) -> list[HelpArticle]:
+        return self.sections.get(resource_type, [])
+
+    @property
+    def faq(self) -> list[HelpArticle]:
+        return self.get_section("faq")
+
+    @property
+    def guides(self) -> list[HelpArticle]:
+        return self.get_section("guide")
+
+    @property
+    def webinars(self) -> list[HelpArticle]:
+        return self.get_section("webinar")
+
+    @property
+    def notebooks(self) -> list[HelpArticle]:
+        return self.get_section("notebook")
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "articles": [article.to_payload() for article in self.articles],
+            "sections": {
+                section: [article.to_payload() for article in articles]
+                for section, articles in self.sections.items()
+            },
+        }
+
+
+def _markdown_to_html(text: str) -> str:
+    if not text.strip():
+        return ""
+    return markdown.markdown(
+        text,
+        extensions=[
+            "markdown.extensions.extra",
+            "markdown.extensions.sane_lists",
+        ],
+        output_format="html5",
+    )
+
+
+def _load_catalog() -> Iterable[dict[str, object]]:
+    if not CATALOG_PATH.exists():
+        return []
+    try:
+        catalog = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:  # pragma: no cover - defensive guard
+        return []
+    if not isinstance(catalog, list):
+        return []
+    return catalog
+
+
+def _load_article(entry: dict[str, object]) -> HelpArticle | None:
+    slug = str(entry.get("slug") or "").strip()
+    title = str(entry.get("title") or "").strip()
+    summary = str(entry.get("summary") or "").strip()
+    resource_type = str(entry.get("resource_type") or "").strip().lower()
+    category = str(entry.get("category") or "").strip() or "Ressources"
+    body_path = str(entry.get("body_path") or "").strip()
+    resource_link = entry.get("resource_link")
+    tags_field = entry.get("tags")
+
+    if not slug or not title or not body_path:
+        return None
+    if resource_type not in {"faq", "guide", "webinar", "notebook"}:
+        resource_type = "guide"
+
+    body_file = HELP_ROOT / body_path
+    if not body_file.exists():
+        body_html = "<p class=\"text text--muted\">Contenu introuvable.</p>"
+    else:
+        body_html = _markdown_to_html(body_file.read_text(encoding="utf-8"))
+
+    tags: list[str] = []
+    if isinstance(tags_field, list):
+        tags = [str(tag).strip() for tag in tags_field if str(tag).strip()]
+
+    link_value: str | None = None
+    if isinstance(resource_link, str) and resource_link.strip():
+        link_value = resource_link.strip()
+
+    return HelpArticle(
+        slug=slug,
+        title=title,
+        summary=summary,
+        resource_type=resource_type,  # type: ignore[arg-type]
+        category=category,
+        body_html=body_html,
+        resource_link=link_value,
+        tags=tags,
+    )
+
+
+@lru_cache(maxsize=1)
+def load_help_center() -> HelpCenterContent:
+    """Load and group all help center resources."""
+
+    articles: list[HelpArticle] = []
+    sections: Dict[HelpArticleType, list[HelpArticle]] = {
+        "faq": [],
+        "guide": [],
+        "webinar": [],
+        "notebook": [],
+    }
+
+    for entry in _load_catalog():
+        if not isinstance(entry, dict):
+            continue
+        article = _load_article(entry)
+        if article is None:
+            continue
+        articles.append(article)
+        sections[article.resource_type].append(article)
+
+    articles.sort(key=lambda article: article.title.lower())
+    for bucket in sections.values():
+        bucket.sort(key=lambda article: article.title.lower())
+
+    return HelpCenterContent(articles=articles, sections=sections)
+
+
+def get_article_by_slug(slug: str) -> HelpArticle | None:
+    slug = slug.strip().lower()
+    if not slug:
+        return None
+    content = load_help_center()
+    for article in content.articles:
+        if article.slug.lower() == slug:
+            return article
+    return None
+
+
+__all__ = [
+    "HelpArticle",
+    "HelpCenterContent",
+    "HelpArticleType",
+    "get_article_by_slug",
+    "load_help_center",
+]

--- a/services/web-dashboard/app/main.py
+++ b/services/web-dashboard/app/main.py
@@ -51,6 +51,12 @@ from .schemas import (
     TradingViewConfigUpdate,
 )
 from .documentation import load_strategy_documentation
+from .helpcenter import HelpArticle, get_article_by_slug, load_help_center
+from .help_progress import (
+    LearningProgress,
+    get_learning_progress,
+    record_learning_activity,
+)
 from .strategy_presets import STRATEGY_PRESETS, STRATEGY_PRESET_SUMMARIES
 from pydantic import BaseModel, Field, ConfigDict
 from schemas.order_router import PositionCloseRequest
@@ -78,6 +84,7 @@ AI_ASSISTANT_BASE_URL = os.getenv(
 )
 AI_ASSISTANT_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AI_ASSISTANT_TIMEOUT", "10.0"))
 DEFAULT_FOLLOWER_ID = os.getenv("WEB_DASHBOARD_DEFAULT_FOLLOWER_ID", "demo-investor")
+HELP_DEFAULT_USER_ID = os.getenv("WEB_DASHBOARD_HELP_DEFAULT_USER_ID", "demo-user")
 
 security = HTTPBearer(auto_error=False)
 
@@ -202,6 +209,46 @@ class StrategyAssistantImportRequest(BaseModel):
     tags: list[str] = Field(default_factory=list)
     metadata: dict[str, object] = Field(default_factory=dict)
     parameters: dict[str, object] = Field(default_factory=dict)
+
+
+class HelpArticlePayload(BaseModel):
+    """Article payload returned by the help center API."""
+
+    slug: str
+    title: str
+    summary: str
+    resource_type: str
+    category: str
+    body_html: str
+    resource_link: str | None = None
+    tags: list[str] = Field(default_factory=list)
+
+
+class LearningResourceVisitPayload(BaseModel):
+    """Single resource visit serialised for the API."""
+
+    slug: str
+    title: str
+    resource_type: str
+    viewed_at: datetime
+
+
+class LearningProgressPayload(BaseModel):
+    """Learning progress metrics for the help center."""
+
+    user_id: str
+    completion_rate: int
+    completed_resources: int
+    total_resources: int
+    recent_resources: list[LearningResourceVisitPayload] = Field(default_factory=list)
+
+
+class HelpArticlesResponse(BaseModel):
+    """Envelope returned by `/help/articles`."""
+
+    articles: list[HelpArticlePayload]
+    sections: Dict[str, list[HelpArticlePayload]]
+    progress: LearningProgressPayload
 
 
 SUPPORTED_TIMEFRAMES: Dict[str, int] = {
@@ -930,6 +977,86 @@ def render_strategy_documentation(request: Request) -> HTMLResponse:
             "documentation": documentation,
             "active_page": "strategy-docs",
         },
+    )
+
+
+def _build_help_article_payload(article: HelpArticle) -> HelpArticlePayload:
+    return HelpArticlePayload(
+        slug=article.slug,
+        title=article.title,
+        summary=article.summary,
+        resource_type=article.resource_type,
+        category=article.category,
+        body_html=article.body_html,
+        resource_link=article.resource_link,
+        tags=list(article.tags),
+    )
+
+
+def _build_learning_progress_payload(progress: LearningProgress) -> LearningProgressPayload:
+    return LearningProgressPayload(
+        user_id=progress.user_id,
+        completion_rate=progress.completion_rate,
+        completed_resources=progress.completed_resources,
+        total_resources=progress.total_resources,
+        recent_resources=[
+            LearningResourceVisitPayload(
+                slug=visit.slug,
+                title=visit.title,
+                resource_type=visit.resource_type,
+                viewed_at=visit.viewed_at,
+            )
+            for visit in progress.recent_resources
+        ],
+    )
+
+
+@app.get("/help", response_class=HTMLResponse)
+def render_help_center(request: Request) -> HTMLResponse:
+    """Expose the help & training knowledge base."""
+
+    help_content = load_help_center()
+    progress = get_learning_progress(HELP_DEFAULT_USER_ID, len(help_content.articles))
+    return templates.TemplateResponse(
+        "help_center.html",
+        {
+            "request": request,
+            "help_content": help_content,
+            "progress": progress,
+            "articles_endpoint": request.url_for("list_help_articles"),
+            "active_page": "help",
+        },
+    )
+
+
+@app.get(
+    "/help/articles",
+    response_model=HelpArticlesResponse,
+    name="list_help_articles",
+)
+def list_help_articles(viewed: str | None = Query(default=None, description="Slug de la ressource consultée")) -> HelpArticlesResponse:
+    """Return rendered help center articles and progress metadata."""
+
+    help_content = load_help_center()
+    if viewed:
+        article = get_article_by_slug(viewed)
+        if article is not None:
+            record_learning_activity(
+                HELP_DEFAULT_USER_ID,
+                slug=article.slug,
+                title=article.title,
+                resource_type=article.resource_type,
+            )
+
+    progress = get_learning_progress(HELP_DEFAULT_USER_ID, len(help_content.articles))
+    sections_payload = {
+        section: [_build_help_article_payload(item) for item in items]
+        for section, items in help_content.sections.items()
+    }
+    return HelpArticlesResponse(
+        articles=[_build_help_article_payload(article) for article in help_content.articles],
+        sections=sections_payload,
+        progress=_build_learning_progress_payload(progress),
     )
 
 

--- a/services/web-dashboard/app/static/help-center.js
+++ b/services/web-dashboard/app/static/help-center.js
@@ -1,0 +1,124 @@
+(function () {
+  const container = document.querySelector("[data-help-center]");
+  if (!container) {
+    return;
+  }
+
+  const endpoint = container.getAttribute("data-articles-endpoint");
+  if (!endpoint) {
+    return;
+  }
+
+  const progressValue = container.querySelector("[data-progress-value]");
+  const progressFill = container.querySelector("[data-progress-fill]");
+  const progressBar = container.querySelector("[data-progressbar]");
+  const recentList = container.querySelector("[data-recent-resources]");
+
+  async function refreshProgress(slug) {
+    try {
+      const url = new URL(endpoint, window.location.origin);
+      if (slug) {
+        url.searchParams.set("viewed", slug);
+      }
+      const response = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        return;
+      }
+      const payload = await response.json();
+      if (!payload || typeof payload !== "object" || !payload.progress) {
+        return;
+      }
+
+      const progress = payload.progress;
+      const completion = Number(progress.completion_rate ?? progress.completionRate ?? 0);
+      if (progressValue) {
+        progressValue.textContent = `${completion}%`;
+      }
+      if (progressFill) {
+        progressFill.style.width = `${Math.min(Math.max(completion, 0), 100)}%`;
+      }
+      if (progressBar) {
+        progressBar.setAttribute("aria-valuenow", `${Math.min(Math.max(completion, 0), 100)}`);
+      }
+
+      if (!recentList) {
+        return;
+      }
+
+      const visits = Array.isArray(progress.recent_resources)
+        ? progress.recent_resources
+        : Array.isArray(progress.recentResources)
+        ? progress.recentResources
+        : [];
+
+      recentList.innerHTML = "";
+      if (!visits.length) {
+        const empty = document.createElement("li");
+        empty.className = "help-recent__item help-recent__item--empty";
+        empty.textContent = "Aucune ressource consultée pour le moment.";
+        recentList.appendChild(empty);
+        return;
+      }
+
+      visits.forEach((visit) => {
+        const item = document.createElement("li");
+        item.className = "help-recent__item";
+
+        const title = document.createElement("p");
+        title.className = "help-recent__title";
+        title.textContent = visit.title || "Ressource";
+
+        const meta = document.createElement("p");
+        meta.className = "help-recent__meta";
+        const viewedAt = visit.viewed_at || visit.viewedAt;
+        let formattedDate = "Consulté récemment";
+        if (viewedAt) {
+          const parsed = new Date(viewedAt);
+          if (!Number.isNaN(parsed.getTime())) {
+            formattedDate = parsed.toLocaleString("fr-FR", {
+              day: "2-digit",
+              month: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            });
+          }
+        }
+        const resourceType = visit.resource_type || visit.resourceType || "ressource";
+        meta.textContent = `${resourceType} · ${formattedDate}`;
+
+        item.appendChild(title);
+        item.appendChild(meta);
+        recentList.appendChild(item);
+      });
+    } catch (error) {
+      console.warn("Impossible de mettre à jour la progression de formation", error);
+    }
+  }
+
+  container.addEventListener("toggle", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLDetailsElement)) {
+      return;
+    }
+    if (!target.open) {
+      return;
+    }
+    const slug = target.getAttribute("data-article-slug");
+    if (!slug) {
+      return;
+    }
+    void refreshProgress(slug);
+  });
+
+  container.querySelectorAll("[data-article-link]").forEach((element) => {
+    element.addEventListener("click", () => {
+      const slug = element.getAttribute("data-article-link");
+      if (!slug) {
+        return;
+      }
+      void refreshProgress(slug);
+    });
+  });
+})();

--- a/services/web-dashboard/app/static/styles.css
+++ b/services/web-dashboard/app/static/styles.css
@@ -1824,3 +1824,176 @@ body {
     flex-direction: column;
   }
 }
+
+.help-layout {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.help-card {
+  min-height: auto;
+}
+
+.help-progress {
+  gap: var(--space-lg);
+}
+
+.help-progress__bar {
+  position: relative;
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.help-progress__bar-fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.8), rgba(129, 140, 248, 0.85));
+  transition: width 240ms ease;
+}
+
+.help-progress__value {
+  font-weight: 600;
+  color: var(--color-info);
+}
+
+.help-recent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.help-recent__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.help-recent__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.help-recent__item {
+  padding: var(--space-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.help-recent__item--empty {
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.help-recent__title {
+  margin: 0 0 var(--space-xs);
+  font-weight: 600;
+}
+
+.help-recent__meta {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.help-faq {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.help-faq__item {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.35);
+  padding: 0 var(--space-md);
+}
+
+.help-faq__item[open] {
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.help-faq__question {
+  font-weight: 600;
+  margin: var(--space-md) 0;
+  cursor: pointer;
+}
+
+.help-article {
+  padding-bottom: var(--space-md);
+}
+
+.help-article p {
+  margin-bottom: var(--space-sm);
+}
+
+.help-article__tags {
+  list-style: none;
+  margin: var(--space-md) 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.help-article__tag {
+  background: rgba(56, 189, 248, 0.18);
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-size: var(--font-size-sm);
+}
+
+.help-guides__list,
+.help-resources__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.help-guides__item,
+.help-resources__item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.35);
+  padding: var(--space-lg);
+}
+
+.help-guides__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.help-guides__item--empty,
+.help-resources__item--empty {
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.help-resources__item .button {
+  align-self: flex-start;
+}
+
+@media (max-width: 768px) {
+  .help-guides__item,
+  .help-resources__item {
+    padding: var(--space-md);
+  }
+
+  .help-progress {
+    gap: var(--space-md);
+  }
+}

--- a/services/web-dashboard/app/templates/account.html
+++ b/services/web-dashboard/app/templates/account.html
@@ -45,6 +45,13 @@
           Documentation stratégies
         </a>
         <a
+          href="{{ request.url_for('render_help_center') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'help' else '' }}"
+          aria-current="{{ 'page' if active_page == 'help' else 'false' }}"
+        >
+          Aide &amp; formation
+        </a>
+        <a
           href="{{ request.url_for('render_account') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
           aria-current="{{ 'page' if active_page == 'account' else 'false' }}"

--- a/services/web-dashboard/app/templates/dashboard.html
+++ b/services/web-dashboard/app/templates/dashboard.html
@@ -45,6 +45,13 @@
           Documentation stratégies
         </a>
         <a
+          href="{{ request.url_for('render_help_center') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'help' else '' }}"
+          aria-current="{{ 'page' if active_page == 'help' else 'false' }}"
+        >
+          Aide &amp; formation
+        </a>
+        <a
           href="{{ request.url_for('render_account') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
           aria-current="{{ 'page' if active_page == 'account' else 'false' }}"

--- a/services/web-dashboard/app/templates/follower.html
+++ b/services/web-dashboard/app/templates/follower.html
@@ -45,6 +45,13 @@
           Documentation stratégies
         </a>
         <a
+          href="{{ request.url_for('render_help_center') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'help' else '' }}"
+          aria-current="{{ 'page' if active_page == 'help' else 'false' }}"
+        >
+          Aide &amp; formation
+        </a>
+        <a
           href="{{ request.url_for('render_account') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
           aria-current="{{ 'page' if active_page == 'account' else 'false' }}"

--- a/services/web-dashboard/app/templates/help_center.html
+++ b/services/web-dashboard/app/templates/help_center.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Aide &amp; formation</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="layout__header">
+      <nav class="app-nav" aria-label="Navigation principale">
+        <a
+          href="{{ request.url_for('render_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'dashboard' else '' }}"
+          aria-current="{{ 'page' if active_page == 'dashboard' else 'false' }}"
+        >
+          Tableau de bord
+        </a>
+        <a
+          href="{{ request.url_for('render_marketplace') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'marketplace' else '' }}"
+          aria-current="{{ 'page' if active_page == 'marketplace' else 'false' }}"
+        >
+          Marketplace
+        </a>
+        <a
+          href="{{ request.url_for('render_follower_dashboard') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'followers' else '' }}"
+          aria-current="{{ 'page' if active_page == 'followers' else 'false' }}"
+        >
+          Suivi copies
+        </a>
+        <a
+          href="{{ request.url_for('render_strategies') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies' else '' }}"
+          aria-current="{{ 'page' if active_page == 'strategies' else 'false' }}"
+        >
+          Stratégies
+        </a>
+        <a
+          href="{{ request.url_for('render_strategy_documentation') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategy-docs' else '' }}"
+          aria-current="{{ 'page' if active_page == 'strategy-docs' else 'false' }}"
+        >
+          Documentation stratégies
+        </a>
+        <a
+          href="{{ request.url_for('render_help_center') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'help' else '' }}"
+          aria-current="{{ 'page' if active_page == 'help' else 'false' }}"
+        >
+          Aide &amp; formation
+        </a>
+        <a
+          href="{{ request.url_for('render_account') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
+          aria-current="{{ 'page' if active_page == 'account' else 'false' }}"
+        >
+          Compte &amp; API
+        </a>
+      </nav>
+      <h1 class="heading heading--xl">Aide &amp; formation</h1>
+      <p class="text text--muted">
+        Explorez la base de connaissances, suivez votre progression et accédez rapidement aux webinars et notebooks.
+      </p>
+    </header>
+    <main
+      class="layout__main help-layout"
+      data-help-center
+      data-articles-endpoint="{{ articles_endpoint }}"
+    >
+      <section class="card help-card" aria-labelledby="help-progress-title">
+        <div class="card__header">
+          <h2 id="help-progress-title" class="heading heading--lg">Suivi de progression</h2>
+          <p class="text text--muted">
+            Visualisez vos avancées dans la base de connaissances et reprenez là où vous vous êtes arrêté.
+          </p>
+        </div>
+        <div class="card__body help-progress">
+          <div
+            class="help-progress__bar"
+            role="progressbar"
+            aria-label="Progression de la formation"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="{{ progress.completion_rate }}"
+            data-progressbar
+          >
+            <span
+              class="help-progress__bar-fill"
+              style="width: {{ progress.completion_rate }}%"
+              data-progress-fill
+            ></span>
+          </div>
+          <p class="text" aria-live="polite">
+            Progression globale :
+            <span class="help-progress__value" data-progress-value>
+              {{ progress.completion_rate }}%
+            </span>
+            — {{ progress.completed_resources }} / {{ progress.total_resources }} ressources parcourues.
+          </p>
+          <section class="help-recent" aria-labelledby="help-recent-title">
+            <div class="help-recent__header">
+              <h3 id="help-recent-title" class="heading heading--md">Dernières ressources consultées</h3>
+              <p class="text text--muted">Mises à jour après chaque consultation.</p>
+            </div>
+            <ul class="help-recent__list" data-recent-resources>
+              {% if progress.recent_resources %}
+              {% for visit in progress.recent_resources %}
+              <li class="help-recent__item">
+                <p class="help-recent__title">{{ visit.title }}</p>
+                <p class="help-recent__meta">
+                  {{ visit.resource_type|capitalize }} · Consulté le
+                  {{ visit.viewed_at.strftime('%d/%m/%Y %H:%M') }}
+                </p>
+              </li>
+              {% endfor %}
+              {% else %}
+              <li class="help-recent__item help-recent__item--empty">
+                Aucune ressource consultée pour le moment.
+              </li>
+              {% endif %}
+            </ul>
+          </section>
+        </div>
+      </section>
+
+      <section class="card help-card" aria-labelledby="help-faq-title">
+        <div class="card__header">
+          <h2 id="help-faq-title" class="heading heading--lg">FAQ opérationnelle</h2>
+          <p class="text text--muted">
+            Questions récurrentes sur la configuration et l'utilisation quotidienne du tableau de bord.
+          </p>
+        </div>
+        <div class="card__body help-faq" role="list">
+          {% for article in help_content.faq %}
+          <details class="help-faq__item" role="listitem" data-article-slug="{{ article.slug }}">
+            <summary class="help-faq__question">{{ article.title }}</summary>
+            <div class="help-article" id="help-article-{{ article.slug }}">
+              {{ article.body_html | safe }}
+              {% if article.tags %}
+              <ul class="help-article__tags" aria-label="Mots-clés">
+                {% for tag in article.tags %}
+                <li class="help-article__tag">{{ tag }}</li>
+                {% endfor %}
+              </ul>
+              {% endif %}
+            </div>
+          </details>
+          {% else %}
+          <p class="text text--muted">Aucune question enregistrée pour le moment.</p>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section class="card help-card" aria-labelledby="help-guides-title">
+        <div class="card__header">
+          <h2 id="help-guides-title" class="heading heading--lg">Guides &amp; ateliers</h2>
+          <p class="text text--muted">
+            Parcours structurés pour monter en compétence rapidement.
+          </p>
+        </div>
+        <div class="card__body help-guides">
+          <ul class="help-guides__list" role="list">
+            {% for article in help_content.guides %}
+            <li class="help-guides__item" role="listitem">
+              <div class="help-guides__content">
+                <h3 class="heading heading--md">{{ article.title }}</h3>
+                <p class="text text--muted">{{ article.summary }}</p>
+              </div>
+              <div class="help-guides__actions">
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  data-article-link="{{ article.slug }}"
+                  aria-label="Marquer {{ article.title }} comme consulté"
+                >
+                  Marquer comme consulté
+                </button>
+                {% if article.resource_link %}
+                <a
+                  href="{{ article.resource_link }}"
+                  class="button"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-article-link="{{ article.slug }}"
+                >
+                  Ouvrir le guide
+                </a>
+                {% endif %}
+              </div>
+            </li>
+            {% else %}
+            <li class="help-guides__item help-guides__item--empty">
+              <p class="text text--muted">Aucun guide n'est disponible pour le moment.</p>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </section>
+
+      <section class="card help-card" aria-labelledby="help-resources-title">
+        <div class="card__header">
+          <h2 id="help-resources-title" class="heading heading--lg">Webinars &amp; notebooks</h2>
+          <p class="text text--muted">
+            Sessions enregistrées et notebooks interactifs pour approfondir vos connaissances.
+          </p>
+        </div>
+        <div class="card__body help-resources">
+          <ul class="help-resources__list" role="list">
+            {% for article in help_content.webinars %}
+            <li class="help-resources__item" role="listitem">
+              <div>
+                <h3 class="heading heading--md">{{ article.title }}</h3>
+                <p class="text text--muted">{{ article.summary }}</p>
+                {{ article.body_html | safe }}
+              </div>
+              {% if article.resource_link %}
+              <a
+                href="{{ article.resource_link }}"
+                class="button"
+                target="_blank"
+                rel="noopener noreferrer"
+                data-article-link="{{ article.slug }}"
+              >
+                Regarder le webinar
+              </a>
+              {% endif %}
+            </li>
+            {% endfor %}
+            {% for article in help_content.notebooks %}
+            <li class="help-resources__item" role="listitem">
+              <div>
+                <h3 class="heading heading--md">{{ article.title }}</h3>
+                <p class="text text--muted">{{ article.summary }}</p>
+                {{ article.body_html | safe }}
+              </div>
+              {% if article.resource_link %}
+              <a
+                href="{{ article.resource_link }}"
+                class="button"
+                target="_blank"
+                rel="noopener noreferrer"
+                data-article-link="{{ article.slug }}"
+              >
+                Ouvrir dans nbviewer
+              </a>
+              {% endif %}
+            </li>
+            {% endfor %}
+            {% if not help_content.webinars and not help_content.notebooks %}
+            <li class="help-resources__item help-resources__item--empty">
+              <p class="text text--muted">Aucune ressource multimédia disponible.</p>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+      </section>
+    </main>
+    <script src="/static/help-center.js" defer></script>
+  </body>
+</html>

--- a/services/web-dashboard/app/templates/marketplace.html
+++ b/services/web-dashboard/app/templates/marketplace.html
@@ -45,6 +45,13 @@
           Documentation stratégies
         </a>
         <a
+          href="{{ request.url_for('render_help_center') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'help' else '' }}"
+          aria-current="{{ 'page' if active_page == 'help' else 'false' }}"
+        >
+          Aide &amp; formation
+        </a>
+        <a
           href="{{ request.url_for('render_account') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
           aria-current="{{ 'page' if active_page == 'account' else 'false' }}"

--- a/services/web-dashboard/app/templates/strategies.html
+++ b/services/web-dashboard/app/templates/strategies.html
@@ -45,6 +45,13 @@
           Documentation stratégies
         </a>
         <a
+          href="{{ request.url_for('render_help_center') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'help' else '' }}"
+          aria-current="{{ 'page' if active_page == 'help' else 'false' }}"
+        >
+          Aide &amp; formation
+        </a>
+        <a
           href="{{ request.url_for('render_account') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
           aria-current="{{ 'page' if active_page == 'account' else 'false' }}"

--- a/services/web-dashboard/app/templates/strategy_documentation.html
+++ b/services/web-dashboard/app/templates/strategy_documentation.html
@@ -45,6 +45,13 @@
           Documentation stratégies
         </a>
         <a
+          href="{{ request.url_for('render_help_center') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'help' else '' }}"
+          aria-current="{{ 'page' if active_page == 'help' else 'false' }}"
+        >
+          Aide &amp; formation
+        </a>
+        <a
           href="{{ request.url_for('render_account') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
           aria-current="{{ 'page' if active_page == 'account' else 'false' }}"

--- a/services/web-dashboard/tests/e2e/test_help_center.py
+++ b/services/web-dashboard/tests/e2e/test_help_center.py
@@ -1,0 +1,33 @@
+import re
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+playwright_async = pytest.importorskip("playwright.async_api")
+Page = playwright_async.Page
+expect = playwright_async.expect
+
+
+async def test_help_center_accessible_via_navigation(page: Page, dashboard_base_url: str):
+    await page.goto(f"{dashboard_base_url}/dashboard", wait_until="networkidle")
+
+    await page.get_by_role("link", name="Aide & formation").click()
+
+    await expect(page).to_have_url(re.compile(r"/help"))
+    await expect(page.get_by_role("heading", level=1, name="Aide & formation")).to_be_visible()
+    await expect(page.get_by_role("progressbar", name=re.compile("Progression", re.I))).to_be_visible()
+
+
+async def test_help_center_faq_toggle_is_accessible(page: Page, dashboard_base_url: str):
+    await page.goto(f"{dashboard_base_url}/help", wait_until="networkidle")
+
+    faq_button = page.get_by_role(
+        "button", name=re.compile("Comment connecter mes clés API broker", re.I)
+    )
+    await faq_button.click()
+    await expect(faq_button).to_have_attribute("aria-expanded", "true")
+
+    await expect(
+        page.locator(".help-article__tag", has_text=re.compile("onboarding", re.I))
+    ).to_be_visible()

--- a/services/web-dashboard/tests/test_help_center.py
+++ b/services/web-dashboard/tests/test_help_center.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from .utils import load_dashboard_app
+
+
+def test_help_center_page_renders():
+    app = load_dashboard_app()
+    client = TestClient(app)
+
+    response = client.get("/help")
+    assert response.status_code == 200
+    html = response.text
+
+    assert "Aide &amp; formation" in html
+    assert "Suivi de progression" in html
+    assert "FAQ opérationnelle" in html
+    assert "role=\"progressbar\"" in html
+    assert "data-articles-endpoint" in html
+
+
+def test_help_articles_api_returns_articles_and_progress():
+    app = load_dashboard_app()
+    client = TestClient(app)
+
+    response = client.get("/help/articles")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert "articles" in payload and payload["articles"], "Aucun article renvoyé"
+    assert "progress" in payload
+    base_progress = payload["progress"]
+    assert base_progress["total_resources"] >= len(payload["articles"])
+
+    slug = payload["articles"][0]["slug"]
+    follow_up = client.get(f"/help/articles?viewed={slug}")
+    assert follow_up.status_code == 200
+    updated = follow_up.json()["progress"]
+    assert updated["completed_resources"] >= base_progress["completed_resources"]
+
+
+def test_navigation_includes_help_link():
+    app = load_dashboard_app()
+    client = TestClient(app)
+
+    response = client.get("/help")
+    assert response.status_code == 200
+    html = response.text
+
+    assert "Aide &amp; formation" in html
+    assert "/help" in html


### PR DESCRIPTION
## Summary
- add a help & training knowledge base sourced from markdown articles with rendered HTML output
- expose a new /help page, /help/articles API, and in-memory learning tracker with updated navigation and styling
- cover the new experience with API and Playwright tests plus ignore generated alert_events.db

## Testing
- pytest services/web-dashboard/tests/test_help_center.py
- pytest services/web-dashboard/tests/test_strategy_documentation.py

------
https://chatgpt.com/codex/tasks/task_e_68ded256decc833297e17f5eaab37037