### PR TITLE
Add native environment configuration helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Base
 ENVIRONMENT=dev
+# Set ENVIRONMENT=native to run the stack against services running on localhost.
 APP_NAME=trading-bot-config
 
 # DSNs (à adapter)

--- a/.env.native
+++ b/.env.native
@@ -1,0 +1,12 @@
+ENVIRONMENT=native
+APP_NAME=trading-bot-config
+
+POSTGRES_DSN=postgresql+psycopg2://trading:trading@localhost:5432/trading
+DATABASE_URL=postgresql+psycopg2://trading:trading@localhost:5432/trading
+REDIS_URL=redis://localhost:6379/0
+RABBITMQ_URL=amqp://guest:guest@localhost:5672//
+
+# ==== Auth/User defaults for native dev ====
+PYTHONPATH=/app
+JWT_SECRET=dev-secret-change-me
+JWT_ALGO=HS256

--- a/README.fr.md
+++ b/README.fr.md
@@ -77,6 +77,30 @@ curl http://localhost:8011/health
 make dev-down
 ```
 
+### Développement natif (hors Docker)
+
+Le fichier `.env.dev` suppose que PostgreSQL/Redis/RabbitMQ tournent dans les
+conteneurs Docker. Si vous exécutez ces dépendances directement sur votre
+machine, basculez sur la configuration native :
+
+```bash
+# Pointer la stack vers les services locaux
+export $(cat .env.native | grep -v '^#' | xargs)
+
+# Vérifier que ENVIRONMENT=native pour activer les URLs localhost
+echo $ENVIRONMENT  # native
+
+# Appliquer les migrations sur votre base hôte
+scripts/run_migrations.sh
+```
+
+Le service de configuration et les helpers partagés s'appuient sur la variable
+`ENVIRONMENT` pour sélectionner le bon fichier `.env.<env>` et le JSON de
+configuration correspondant. Avec `ENVIRONMENT=native`, les DSN (`POSTGRES_DSN`,
+`DATABASE_URL`, `REDIS_URL`, `RABBITMQ_URL`) pointent automatiquement vers
+`localhost` tandis que les environnements Docker continuent d'utiliser les
+hostnames internes.
+
 ### Stack de Démonstration
 
 Pour explorer l'ensemble des services de monitoring et d'alertes, lancez la stack complète :

--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ curl http://localhost:8011/health
 make dev-down
 ```
 
+### Native (host) development
+
+The default `.env.dev` assumes every dependency runs inside Docker. When you
+prefer to run PostgreSQL/Redis/RabbitMQ directly on your machine, switch to the
+native configuration helpers:
+
+```bash
+# Point the stack at localhost services
+export $(cat .env.native | grep -v '^#' | xargs)
+
+# Make sure ENVIRONMENT=native so shared helpers hand out localhost URLs
+echo $ENVIRONMENT  # native
+
+# Apply the latest migrations against your host database
+scripts/run_migrations.sh
+```
+
+Both the configuration service and the shared helpers use the
+`ENVIRONMENT` flag to pick the right `.env.<env>` file and config JSON. Setting
+`ENVIRONMENT=native` automatically rewrites DSNs such as `POSTGRES_DSN`,
+`DATABASE_URL`, `REDIS_URL` and `RABBITMQ_URL` to target `localhost` while the
+Docker-based environments keep pointing at the internal container hostnames.
+
 ### Demo Trading Stack
 
 To explore the monitoring and alerting services together, start the full demo stack:

--- a/data/config.native.json
+++ b/data/config.native.json
@@ -1,0 +1,7 @@
+{
+  "APP_NAME": "trading-bot-config",
+  "ENVIRONMENT": "native",
+  "POSTGRES_DSN": "postgresql+psycopg2://trading:trading@localhost:5432/trading",
+  "REDIS_URL": "redis://localhost:6379/0",
+  "RABBITMQ_URL": "amqp://guest:guest@localhost:5672//"
+}

