### PR TITLE
Add bootstrap helper for FastAPI services

### DIFF
--- a/docs/algo-engine.md
+++ b/docs/algo-engine.md
@@ -53,7 +53,7 @@ et ses dépendances (`langchain`, `langchain-openai`, `openai`, ...). Ces paquet
 sont maintenant déclarés dans `services/algo-engine/requirements.txt` afin que
 `pip install -r services/algo-engine/requirements.txt` prépare l'environnement.
 
-Le service reste néanmoins fonctionnel sans ces dépendances. Pour désactiver explicitement l'assistant, définissez `AI_ASSISTANT_ENABLED=0` avant de lancer `uvicorn app.main:app`. Dans ce cas, `/strategies/generate` renverra un HTTP 503 indiquant que la fonctionnalité est désactivée. Le tutoriel `docs/tutorials/backtest-sandbox.ipynb` fournit un exemple d'appel complet.
+Le service reste néanmoins fonctionnel sans ces dépendances. Pour désactiver explicitement l'assistant, définissez `AI_ASSISTANT_ENABLED=0` avant de lancer `uvicorn app.main:app`. Grâce au module de bootstrap partagé (`services._bootstrap`) importé par chaque service FastAPI, cette commande fonctionne directement depuis `services/algo_engine`. Vous pouvez également utiliser le chemin de module complet : `uvicorn services.algo_engine.app.main:app`. Dans ce cas, `/strategies/generate` renverra un HTTP 503 indiquant que la fonctionnalité est désactivée. Le tutoriel `docs/tutorials/backtest-sandbox.ipynb` fournit un exemple d'appel complet.
 
 Le middleware d'entitlements vérifie la capacité `can.manage_strategies` et expose la limite de stratégies actives (`max_active_strategies`). L'orchestrateur interne applique les limites journalières.
 

--- a/services/_bootstrap.py
+++ b/services/_bootstrap.py
@@ -1,0 +1,9 @@
+"""Ensure service applications can be imported without installing the package."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/services/ai_strategy_assistant/ai_strategy_assistant_service/app/__init__.py
+++ b/services/ai_strategy_assistant/ai_strategy_assistant_service/app/__init__.py
@@ -1,5 +1,7 @@
 """FastAPI application for the AI strategy assistant."""
 
+from services import _bootstrap  # noqa: F401
+
 from .main import app
 
 __all__ = ["app"]

--- a/services/alert_engine/app/__init__.py
+++ b/services/alert_engine/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/algo_engine/app/__init__.py
+++ b/services/algo_engine/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/auth_service/app/__init__.py
+++ b/services/auth_service/app/__init__.py
@@ -1,3 +1,5 @@
-﻿import os, pyotp
+from services import _bootstrap  # noqa: F401
+
+import os, pyotp
 from jose import jwt
 

--- a/services/billing_service/app/__init__.py
+++ b/services/billing_service/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/codex_gateway/app/__init__.py
+++ b/services/codex_gateway/app/__init__.py
@@ -1,1 +1,3 @@
 """Codex gateway FastAPI application."""
+
+from services import _bootstrap  # noqa: F401

--- a/services/codex_worker/app/__init__.py
+++ b/services/codex_worker/app/__init__.py
@@ -1,1 +1,3 @@
 """Codex worker service for automation workflows."""
+
+from services import _bootstrap  # noqa: F401

--- a/services/config_service/app/__init__.py
+++ b/services/config_service/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/copy_trading_worker/app/__init__.py
+++ b/services/copy_trading_worker/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/entitlements_service/app/__init__.py
+++ b/services/entitlements_service/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/inplay/app/__init__.py
+++ b/services/inplay/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/market_data/app/__init__.py
+++ b/services/market_data/app/__init__.py
@@ -1,3 +1,5 @@
+from services import _bootstrap  # noqa: F401
+
 from .main import app
 
 __all__ = ["app"]

--- a/services/marketplace/app/__init__.py
+++ b/services/marketplace/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/notification_service/app/__init__.py
+++ b/services/notification_service/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/order_router/app/__init__.py
+++ b/services/order_router/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/reports/app/__init__.py
+++ b/services/reports/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/screener/app/__init__.py
+++ b/services/screener/app/__init__.py
@@ -1,1 +1,3 @@
 """Application package for the screener service."""
+
+from services import _bootstrap  # noqa: F401

--- a/services/social/app/__init__.py
+++ b/services/social/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/streaming/app/__init__.py
+++ b/services/streaming/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/streaming_gateway/app/__init__.py
+++ b/services/streaming_gateway/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401

--- a/services/user_service/app/__init__.py
+++ b/services/user_service/app/__init__.py
@@ -1,3 +1,5 @@
+from services import _bootstrap  # noqa: F401
+
 from .main import app
 
 __all__ = ["app"]

--- a/services/web_dashboard/app/__init__.py
+++ b/services/web_dashboard/app/__init__.py
@@ -1,0 +1,1 @@
+from services import _bootstrap  # noqa: F401


### PR DESCRIPTION
## Summary
- add a shared bootstrap module that ensures FastAPI services can resolve repository imports when run from their own directories
- import the bootstrap in each FastAPI app package so `uvicorn app.main:app` works without manual PYTHONPATH tweaks
- document the new bootstrap helper and alternative module path in the algo engine developer guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df638d30ac83329a829ca88a17a290