### PR TITLE
Add integration tests for Binance and IBKR providers

### DIFF
--- a/docs/market-data.md
+++ b/docs/market-data.md
@@ -56,6 +56,9 @@ The FastAPI app exposes:
 | `MARKET_DATA_DATABASE_URL` | PostgreSQL/TimescaleDB connection string. |
 | `BINANCE_API_KEY` / `BINANCE_API_SECRET` | Optional API credentials used by the Binance adapter. |
 | `IBKR_HOST` / `IBKR_PORT` / `IBKR_CLIENT_ID` | Connection parameters for the IBKR gateway. |
+| `PROVIDERS_SANDBOX_MODE` | Controls the integration tests: keep `sandbox` (default) for mocked APIs or set to `official` to hit the real exchanges. |
+| `BINANCE_API_BASE_URL` | Optional override for the Binance REST base URL used by integration tests. |
+| `IBKR_HTTP_SANDBOX_URL` | Optional override for the mock IBKR HTTP gateway used by integration tests. |
 
 TimescaleDB must be available with the `timescaledb` extension enabled. Apply
 migrations using Alembic from the `infra/` package before starting the service:
@@ -79,3 +82,8 @@ WebSocket clients. Execute the suite from the project root:
 ```
 pytest services/market_data/tests
 ```
+
+Integration scenarios that exercise the real exchange clients live in
+`tests/integration`. They rely on `respx` to emulate the Binance and IBKR
+APIs by default and can be pointed to the official endpoints by exporting
+`PROVIDERS_SANDBOX_MODE=official` along with the corresponding credentials.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ strict = true
 plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