--- a/libs/db/db.py
+++ b/libs/db/db.py
@@ -1,9 +1,12 @@
-﻿import os
+"""Database helpers shared across services."""
+from __future__ import annotations
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-DB_URL = os.getenv("DATABASE_URL", "postgresql+psycopg2://trading:trading@postgres:5432/trading")
+from libs.env import get_database_url
+
+DB_URL = get_database_url()
 
 engine = create_engine(DB_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/libs/env.py
+++ b/libs/env.py
@@ -1,0 +1,140 @@
+"""Environment helpers for resolving connection URLs.
+
+These utilities centralize how services derive connection strings so we can
+support both Docker-based development and native execution on the host
+machine. The helpers look at specific environment variables first and then
+fall back to shared defaults that adapt when ``ENVIRONMENT=native``.
+"""
+from __future__ import annotations
+
+import os
+from urllib.parse import urlsplit, urlunsplit
+
+DEFAULT_POSTGRES_DSN_DOCKER = "postgresql+psycopg2://trading:trading@postgres:5432/trading"
+DEFAULT_POSTGRES_DSN_NATIVE = "postgresql+psycopg2://trading:trading@localhost:5432/trading"
+
+DEFAULT_REDIS_URL_DOCKER = "redis://redis:6379/0"
+DEFAULT_REDIS_URL_NATIVE = "redis://localhost:6379/0"
+
+DEFAULT_RABBITMQ_URL_DOCKER = "amqp://guest:guest@rabbitmq:5672//"
+DEFAULT_RABBITMQ_URL_NATIVE = "amqp://guest:guest@localhost:5672//"
+
+
+def get_environment(default: str = "dev") -> str:
+    """Return the active environment name.
+
+    The value is read from the ``ENVIRONMENT`` variable if present and
+    normalized to lowercase. When the variable is missing ``default`` is
+    returned.
+    """
+
+    return os.getenv("ENVIRONMENT", default).strip().lower()
+
+
+def is_native_environment(env: str | None = None) -> bool:
+    """Return ``True`` when the environment corresponds to ``native``."""
+
+    env_name = env if env is not None else get_environment()
+    return env_name.lower() == "native"
+
+
+def _choose_native_aware_default(docker_default: str, native_default: str) -> str:
+    """Select the appropriate default based on the active environment."""
+
+    if is_native_environment():
+        return native_default
+    return docker_default
+
+
+def get_database_url(*, env_var: str | None = None) -> str:
+    """Return the database URL for the current environment.
+
+    ``env_var`` allows callers to prioritise a service specific variable while
+    still falling back to ``DATABASE_URL`` or ``POSTGRES_DSN`` when available.
+    When none of these variables are defined a sensible default is returned
+    that points to the Docker network or ``localhost`` for native execution.
+    """
+
+    env_vars: list[str | None] = []
+    if env_var:
+        env_vars.append(env_var)
+    env_vars.extend(["DATABASE_URL", "POSTGRES_DSN"])
+    for variable in env_vars:
+        if not variable:
+            continue
+        value = os.getenv(variable)
+        if value:
+            return value
+    return _choose_native_aware_default(
+        DEFAULT_POSTGRES_DSN_DOCKER, DEFAULT_POSTGRES_DSN_NATIVE
+    )
+
+
+def _replace_redis_database(url: str, database: int) -> str:
+    """Return ``url`` with its database component replaced by ``database``."""
+
+    parsed = urlsplit(url)
+    new_path = f"/{database}"
+    return urlunsplit((parsed.scheme, parsed.netloc, new_path, parsed.query, parsed.fragment))
+
+
+def get_redis_url(*, env_var: str | None = None, database: int | None = None) -> str:
+    """Return the Redis URL honouring service specific overrides.
+
+    ``env_var`` can be provided for service-specific configuration. If neither
+    it nor ``REDIS_URL`` is set, an environment aware default is used. When the
+    URL comes from defaults the ``database`` parameter can adjust the DB index
+    while preserving the host and credentials.
+    """
+
+    env_vars: list[str | None] = []
+    if env_var:
+        env_vars.append(env_var)
+    env_vars.append("REDIS_URL")
+    for variable in env_vars:
+        if not variable:
+            continue
+        value = os.getenv(variable)
+        if value:
+            return value
+
+    base_url = _choose_native_aware_default(
+        DEFAULT_REDIS_URL_DOCKER, DEFAULT_REDIS_URL_NATIVE
+    )
+    if database is None:
+        return base_url
+    return _replace_redis_database(base_url, database)
+
+
+def get_rabbitmq_url(*, env_var: str | None = None) -> str:
+    """Return the RabbitMQ connection URL for the active environment."""
+
+    env_vars: list[str | None] = []
+    if env_var:
+        env_vars.append(env_var)
+    env_vars.append("RABBITMQ_URL")
+    for variable in env_vars:
+        if not variable:
+            continue
+        value = os.getenv(variable)
+        if value:
+            return value
+
+    return _choose_native_aware_default(
+        DEFAULT_RABBITMQ_URL_DOCKER, DEFAULT_RABBITMQ_URL_NATIVE
+    )
+
+
+__all__ = [
+    "DEFAULT_POSTGRES_DSN_DOCKER",
+    "DEFAULT_POSTGRES_DSN_NATIVE",
+    "DEFAULT_REDIS_URL_DOCKER",
+    "DEFAULT_REDIS_URL_NATIVE",
+    "DEFAULT_RABBITMQ_URL_DOCKER",
+    "DEFAULT_RABBITMQ_URL_NATIVE",
+    "get_database_url",
+    "get_environment",
+    "get_redis_url",
+    "get_rabbitmq_url",
+    "is_native_environment",
+]

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -5,8 +5,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
 
-DEFAULT_DB_URL="postgresql+psycopg2://trading:trading@postgres:5432/trading"
-DB_URL="${ALEMBIC_DATABASE_URL:-${DATABASE_URL:-${DEFAULT_DB_URL}}}"
+ENVIRONMENT="${ENVIRONMENT:-dev}"
+
+if [[ "${ENVIRONMENT}" == "native" ]]; then
+  DEFAULT_DB_URL="postgresql+psycopg2://trading:trading@localhost:5432/trading"
+else
+  DEFAULT_DB_URL="postgresql+psycopg2://trading:trading@postgres:5432/trading"
+fi
+
+DB_URL="${ALEMBIC_DATABASE_URL:-${DATABASE_URL:-${POSTGRES_DSN:-${DEFAULT_DB_URL}}}}"
 
 export ALEMBIC_DATABASE_URL="${DB_URL}"
 

--- a/services/config_service/app/persistence.py
+++ b/services/config_service/app/persistence.py
@@ -7,6 +7,7 @@ CONFIG_FILES: Dict[str, str] = {
     "dev": os.path.join(DATA_DIR, "config.dev.json"),
     "test": os.path.join(DATA_DIR, "config.test.json"),
     "prod": os.path.join(DATA_DIR, "config.prod.json"),
+    "native": os.path.join(DATA_DIR, "config.native.json"),
 }
 
 

--- a/services/config_service/app/settings.py
+++ b/services/config_service/app/settings.py
@@ -1,7 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
 from pydantic import AnyUrl, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from libs.env import get_database_url, get_environment, get_rabbitmq_url, get_redis_url
+
 from .persistence import read_config_for_env
+
+
+ENV_FILE_MAP = {
+    "dev": ".env.dev",
+    "test": ".env.test",
+    "prod": ".env.prod",
+    "native": ".env.native",
+}
 
 
 class Settings(BaseSettings):
@@ -10,16 +24,29 @@ class Settings(BaseSettings):
     )
 
     APP_NAME: str = "trading-bot-config"
