### PR TITLE
Use TimescaleDB image for Postgres service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: timescale/timescaledb:2.14.2-pg14
     environment:
       POSTGRES_DB: trading
       POSTGRES_USER: trading


### PR DESCRIPTION
## Summary
- update the Postgres service in docker-compose to use the TimescaleDB PG14 image so the timescaledb extension is available during migrations

## Testing
- not run (Docker CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df65f5c4508332810d7718883be236