### PR TITLE
Fix service path references for reports tests and migrations

### DIFF
--- a/infra/migrations/env.py
+++ b/infra/migrations/env.py
@@ -105,16 +105,16 @@ def _collect_target_metadata() -> tuple[MetaData, ...]:
     service_modules = [
         (
             "alembic.autoload.auth_service.app.models",
-            "services/auth-service/app/models.py",
+            "services/auth_service/app/models.py",
             (),
         ),
         (
             "alembic.autoload.user_service.app.main",
-            "services/user-service/app/main.py",
+            "services/user_service/app/main.py",
             (
                 (
                     "alembic.autoload.user_service.app.schemas",
-                    "services/user-service/app/schemas.py",
+                    "services/user_service/app/schemas.py",
                 ),
             ),
         ),

--- a/services/tests/test_backtest_reporting.py
+++ b/services/tests/test_backtest_reporting.py
@@ -35,7 +35,7 @@ def reports_client(tmp_path: Path) -> TestClient:
 
 
 def _load_algo_main() -> Any:
-    package_root = Path(__file__).resolve().parents[1] / "algo-engine"
+    package_root = Path(__file__).resolve().parents[1] / "algo_engine"
 
     def _load_package(alias: str, path: Path) -> None:
         spec = importlib.util.spec_from_file_location(alias, path / "__init__.py")

--- a/services/web_dashboard/tests/utils.py
+++ b/services/web_dashboard/tests/utils.py
@@ -12,7 +12,7 @@ from pathlib import Path
 MODULE_PATH = Path(__file__).resolve().parents[1] / "app" / "main.py"
 PACKAGE_NAME = "web_dashboard"
 USER_SERVICE_MODULE_PATH = (
-    Path(__file__).resolve().parents[2] / "user-service" / "app" / "main.py"
+    Path(__file__).resolve().parents[2] / "user_service" / "app" / "main.py"
 )
 USER_SERVICE_PACKAGE_NAME = "user_service_dashboard_proxy"
 


### PR DESCRIPTION
## Summary
- update the backtest reporting test loader to import the algo_engine package from its underscore directory
- point the web dashboard test utilities at the user_service package paths
- correct the Alembic autoload configuration for the auth and user service modules

## Testing
- pytest services/tests/test_backtest_reporting.py
- pytest services/web_dashboard/tests *(fails: missing optional playwright dependency in the environment)*
- ALEMBIC_DATABASE_URL=sqlite+pysqlite:////tmp/test.db alembic -c infra/migrations/alembic.ini revision --autogenerate -m "smoke-test" *(fails: target database is not up to date when using a temporary SQLite database)*

------
https://chatgpt.com/codex/tasks/task_e_68df6178d2d88332a79f7849496cbd20