-    ENVIRONMENT: str = Field(default="dev", pattern="^(dev|test|prod)$")
-    POSTGRES_DSN: str = "postgresql+psycopg2://trading:trading@postgres:5432/trading"
-    REDIS_URL: AnyUrl | str = "redis://redis:6379/0"
-    RABBITMQ_URL: AnyUrl | str = "amqp://guest:guest@rabbitmq:5672//"
+    ENVIRONMENT: str = Field(default_factory=get_environment, pattern="^(dev|test|prod|native)$")
+    POSTGRES_DSN: str = Field(default_factory=get_database_url)
+    REDIS_URL: AnyUrl | str = Field(default_factory=get_redis_url)
+    RABBITMQ_URL: AnyUrl | str = Field(default_factory=get_rabbitmq_url)
 
 
 def load_settings() -> Settings:
-    env_settings = Settings()
+    env_name = get_environment()
+    env_file = ENV_FILE_MAP.get(env_name)
+    settings_kwargs = {}
+    if env_file and Path(env_file).exists():
+        settings_kwargs["_env_file"] = env_file
+
+    env_settings = Settings(**settings_kwargs)
     file_data = read_config_for_env(env_settings.ENVIRONMENT)
-    if file_data:
-        merged_data = {**env_settings.model_dump(), **file_data}
-        return Settings(**merged_data)
-    return env_settings
+
+    merged_data = {
+        **env_settings.model_dump(),
+        **(file_data or {}),
+    }
+    merged_data.setdefault("ENVIRONMENT", env_settings.ENVIRONMENT)
+    merged_data.setdefault("POSTGRES_DSN", get_database_url())
+    merged_data.setdefault("REDIS_URL", get_redis_url())
+    merged_data.setdefault("RABBITMQ_URL", get_rabbitmq_url())
+
+    return Settings(**merged_data)

