### PR TITLE
Add TopStep evaluation adapter and API endpoints

### DIFF
--- a/services/market_data/adapters/__init__.py
+++ b/services/market_data/adapters/__init__.py
@@ -2,6 +2,7 @@ from .binance import BinanceMarketConnector
 from .dtc import DTCAdapter, DTCConfig
 from .ibkr import IBKRMarketConnector
 from .rate_limiter import AsyncRateLimiter
+from .topstep import TopStepAdapter
 
 __all__ = [
     "AsyncRateLimiter",
@@ -9,4 +10,5 @@ __all__ = [
     "DTCAdapter",
     "DTCConfig",
     "IBKRMarketConnector",
+    "TopStepAdapter",
 ]

--- a/services/market_data/adapters/topstep.py
+++ b/services/market_data/adapters/topstep.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+
+
+class TopStepAdapter:
+    """Asynchronous client for TopStep's evaluation API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        client_id: str,
+        client_secret: str,
+        http_client: httpx.AsyncClient | None = None,
+        auth_path: str = "/oauth/token",
+        timeout: float = 10.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = http_client or httpx.AsyncClient(base_url=self._base_url, timeout=timeout)
+        self._client_owned = http_client is None
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._auth_path = auth_path
+        self._token: str | None = None
+        self._token_expiry: datetime | None = None
+        self._lock = asyncio.Lock()
+
+    async def aclose(self) -> None:
+        if self._client_owned:
+            await self._client.aclose()
+
+    async def get_account_metrics(self, account_id: str) -> dict[str, Any]:
+        return await self._request("GET", f"/v1/accounts/{account_id}/metrics")
+
+    async def get_performance_history(
+        self,
+        account_id: str,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if start:
+            params["start"] = start
+        if end:
+            params["end"] = end
+        return await self._request(
+            "GET",
+            f"/v1/accounts/{account_id}/performance",
+            params=params,
+        )
+
+    async def get_risk_rules(self, account_id: str) -> dict[str, Any]:
+        return await self._request("GET", f"/v1/accounts/{account_id}/risk-rules")
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        token = await self._ensure_token()
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = await self._client.request(
+            method,
+            path,
+            headers=headers,
+            params=params,
+        )
+
+        if response.status_code == 401:
+            token = await self._ensure_token(force_refresh=True)
+            headers["Authorization"] = f"Bearer {token}"
+            response = await self._client.request(
+                method,
+                path,
+                headers=headers,
+                params=params,
+            )
+
+        response.raise_for_status()
+        return response.json()
+
+    async def _ensure_token(self, *, force_refresh: bool = False) -> str:
+        async with self._lock:
+            if not force_refresh and self._token and self._token_expiry:
+                now = datetime.now(timezone.utc)
+                if now < self._token_expiry:
+                    return self._token
+
+            token, expires_in = await self._authenticate()
+            self._token = token
+            expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            # Refresh slightly before actual expiry to avoid race conditions
+            self._token_expiry = expiry - timedelta(seconds=30)
+            return self._token
+
+    async def _authenticate(self) -> tuple[str, int]:
+        response = await self._client.post(
+            self._auth_path,
+            json={
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        token = payload.get("access_token")
+        expires_in = int(payload.get("expires_in", 0))
+        if not token or expires_in <= 0:
+            raise httpx.HTTPError("Invalid authentication response")
+        return token, expires_in
+
+
+__all__ = ["TopStepAdapter"]

--- a/services/market_data/app/config.py
+++ b/services/market_data/app/config.py
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
     ibkr_host: str = Field("127.0.0.1", alias="IBKR_HOST")
     ibkr_port: int = Field(4001, alias="IBKR_PORT")
     ibkr_client_id: int = Field(1, alias="IBKR_CLIENT_ID")
+    topstep_base_url: str = Field("https://api.topstep.com", alias="TOPSTEP_BASE_URL")
+    topstep_client_id: str | None = Field(None, alias="TOPSTEP_CLIENT_ID")
+    topstep_client_secret: str | None = Field(None, alias="TOPSTEP_CLIENT_SECRET")
 
     class Config:
         env_file = ".env"
@@ -41,6 +44,8 @@ _SECRET_KEYS = [
     "TRADINGVIEW_HMAC_SECRET",
     "BINANCE_API_KEY",
     "BINANCE_API_SECRET",
+    "TOPSTEP_CLIENT_ID",
+    "TOPSTEP_CLIENT_SECRET",
 ]
 
 

--- a/services/market_data/requirements.txt
+++ b/services/market_data/requirements.txt
@@ -7,3 +7,4 @@ ib-async>=2.0.1
 pydantic>=1.10,<3
 pydantic-settings>=2.2
 prometheus-client>=0.20
+httpx>=0.24

--- a/services/market_data/tests/test_topstep_adapter.py
+++ b/services/market_data/tests/test_topstep_adapter.py
@@ -1,0 +1,106 @@
+import asyncio
+
+import httpx
+
+from services.market_data.adapters.topstep import TopStepAdapter
+
+
+class _TransportState:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, httpx.Request]] = []
+        self.token_requests = 0
+
+
+def _build_transport(state: _TransportState) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        state.calls.append((request.method, request))
+        if request.url.path == "/oauth/token":
+            state.token_requests += 1
+            return httpx.Response(200, json={"access_token": "token-1", "expires_in": 60})
+
+        auth = request.headers.get("Authorization")
+        if auth != "Bearer token-1":
+            return httpx.Response(401, json={"detail": "unauthorized"})
+
+        if request.url.path.endswith("/metrics"):
+            return httpx.Response(200, json={"balance": 1000})
+        if request.url.path.endswith("/performance"):
+            params = dict(request.url.params)
+            return httpx.Response(200, json={"pnl": [params]})
+        if request.url.path.endswith("/risk-rules"):
+            return httpx.Response(200, json={"max_drawdown": 100})
+
+        return httpx.Response(404)
+
+    return httpx.MockTransport(handler)
+
+
+def test_topstep_adapter_authenticates_and_fetches_metrics() -> None:
+    state = _TransportState()
+    client = httpx.AsyncClient(base_url="https://topstep.local", transport=_build_transport(state))
+    adapter = TopStepAdapter(
+        base_url="https://topstep.local",
+        client_id="abc",
+        client_secret="def",
+        http_client=client,
+    )
+
+    async def run() -> None:
+        metrics = await adapter.get_account_metrics("acct-1")
+        assert metrics == {"balance": 1000}
+        await adapter.aclose()
+
+    asyncio.run(run())
+
+    assert state.token_requests == 1
+    assert any(path.endswith("/metrics") for _, path in [(m, req.url.path) for m, req in state.calls])
+
+
+def test_topstep_adapter_reuses_token_until_expiry_and_passes_params() -> None:
+    state = _TransportState()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        state.calls.append((request.method, request))
+        if request.url.path == "/oauth/token":
+            state.token_requests += 1
+            token = f"token-{state.token_requests}"
+            return httpx.Response(200, json={"access_token": token, "expires_in": 1})
+
+        auth = request.headers.get("Authorization")
+        if auth != f"Bearer token-{state.token_requests}":
+            return httpx.Response(401, json={"detail": "unauthorized"})
+
+        if request.url.path.endswith("/performance"):
+            params = dict(request.url.params)
+            return httpx.Response(200, json={"pnl": params})
+        if request.url.path.endswith("/risk-rules"):
+            return httpx.Response(200, json={"max_daily_loss": 50})
+        return httpx.Response(404)
+
+    client = httpx.AsyncClient(
+        base_url="https://topstep.local",
+        transport=httpx.MockTransport(handler),
+    )
+
+    adapter = TopStepAdapter(
+        base_url="https://topstep.local",
+        client_id="abc",
+        client_secret="def",
+        http_client=client,
+    )
+
+    async def run() -> None:
+        history = await adapter.get_performance_history(
+            "acct-1", start="2024-01-01", end="2024-02-01"
+        )
+        await asyncio.sleep(1.1)
+        rules = await adapter.get_risk_rules("acct-1")
+        assert history == {"pnl": {"start": "2024-01-01", "end": "2024-02-01"}}
+        assert rules == {"max_daily_loss": 50}
+        await adapter.aclose()
+
+    asyncio.run(run())
+
+    # Token should be refreshed due to expiry before second request
+    assert state.token_requests == 2
+

--- a/services/market_data/tests/test_topstep_api.py
+++ b/services/market_data/tests/test_topstep_api.py
@@ -1,0 +1,102 @@
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import os
+
+os.environ.setdefault("TRADINGVIEW_HMAC_SECRET", "test-secret")
+
+from services.market_data.app.main import (  # noqa: E402
+    app,
+    get_topstep_adapter,
+)
+
+
+class TopStepAdapterFake:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def _record(self, method: str, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((method, args, kwargs))
+
+    async def get_account_metrics(self, account_id: str) -> dict[str, Any]:
+        self._record("get_account_metrics", account_id)
+        return {"balance": 1000, "account": account_id}
+
+    async def get_performance_history(
+        self,
+        account_id: str,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> dict[str, Any]:
+        self._record("get_performance_history", account_id, start, end)
+        return {"points": [start, end]}
+
+    async def get_risk_rules(self, account_id: str) -> dict[str, Any]:
+        self._record("get_risk_rules", account_id)
+        return {"max_drawdown": 100}
+
+
+def _override_dependency(fake: TopStepAdapterFake) -> None:
+    async def dependency() -> AsyncIterator[TopStepAdapterFake]:
+        yield fake
+
+    app.dependency_overrides[get_topstep_adapter] = dependency
+
+
+def test_topstep_metrics_endpoint_returns_payload() -> None:
+    fake = TopStepAdapterFake()
+    _override_dependency(fake)
+    client = TestClient(app)
+    try:
+        response = client.get("/market-data/topstep/accounts/acct-1/metrics")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["metrics"]["balance"] == 1000
+    assert fake.calls[0][0] == "get_account_metrics"
+
+
+def test_topstep_performance_endpoint_passes_query_params() -> None:
+    fake = TopStepAdapterFake()
+    _override_dependency(fake)
+    client = TestClient(app)
+    try:
+        response = client.get(
+            "/market-data/topstep/accounts/acct-2/performance",
+            params={"start": "2024-01-01", "end": "2024-02-01"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["performance"]["points"] == ["2024-01-01", "2024-02-01"]
+    assert fake.calls[0][1][1:] == ("2024-01-01", "2024-02-01")
+
+
+def test_topstep_risk_rules_endpoint_handles_upstream_errors() -> None:
+    class FailingAdapter(TopStepAdapterFake):
+        async def get_risk_rules(self, account_id: str) -> dict[str, Any]:
+            raise HTTPException(status_code=404, detail="not found")
+
+    fake = FailingAdapter()
+
+    async def dependency() -> AsyncIterator[FailingAdapter]:
+        yield fake
+
+    app.dependency_overrides[get_topstep_adapter] = dependency
+
+    client = TestClient(app)
+    try:
+        response = client.get("/market-data/topstep/accounts/acct-3/risk-rules")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "not found"


### PR DESCRIPTION
## Summary
- add a TopStep adapter that authenticates against the evaluation API and exposes metrics, performance, and risk data helpers
- surface TopStep configuration in the market data service and register new endpoints delivering evaluation results
- cover the adapter interactions and API routes with unit tests and add the required httpx dependency

## Testing
- pytest services/market_data/tests/test_topstep_adapter.py services/market_data/tests/test_topstep_api.py

------
https://chatgpt.com/codex/tasks/task_e_68df67d59ed8833281f70e0d790c4532