### PR TITLE
Prevent backtest metrics from overwriting target/stop levels

### DIFF
--- a/schemas/report.py
+++ b/schemas/report.py
@@ -25,13 +25,21 @@ class TradeOutcome(str, Enum):
 class StrategyMetrics(BaseModel):
     strategy: StrategyName
     probability: float = Field(..., ge=0.0, le=1.0)
-    target: float
-    stop: float
+    target: float | None = None
+    stop: float | None = None
     expectancy: float
     sample_size: int = Field(..., ge=0)
 
-    @validator("target", "stop", "expectancy")
-    def validate_numeric(cls, value: float) -> float:  # noqa: N805
+    @validator("target", "stop", pre=True)
+    def validate_optional_numeric(cls, value: float | None) -> float | None:  # noqa: N805
+        if value is None:
+            return None
+        if not isinstance(value, (int, float)):
+            raise TypeError("numeric field expected")
+        return float(value)
+
+    @validator("expectancy", pre=True)
+    def validate_expectancy(cls, value: float) -> float:  # noqa: N805
         if not isinstance(value, (int, float)):
             raise TypeError("numeric field expected")
         return float(value)

--- a/services/reports/tests/test_calculations.py
+++ b/services/reports/tests/test_calculations.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import MagicMock
 
 from schemas.report import StrategyMetrics, StrategyName
 from services.reports.app.calculations import ReportCalculator
@@ -50,3 +51,46 @@ def test_merge_metrics_uses_present_dataset_when_other_empty() -> None:
 
     assert merged.target == pytest.approx(4.0)
     assert merged.stop == pytest.approx(2.0)
+
+
+def test_merge_metrics_preserves_live_price_levels_when_backtest_missing_levels() -> None:
+    live = StrategyMetrics(
+        strategy=StrategyName.ORB,
+        probability=0.6,
+        target=101.5,
+        stop=99.25,
+        expectancy=0.8,
+        sample_size=5,
+    )
+    backtest = StrategyMetrics(
+        strategy=StrategyName.ORB,
+        probability=0.4,
+        target=None,
+        stop=None,
+        expectancy=0.5,
+        sample_size=20,
+    )
+
+    merged = ReportCalculator._merge_metrics(live, backtest)
+
+    assert merged.target == pytest.approx(live.target)
+    assert merged.stop == pytest.approx(live.stop)
+
+
+def test_metrics_from_backtest_omits_target_and_stop_levels() -> None:
+    class StubBacktest:
+        strategy_type = "ORB"
+        strategy_name = "ORB"
+        symbol = "AAPL"
+        trades = 10
+        total_return = 0.1
+        initial_balance = 10000.0
+        equity_curve = [10000.0, 10050.0, 10025.0, 10080.0]
+        context = {"report_strategy": "ORB"}
+
+    calculator = ReportCalculator(session=MagicMock())
+    metrics = calculator._metrics_from_backtest(StubBacktest())
+
+    assert metrics is not None
+    assert metrics.target is None
+    assert metrics.stop is None


### PR DESCRIPTION
## Summary
- avoid populating backtest target/stop levels so they no longer inject P&L deltas
- allow optional price levels in strategy metrics and keep live data when merging with backtests
- extend calculator tests to cover the new merging behaviour and missing backtest levels

## Testing
- pytest services/reports/tests/test_calculations.py

------
https://chatgpt.com/codex/tasks/task_e_68df6161e4688332b21a8bb053b8d5fb