--- a/services/inplay/app/config.py
+++ b/services/inplay/app/config.py
@@ -6,6 +6,12 @@ from typing import Dict, List
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from libs.env import get_redis_url
+
+
+def _default_redis_url() -> str:
+    return get_redis_url(env_var="INPLAY_REDIS_URL")
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
@@ -14,7 +20,7 @@ class Settings(BaseSettings):
         populate_by_name=True,
     )
 
-    redis_url: str = Field("redis://redis:6379/0", alias="INPLAY_REDIS_URL")
+    redis_url: str = Field(default_factory=_default_redis_url, alias="INPLAY_REDIS_URL")
     watchlists: Dict[str, List[str]] = Field(
         default_factory=lambda: {
             "momentum": ["AAPL", "MSFT", "TSLA"],

--- a/services/market_data/app/config.py
+++ b/services/market_data/app/config.py
@@ -6,11 +6,16 @@ from pydantic import Field
 from pydantic_settings import BaseSettings
 
 from libs.secrets import get_secret
+from libs.env import get_database_url
+
+
+def _default_database_url() -> str:
+    return get_database_url(env_var="MARKET_DATA_DATABASE_URL")
 
 
 class Settings(BaseSettings):
     database_url: str = Field(
-        "postgresql+psycopg2://trading:trading@postgres:5432/trading",
+        default_factory=_default_database_url,
         alias="MARKET_DATA_DATABASE_URL",
     )
     tradingview_hmac_secret: str = Field(..., alias="TRADINGVIEW_HMAC_SECRET")

--- a/services/reports/app/config.py
+++ b/services/reports/app/config.py
@@ -5,14 +5,30 @@ import functools
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
+from libs.env import get_redis_url
+
+
+def _default_celery_broker_url() -> str:
+    return get_redis_url(env_var="REPORTS_CELERY_BROKER", database=0)
+
+
+def _default_celery_backend_url() -> str:
+    return get_redis_url(env_var="REPORTS_CELERY_BACKEND", database=1)
+
 
 class Settings(BaseSettings):
     database_url: str = Field(
         "sqlite+pysqlite:///./reports.db",
         alias="REPORTS_DATABASE_URL",
     )
-    celery_broker_url: str = Field("redis://redis:6379/0", alias="REPORTS_CELERY_BROKER")
-    celery_backend_url: str = Field("redis://redis:6379/1", alias="REPORTS_CELERY_BACKEND")
+    celery_broker_url: str = Field(
+        default_factory=_default_celery_broker_url,
+        alias="REPORTS_CELERY_BROKER",
+    )
+    celery_backend_url: str = Field(
+        default_factory=_default_celery_backend_url,
+        alias="REPORTS_CELERY_BACKEND",
+    )
     refresh_interval_seconds: int = Field(300, alias="REPORTS_REFRESH_INTERVAL")
     reports_storage_path: str = Field("./generated-reports", alias="REPORTS_STORAGE_PATH")
 


### PR DESCRIPTION
## Summary
- add reusable helpers and native-friendly env/config files that point services to localhost
- update configuration loaders and service settings to respect ENVIRONMENT=native and fall back to shared DSNs
- document how to switch to the native setup and adjust migration scripts to default to localhost when appropriate

## Testing
- python -m compileall libs/env.py services/config_service/app/settings.py services/market_data/app/config.py services/inplay/app/config.py services/reports/app/config.py
- env $(grep -v '^#' .env.native | xargs) scripts/run_migrations.sh *(fails: no PostgreSQL listening on localhost)*

------
https://chatgpt.com/codex/tasks/task_e_68df62f7749c8332adb1ebffbe484f75