### PR TITLE
Add merge migration to reconcile Alembic heads

### DIFF
--- a/infra/migrations/versions/9f1741437496_merge_heads.py
+++ b/infra/migrations/versions/9f1741437496_merge_heads.py
@@ -1,0 +1,25 @@
+"""Merge heads
+
+Revision ID: 9f1741437496
+Revises: 17d54bc596c1, 2a0f9a0cb742
+Create Date: 2025-10-03 06:05:24.366119
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "9f1741437496"
+down_revision = ('17d54bc596c1', '2a0f9a0cb742')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- add a merge migration that links revisions 17d54bc596c1 and 2a0f9a0cb742
- ensure the merge contains no schema changes so the history remains linear

## Testing
- alembic -c infra/migrations/alembic.ini heads

------
https://chatgpt.com/codex/tasks/task_e_68df677b1bb4833288264a1b2cce1159