### PR TITLE
Add native Postgres and Redis helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: setup dev-up dev-down demo-up demo-down lint test e2e e2e-sh migrate-generate migrate-up migrate-down \
+.PHONY: setup dev-up dev-down demo-up demo-down native-up native-down lint test e2e e2e-sh migrate-generate migrate-up migrate-down \
         web_dashboard-e2e
 
 ALEMBIC_CONFIG ?= infra/migrations/alembic.ini
@@ -17,10 +17,16 @@ dev-up:
 	docker compose up -d --build auth_service user_service
 
 dev-down:
-	docker compose down -v
+        docker compose down -v
+
+native-up:
+        ./scripts/dev/native_up.sh
+
+native-down:
+        ./scripts/dev/native_down.sh
 
 demo-up:
-	docker compose up -d postgres redis
+        docker compose up -d postgres redis
 	docker compose up -d --build streaming streaming_gateway market_data order_router algo_engine \
 	reports alert_engine notification_service inplay web_dashboard auth_service user_service \
 	prometheus grafana

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Track detailed milestones and owners in [`docs/release-highlights/2025-12.md`](d
 
 ### Basic Setup
 
+**Prerequisites:**
+
+- [Docker](https://docs.docker.com/get-docker/) (default workflow), **or** native installations of `postgresql` (providing `pg_ctl`, `pg_isready`, `initdb`) and `redis` (`redis-server`, `redis-cli`).
+
 ```bash
 # 1. Clone the project
 git clone https://github.com/decarvalhoe/trading-bot-open-source.git
@@ -67,7 +71,7 @@ cd trading-bot-open-source
 # 2. Install development tools
 make setup
 
-# 3. Start the development environment
+# 3. Start the development environment (Docker)
 make dev-up
 
 # 4. Check that everything is working (auth-service health)
@@ -75,6 +79,21 @@ curl http://localhost:8011/health
 
 # 5. Stop the environment
 make dev-down
+```
+
+To develop without Docker (for example on platforms where virtualization is unavailable), start the PostgreSQL and Redis services natively and skip the compose steps:
+
+```bash
+# Start native services
+make native-up
+
+# (Optional) decrypt .env.enc and export variables without invoking Docker
+USE_NATIVE=1 scripts/dev/start.sh
+
+# When finished
+make native-down
+# or
+USE_NATIVE=1 scripts/dev/stop.sh
 ```
 
 ### Demo Trading Stack

--- a/scripts/dev/native_down.sh
+++ b/scripts/dev/native_down.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DATA_ROOT="${PROJECT_ROOT}/data/native"
+PGDATA="${DATA_ROOT}/postgres"
+REDIS_DATA="${DATA_ROOT}/redis"
+REDIS_PID="${REDIS_DATA}/redis.pid"
+
+if command -v pg_ctl >/dev/null 2>&1 && [[ -d "${PGDATA}" ]]; then
+    if pg_ctl -D "${PGDATA}" status >/dev/null 2>&1; then
+        echo "-> stopping PostgreSQL"
+        pg_ctl -D "${PGDATA}" stop -m fast >/dev/null
+    fi
+fi
+
+if command -v redis-cli >/dev/null 2>&1; then
+    if redis-cli -p 6379 ping >/dev/null 2>&1; then
+        echo "-> stopping Redis"
+        redis-cli -p 6379 shutdown >/dev/null || true
+    fi
+fi
+
+if [[ -f "${REDIS_PID}" ]]; then
+    rm -f "${REDIS_PID}"
+fi
+
+echo "-> native services down"

--- a/scripts/dev/native_up.sh
+++ b/scripts/dev/native_up.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DATA_ROOT="${PROJECT_ROOT}/data/native"
+PGDATA="${DATA_ROOT}/postgres"
+REDIS_DATA="${DATA_ROOT}/redis"
+PG_LOG="${PGDATA}/server.log"
+REDIS_LOG="${REDIS_DATA}/redis.log"
+REDIS_PID="${REDIS_DATA}/redis.pid"
+
+mkdir -p "${PGDATA}" "${REDIS_DATA}"
+
+for cmd in pg_ctl pg_isready initdb redis-server redis-cli; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "Error: ${cmd} is required but not installed or not on PATH." >&2
+        exit 1
+    fi
+done
+
+if [[ ! -f "${PGDATA}/PG_VERSION" ]]; then
+    echo "-> initializing PostgreSQL data directory at ${PGDATA}"
+    initdb -D "${PGDATA}" >/dev/null
+fi
+
+if ! pg_ctl -D "${PGDATA}" status >/dev/null 2>&1; then
+    echo "-> starting PostgreSQL on port 5432"
+    pg_ctl -D "${PGDATA}" -l "${PG_LOG}" -o "-p 5432" start >/dev/null
+fi
+
+echo "-> waiting for PostgreSQL to become ready"
+until pg_isready -q -h localhost -p 5432; do
+    sleep 1
+done
+
+echo "-> PostgreSQL is ready"
+
+if ! redis-cli -p 6379 ping >/dev/null 2>&1; then
+    echo "-> starting Redis on port 6379"
+    redis-server --daemonize yes --port 6379 --dir "${REDIS_DATA}" --pidfile "${REDIS_PID}" --logfile "${REDIS_LOG}" >/dev/null
+fi
+
+echo "-> waiting for Redis to become ready"
+until redis-cli -p 6379 ping >/dev/null 2>&1; do
+    sleep 1
+done
+
+echo "-> Redis is ready"
+
+echo "-> native services up (PostgreSQL @ 5432, Redis @ 6379)"

--- a/scripts/dev/start.sh
+++ b/scripts/dev/start.sh
@@ -24,5 +24,11 @@ if [[ -f "${ENCRYPTED_ENV_FILE}" ]]; then
     trap cleanup EXIT
 fi
 
+if [[ "${USE_NATIVE:-0}" == "1" ]]; then
+    "${SCRIPT_DIR}/native_up.sh"
+    echo "-> native dependencies up. start services manually as needed."
+    exit 0
+fi
+
 docker compose up -d --build
 echo "-> dev up. config_service: http://localhost:8000"

--- a/scripts/dev/stop.sh
+++ b/scripts/dev/stop.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${USE_NATIVE:-0}" == "1" ]]; then
+    "${SCRIPT_DIR}/native_down.sh"
+    exit 0
+fi
+
 docker compose down -v
 echo "-> dev down."


### PR DESCRIPTION
## Summary
- add scripts to manage PostgreSQL and Redis natively with readiness checks
- update Makefile and dev helpers to expose native-up/native-down and USE_NATIVE flag
- document the native workflow option in the quick start guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df62eda3a08332a8b0957422527812