### PR TITLE
Default Postgres fallbacks to localhost for native workflows

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,11 +1,11 @@
 ENVIRONMENT=dev
 APP_NAME=trading-bot-config
-POSTGRES_DSN=postgresql+psycopg2://trading:trading@postgres:5432/trading
+POSTGRES_DSN=postgresql+psycopg2://trading:trading@localhost:5432/trading
 REDIS_URL=redis://redis:6379/0
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672//
 
 # ==== Auth/User defaults for local dev ====
-DATABASE_URL=postgresql+psycopg2://trading:trading@postgres:5432/trading
+DATABASE_URL=postgresql+psycopg2://trading:trading@localhost:5432/trading
 PYTHONPATH=/app
 JWT_SECRET=dev-secret-change-me
 JWT_ALGO=HS256

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@ ENVIRONMENT=dev
 APP_NAME=trading-bot-config
 
 # DSNs (à adapter)
-POSTGRES_DSN=postgresql+psycopg2://trading:trading@postgres:5432/trading
+POSTGRES_DSN=postgresql+psycopg2://trading:trading@localhost:5432/trading
 REDIS_URL=redis://redis:6379/0
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672//

--- a/data/config.dev.json
+++ b/data/config.dev.json
@@ -1,7 +1,7 @@
 {
   "APP_NAME": "trading-bot-config",
   "ENVIRONMENT": "dev",
-  "POSTGRES_DSN": "postgresql+psycopg2://trading:trading@postgres:5432/trading",
+  "POSTGRES_DSN": "postgresql+psycopg2://trading:trading@localhost:5432/trading",
   "REDIS_URL": "redis://redis:6379/0",
   "RABBITMQ_URL": "amqp://guest:guest@rabbitmq:5672//"
 }

--- a/libs/db/db.py
+++ b/libs/db/db.py
@@ -1,12 +1,25 @@
 """Database helpers shared across services."""
 from __future__ import annotations
 
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from libs.env import get_database_url
+from libs.env import DEFAULT_POSTGRES_DSN_NATIVE
 
-DB_URL = get_database_url()
+
+def _resolve_database_url() -> str:
+    """Return the configured database URL or fall back to localhost."""
+
+    for env_var in ("DATABASE_URL", "POSTGRES_DSN"):
+        value = os.getenv(env_var)
+        if value:
+            return value
+    return DEFAULT_POSTGRES_DSN_NATIVE
+
+
+DB_URL = _resolve_database_url()
 
 engine = create_engine(DB_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -7,11 +7,7 @@ cd "${REPO_ROOT}"
 
 ENVIRONMENT="${ENVIRONMENT:-dev}"
 
-if [[ "${ENVIRONMENT}" == "native" ]]; then
-  DEFAULT_DB_URL="postgresql+psycopg2://trading:trading@localhost:5432/trading"
-else
-  DEFAULT_DB_URL="postgresql+psycopg2://trading:trading@postgres:5432/trading"
-fi
+DEFAULT_DB_URL="postgresql+psycopg2://trading:trading@localhost:5432/trading"
 
 DB_URL="${ALEMBIC_DATABASE_URL:-${DATABASE_URL:-${POSTGRES_DSN:-${DEFAULT_DB_URL}}}}"
 

--- a/services/market_data/app/config.py
+++ b/services/market_data/app/config.py
@@ -2,15 +2,21 @@ from __future__ import annotations
 
 import functools
 
+import os
+
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
 from libs.secrets import get_secret
-from libs.env import get_database_url
+from libs.env import DEFAULT_POSTGRES_DSN_NATIVE
 
 
 def _default_database_url() -> str:
-    return get_database_url(env_var="MARKET_DATA_DATABASE_URL")
+    for env_var in ("MARKET_DATA_DATABASE_URL", "DATABASE_URL", "POSTGRES_DSN"):
+        value = os.getenv(env_var)
+        if value:
+            return value
+    return DEFAULT_POSTGRES_DSN_NATIVE
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- update database helper and service configuration defaults to fall back to the localhost Postgres DSN while respecting environment overrides
- align local environment files, development config, and migration script defaults with the localhost DSN
- note that docker compose still injects container-specific DSNs that point at the `postgres` hostname

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df660d262c8332aee04d31bae9b1c7