### PR TITLE
Add python-multipart dependency for web dashboard

### DIFF
--- a/services/web_dashboard/README.md
+++ b/services/web_dashboard/README.md
@@ -90,6 +90,13 @@ le backend FastAPI.
 
 La section « Setups en temps réel » propose un sélecteur de session (`Toutes les sessions`, `Londres`, `New York`, `Asie`). Le filtrage est appliqué côté navigateur et déclenche, si besoin, une requête `GET /inplay/watchlists/{id}?session=...` pour synchroniser l'instantané InPlay. Sans sélection particulière, toutes les sessions restent visibles et les mises à jour temps réel continuent d'être diffusées via le WebSocket.
 
+## Installation manuelle
+
+Pour lancer le service hors Docker, installez les dépendances Python via
+`pip install -r services/web_dashboard/requirements.txt`. Cette liste inclut désormais
+`python-multipart` (>=0.0.6) afin de permettre à FastAPI de parser les formulaires et
+fichiers envoyés par le designer de stratégies.
+
 ## Tests
 
 Deux familles de tests couvrent le service :

--- a/services/web_dashboard/requirements.txt
+++ b/services/web_dashboard/requirements.txt
@@ -4,3 +4,4 @@ jinja2>=3.1
 httpx>=0.26
 markdown==3.5.2
 python-jose>=3.3
+python-multipart>=0.0.6


### PR DESCRIPTION
## Summary
- add python-multipart to the web dashboard service requirements to enable FastAPI form parsing
- document the runtime dependency for manual service installs in the web dashboard README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df678cea588332a523ead8f4867c65