### PR TITLE
Fix service requirements include paths and add validation

### DIFF
--- a/requirements/services-dev.txt
+++ b/requirements/services-dev.txt
@@ -1,13 +1,13 @@
 # Consolidated development/test dependencies for Python services.
--r ../services/auth-service/requirements-dev.txt
--r ../services/billing-service/requirements-dev.txt
+-r ../services/auth_service/requirements-dev.txt
+-r ../services/billing_service/requirements-dev.txt
 -r ../services/codex_gateway/requirements-dev.txt
 -r ../services/codex_worker/requirements-dev.txt
--r ../services/config-service/requirements-dev.txt
--r ../services/entitlements-service/requirements-dev.txt
--r ../services/notification-service/requirements-dev.txt
+-r ../services/config_service/requirements-dev.txt
+-r ../services/entitlements_service/requirements-dev.txt
+-r ../services/notification_service/requirements-dev.txt
 -r ../services/screener/requirements-dev.txt
 -r ../services/streaming/requirements-dev.txt
 -r ../services/streaming_gateway/requirements-dev.txt
--r ../services/user-service/requirements-dev.txt
--r ../services/web-dashboard/requirements-dev.txt
+-r ../services/user_service/requirements-dev.txt
+-r ../services/web_dashboard/requirements-dev.txt

--- a/requirements/services.txt
+++ b/requirements/services.txt
@@ -3,21 +3,21 @@
 # GitHub workflows and local automation install a consistent set of
 # third-party packages before running tests.
 -r ../services/alert_engine/requirements.txt
--r ../services/algo-engine/requirements.txt
--r ../services/ai-strategy-assistant/requirements.txt
--r ../services/auth-service/requirements.txt
--r ../services/billing-service/requirements.txt
+-r ../services/algo_engine/requirements.txt
+-r ../services/ai_strategy_assistant/requirements.txt
+-r ../services/auth_service/requirements.txt
+-r ../services/billing_service/requirements.txt
 -r ../services/codex_gateway/requirements.txt
 -r ../services/codex_worker/requirements.txt
--r ../services/config-service/requirements.txt
--r ../services/entitlements-service/requirements.txt
+-r ../services/config_service/requirements.txt
+-r ../services/entitlements_service/requirements.txt
 -r ../services/inplay/requirements.txt
 -r ../services/market_data/requirements.txt
--r ../services/notification-service/requirements.txt
--r ../services/order-router/requirements.txt
+-r ../services/notification_service/requirements.txt
+-r ../services/order_router/requirements.txt
 -r ../services/reports/requirements.txt
 -r ../services/screener/requirements.txt
 -r ../services/streaming/requirements.txt
 -r ../services/streaming_gateway/requirements.txt
--r ../services/user-service/requirements.txt
--r ../services/web-dashboard/requirements.txt
+-r ../services/user_service/requirements.txt
+-r ../services/web_dashboard/requirements.txt

--- a/tests/test_requirements_paths.py
+++ b/tests/test_requirements_paths.py
@@ -1,0 +1,40 @@
+"""Regression tests for consolidated requirements include directives."""
+
+from pathlib import Path
+
+
+def _extract_requirement_paths(requirements_file: Path) -> list[Path]:
+    """Return filesystem paths referenced via ``-r`` in a requirements file."""
+
+    referenced_paths: list[Path] = []
+    for raw_line in requirements_file.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("-r "):
+            relative_path = line.split(maxsplit=1)[1]
+            referenced_paths.append((requirements_file.parent / relative_path).resolve())
+    return referenced_paths
+
+
+def test_referenced_service_requirements_exist():
+    repo_root = Path(__file__).resolve().parents[1]
+    requirement_files = [
+        repo_root / "requirements" / "services.txt",
+        repo_root / "requirements" / "services-dev.txt",
+    ]
+
+    missing_paths = []
+
+    for requirements_file in requirement_files:
+        for referenced_path in _extract_requirement_paths(requirements_file):
+            if not referenced_path.exists():
+                missing_paths.append((requirements_file, referenced_path))
+
+    assert not missing_paths, (
+        "The following requirements include directives point to missing files: "
+        + ", ".join(
+            f"{req_file.relative_to(repo_root)} -> {ref_path.relative_to(repo_root)}"
+            for req_file, ref_path in missing_paths
+        )
+    )


### PR DESCRIPTION
## Summary
- update consolidated service requirements files to point at the actual underscore-named directories
- add a regression test that verifies all referenced requirements files exist to prevent future typos

## Testing
- pip install -r requirements/services.txt
- pytest *(fails: requires schemathesis, playwright, and other service-specific dependencies that are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df616355008332996d2edc232d9ad3