-testpaths = ["services"]
+testpaths = ["services", "tests"]
 addopts = "-q"
 pythonpath = ["services/config-service"]
 markers = [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,47 @@
+"""Pytest fixtures configuring provider sandbox and live modes."""
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+import respx
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+_SANDBOX_ENV = "PROVIDERS_SANDBOX_MODE"
+_DEFAULT_MODE = "sandbox"
+
+
+def _sandbox_mode() -> str:
+    return os.environ.get(_SANDBOX_ENV, _DEFAULT_MODE).strip().lower()
+
+
+@pytest.fixture(scope="session")
+def sandbox_mode() -> str:
+    """Return the configured provider test mode.
+
+    The default mode uses mocked HTTP responses. Setting
+    ``PROVIDERS_SANDBOX_MODE=official`` runs the tests against the real
+    exchanges instead. Individual tests may still skip themselves if the
+    official dependencies are unavailable in the current environment.
+    """
+
+    return _sandbox_mode()
+
+
+@pytest.fixture
+def sandbox_respx(sandbox_mode: str) -> Generator[respx.MockRouter | None, None, None]:
+    """Provide a respx router when running in sandbox mode."""
+
+    if sandbox_mode != _DEFAULT_MODE:
+        yield None
+        return
+    with respx.mock(assert_all_called=True) as mock:
+        yield mock

--- a/tests/integration/test_providers_binance.py
+++ b/tests/integration/test_providers_binance.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import pytest
+import httpx
+from httpx import Response
+
+from services.market_data.adapters import BinanceMarketConnector
+
+BINANCE_BASE_URL = os.environ.get("BINANCE_API_BASE_URL", "https://api.binance.com")
+
+
+class _HttpxSpotClient:
+    def __init__(self, base_url: str) -> None:
+        self._client = httpx.Client(base_url=base_url)
+
+    def klines(self, *, symbol: str, interval: str, limit: int) -> list[list[str | float | int]]:
+        response = self._client.get(
+            "/api/v3/klines", params={"symbol": symbol, "interval": interval, "limit": limit}
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload  # type: ignore[return-value]
+
+    def close(self) -> None:
+        self._client.close()
+
+
+@pytest.mark.asyncio
+async def test_binance_provider_latency_and_resilience(
+    sandbox_mode: str, sandbox_respx: Any
+) -> None:
+    """Ensure the Binance connector tolerates latency and transient failures."""
+
+    rest_client = _HttpxSpotClient(BINANCE_BASE_URL)
+    adapter = BinanceMarketConnector(
+        rest_client=rest_client,
+        api_key=os.environ.get("BINANCE_API_KEY"),
+        api_secret=os.environ.get("BINANCE_API_SECRET"),
+        request_rate=1,
+        request_interval_seconds=0.2,
+    )
+
+    try:
+        if sandbox_mode == "sandbox":
+            call_count = {"value": 0}
+
+            assert sandbox_respx is not None
+
+            def _mock_response(request: Any) -> Response:
+                call_count["value"] += 1
+                attempt = call_count["value"]
+                if attempt == 1:
+                    time.sleep(0.05)
+                    return Response(500, json={"code": -1000, "msg": "internal error"})
+                time.sleep(0.01)
+                return Response(
+                    200,
+                    json=[[1_000, "1", "2", "0.5", "1.5", "10", 1_060, "100", 5]],
+                )
+
+            sandbox_respx.get(f"{BINANCE_BASE_URL}/api/v3/klines").mock(side_effect=_mock_response)
+
+            start = time.perf_counter()
+            with pytest.raises(Exception):
+                await adapter.fetch_ohlcv("BTCUSDT", "1m", limit=1)
+            between = time.perf_counter()
+            candles = await adapter.fetch_ohlcv("BTCUSDT", "1m", limit=1)
+            end = time.perf_counter()
+
+            assert call_count["value"] == 2
+        else:
+            try:
+                start = time.perf_counter()
+                await adapter.fetch_ohlcv("BTCUSDT", "1m", limit=1)
+                between = time.perf_counter()
+                candles = await adapter.fetch_ohlcv("BTCUSDT", "1m", limit=1)
+                end = time.perf_counter()
+            except Exception as exc:  # pragma: no cover - live environment failure
+                pytest.skip(f"Binance live environment unavailable: {exc}")
+
+        assert candles, "Connector should return at least one candle"
+        if sandbox_mode == "sandbox":
+            assert candles[0]["close"] == 1.5
+        else:
+            assert "close" in candles[0]
+        assert end - between >= 0.15
+        if sandbox_mode == "sandbox":
+            assert between - start >= 0.05
+    finally:
+        rest_client.close()

--- a/tests/integration/test_providers_ibkr.py
+++ b/tests/integration/test_providers_ibkr.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any, AsyncIterator, Iterable
+
+import httpx
+import pytest
+from httpx import Response
+
+from services.market_data.adapters import IBKRMarketConnector
+
+_IBKR_BASE_URL = os.environ.get("IBKR_HTTP_SANDBOX_URL", "https://ibkr.test")
+
+
+class _TickerEvent:
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[Iterable[Any]] = asyncio.Queue()
+
+    def add_sequence(self, sequence: Iterable[Any]) -> None:
+        self._queue.put_nowait(sequence)
+
+    async def aiter(self) -> AsyncIterator[Iterable[Any]]:  # type: ignore[override]
+        while True:
+            sequence = await self._queue.get()
+            yield sequence
+
+
+class _HttpIBGateway:
+    MaxRequests = 5
+    RequestsInterval = 0.2
+
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.AsyncClient(base_url=self._base_url)
+        self.connected = False
+        self.pendingTickersEvent = _TickerEvent()
+        self.reqHistoricalData_calls: list[dict[str, Any]] = []
+        self.reqMktData_calls = 0
+
+    async def connectAsync(self, host: str, port: int, clientId: int) -> None:  # noqa: N802
+        self.connected = True
+        await asyncio.sleep(0)
+
+    def isConnected(self) -> bool:  # noqa: N802
+        return self.connected
+
+    async def reqHistoricalDataAsync(self, contract: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        response = await self._client.get("/historical", params={"contract": contract})
+        response.raise_for_status()
+        payload = response.json()
+        self.reqHistoricalData_calls.append({"contract": contract, **kwargs})
+        return list(payload.get("bars", []))
+
+    def reqMktData(self, contract: Any, *args: Any, **kwargs: Any) -> None:  # noqa: N802
+        self.reqMktData_calls += 1
+        if self.reqMktData_calls == 1:
+            raise ConnectionError("gateway warmup")
+        asyncio.create_task(self._populate_ticks(contract))
+
+    async def _populate_ticks(self, contract: Any) -> None:
+        try:
+            response = await self._client.get("/stream", params={"contract": contract})
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPError as exc:
+            raise ConnectionError("stream failure") from exc
+        ticks = [
+            type("Ticker", (), {"contract": contract, "last": item["last"], "time": item["time"]})
+            for item in payload.get("ticks", [])
+        ]
+        self.pendingTickersEvent.add_sequence(ticks)
+
+    def cancelMktData(self, contract: Any) -> None:  # noqa: N802
+        return None
+
+    def disconnect(self) -> None:
+        self.connected = False
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_ibkr_provider_latency_and_reconnect(
+    sandbox_mode: str, sandbox_respx: Any
+) -> None:
+    """Ensure the IBKR connector handles pacing and reconnects."""
+
+    if sandbox_mode != "sandbox":
+        pytest.skip("IBKR official gateway requires dedicated infrastructure")
+
+    assert sandbox_respx is not None
+
+    gateway = _HttpIBGateway(_IBKR_BASE_URL)
+    connector = IBKRMarketConnector(
+        host="127.0.0.1",
+        port=4001,
+        client_id=1,
+        ib=gateway,
+        request_rate=1,
+        request_interval_seconds=0.2,
+        reconnect_delay=0.01,
+    )
+
+    async def _historical_handler(request: httpx.Request) -> Response:
+        await asyncio.sleep(0.05)
+        return Response(200, json={"bars": [{"close": 100.0, "open": 99.5}]})
+
+    async def _stream_handler(request: httpx.Request) -> Response:
+        await asyncio.sleep(0.01)
+        return Response(
+            200,
+            json={"ticks": [{"last": 101.0, "time": "2024-01-01T00:00:00Z"}]},
+        )
+
+    sandbox_respx.get(f"{_IBKR_BASE_URL}/historical").mock(side_effect=_historical_handler)
+    sandbox_respx.get(f"{_IBKR_BASE_URL}/stream").mock(side_effect=_stream_handler)
+
+    start = time.perf_counter()
+    bars_first = await connector.fetch_ohlcv("ES", end="", duration="1 D", bar_size="1 min")
+    middle = time.perf_counter()
+    bars_second = await connector.fetch_ohlcv("ES", end="", duration="1 D", bar_size="1 min")
+    end = time.perf_counter()
+
+    assert bars_first and bars_second
+    assert bars_first[0]["close"] == pytest.approx(100.0)
+    assert end - middle >= 0.18
+    assert middle - start >= 0.05
+
+    stream = connector.stream_trades("ES")
+    ticker = await stream.__anext__()
+    await stream.aclose()
+
+    assert gateway.reqMktData_calls >= 2
+    assert getattr(ticker, "last", None) == pytest.approx(101.0)
+
+    await gateway.aclose()


### PR DESCRIPTION
## Summary
- add integration tests for the Binance and IBKR market data connectors that simulate exchange APIs via respx
- introduce a sandbox-aware pytest fixture and update pytest discovery so the new integration suite runs in CI
- document the environment variables required to toggle between sandbox and live provider modes

## Testing
- PROVIDERS_SANDBOX_MODE=sandbox pytest tests/integration -q

------
https://chatgpt.com/codex/tasks/task_e_68ded687816483328d013c64559e3be2