### PR TITLE
Set default TradingView HMAC secret and document configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ APP_NAME=trading-bot-config
 POSTGRES_DSN=postgresql+psycopg2://trading:trading@localhost:5432/trading
 REDIS_URL=redis://redis:6379/0
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672//
+
+# Secrets
+TRADINGVIEW_HMAC_SECRET=demo-hmac-secret

--- a/services/market_data/app/config.py
+++ b/services/market_data/app/config.py
@@ -24,7 +24,10 @@ class Settings(BaseSettings):
         default_factory=_default_database_url,
         alias="MARKET_DATA_DATABASE_URL",
     )
-    tradingview_hmac_secret: str = Field(..., alias="TRADINGVIEW_HMAC_SECRET")
+    tradingview_hmac_secret: str = Field(
+        "demo-hmac-secret",
+        alias="TRADINGVIEW_HMAC_SECRET",
+    )
     binance_api_key: str | None = Field(None, alias="BINANCE_API_KEY")
     binance_api_secret: str | None = Field(None, alias="BINANCE_API_SECRET")
     ibkr_host: str = Field("127.0.0.1", alias="IBKR_HOST")


### PR DESCRIPTION
## Summary
- default the TradingView HMAC secret in market data settings to the compose fallback
- keep environment and secret manager overrides working as before
- document the secret in the sample environment file so operators change it in production

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df679b30b88332bf28ae399cf997bd