### PR TITLE
Refine market data primary keys

### DIFF
--- a/infra/migrations/versions/0002_market_data.py
+++ b/infra/migrations/versions/0002_market_data.py
@@ -15,7 +15,6 @@ def upgrade() -> None:
 
     op.create_table(
         "market_data_ohlcv",
-        sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("exchange", sa.String(length=32), nullable=False),
         sa.Column("symbol", sa.String(length=64), nullable=False),
         sa.Column("interval", sa.String(length=16), nullable=False),
@@ -28,7 +27,9 @@ def upgrade() -> None:
         sa.Column("quote_volume", sa.Float, nullable=True),
         sa.Column("trades", sa.Integer, nullable=True),
         sa.Column("extra", postgresql.JSONB, nullable=True),
-        sa.UniqueConstraint("exchange", "symbol", "interval", "timestamp", name="uq_ohlcv_bar"),
+        sa.PrimaryKeyConstraint(
+            "exchange", "symbol", "interval", "timestamp", name="pk_market_data_ohlcv"
+        ),
     )
     op.execute(
         "SELECT create_hypertable('market_data_ohlcv', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"
@@ -36,7 +37,6 @@ def upgrade() -> None:
 
     op.create_table(
         "market_data_ticks",
-        sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("exchange", sa.String(length=32), nullable=False),
         sa.Column("symbol", sa.String(length=64), nullable=False),
         sa.Column("source", sa.String(length=32), nullable=False),
@@ -45,7 +45,9 @@ def upgrade() -> None:
         sa.Column("size", sa.Float, nullable=True),
         sa.Column("side", sa.String(length=8), nullable=True),
         sa.Column("extra", postgresql.JSONB, nullable=True),
-        sa.UniqueConstraint("exchange", "symbol", "timestamp", "source", name="uq_tick"),
+        sa.PrimaryKeyConstraint(
+            "exchange", "symbol", "source", "timestamp", name="pk_market_data_ticks"
+        ),
     )
     op.execute(
         "SELECT create_hypertable('market_data_ticks', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"

--- a/infra/migrations/versions/a1b8c9d0e1f2_market_data_composite_pk.py
+++ b/infra/migrations/versions/a1b8c9d0e1f2_market_data_composite_pk.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a1b8c9d0e1f2"
+down_revision = "17d54bc596c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("market_data_ohlcv", schema=None) as batch_op:
+        batch_op.drop_constraint("uq_ohlcv_bar", type_="unique")
+        batch_op.drop_constraint("market_data_ohlcv_pkey", type_="primary")
+        batch_op.drop_column("id")
+        batch_op.create_primary_key(
+            "pk_market_data_ohlcv", ["exchange", "symbol", "interval", "timestamp"]
+        )
+
+    op.execute("DROP SEQUENCE IF EXISTS market_data_ohlcv_id_seq")
+
+    with op.batch_alter_table("market_data_ticks", schema=None) as batch_op:
+        batch_op.drop_constraint("uq_tick", type_="unique")
+        batch_op.drop_constraint("market_data_ticks_pkey", type_="primary")
+        batch_op.drop_column("id")
+        batch_op.create_primary_key(
+            "pk_market_data_ticks", ["exchange", "symbol", "source", "timestamp"]
+        )
+
+    op.execute("DROP SEQUENCE IF EXISTS market_data_ticks_id_seq")
+
+    op.execute(
+        "SELECT create_hypertable('market_data_ohlcv', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"
+    )
+    op.execute(
+        "SELECT create_hypertable('market_data_ticks', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"
+    )
+
+
+def downgrade() -> None:
+    op.execute("CREATE SEQUENCE IF NOT EXISTS market_data_ohlcv_id_seq")
+    op.execute("CREATE SEQUENCE IF NOT EXISTS market_data_ticks_id_seq")
+
+    with op.batch_alter_table("market_data_ohlcv", schema=None) as batch_op:
+        batch_op.drop_constraint("pk_market_data_ohlcv", type_="primary")
+        batch_op.add_column(
+            sa.Column(
+                "id",
+                sa.BigInteger(),
+                server_default=sa.text("nextval('market_data_ohlcv_id_seq'::regclass)"),
+                nullable=False,
+            )
+        )
+        batch_op.create_primary_key("market_data_ohlcv_pkey", ["id"])
+        batch_op.create_unique_constraint(
+            "uq_ohlcv_bar", ["exchange", "symbol", "interval", "timestamp"]
+        )
+
+    with op.batch_alter_table("market_data_ticks", schema=None) as batch_op:
+        batch_op.drop_constraint("pk_market_data_ticks", type_="primary")
+        batch_op.add_column(
+            sa.Column(
+                "id",
+                sa.BigInteger(),
+                server_default=sa.text("nextval('market_data_ticks_id_seq'::regclass)"),
+                nullable=False,
+            )
+        )
+        batch_op.create_primary_key("market_data_ticks_pkey", ["id"])
+        batch_op.create_unique_constraint(
+            "uq_tick", ["exchange", "symbol", "timestamp", "source"]
+        )
+
+    op.execute(
+        "ALTER SEQUENCE market_data_ohlcv_id_seq OWNED BY market_data_ohlcv.id"
+    )
+    op.execute(
+        "ALTER SEQUENCE market_data_ticks_id_seq OWNED BY market_data_ticks.id"
+    )

--- a/services/market_data/app/persistence.py
+++ b/services/market_data/app/persistence.py
@@ -33,7 +33,7 @@ def persist_ohlcv(session: Session, rows: Iterable[Mapping[str, object]]) -> Non
             for row in payload
         ]
     ).on_conflict_do_update(
-        constraint="uq_ohlcv_bar",
+        constraint="pk_market_data_ohlcv",
         set_={
             "open": insert_stmt.excluded.open,
             "high": insert_stmt.excluded.high,
@@ -53,5 +53,9 @@ def persist_ticks(session: Session, rows: Iterable[Mapping[str, object]]) -> Non
     if not payload:
         return
 
-    stmt = insert(MarketDataTick).values(payload).on_conflict_do_nothing(constraint="uq_tick")
+    stmt = (
+        insert(MarketDataTick)
+        .values(payload)
+        .on_conflict_do_nothing(constraint="pk_market_data_ticks")
+    )
     session.execute(stmt)

--- a/services/market_data/app/tables.py
+++ b/services/market_data/app/tables.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from sqlalchemy import BigInteger, Column, DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    PrimaryKeyConstraint,
+    String,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import declarative_base
 
@@ -10,14 +17,15 @@ Base = declarative_base()
 class MarketDataOHLCV(Base):
     __tablename__ = "market_data_ohlcv"
     __table_args__ = (
-        UniqueConstraint("exchange", "symbol", "interval", "timestamp", name="uq_ohlcv_bar"),
+        PrimaryKeyConstraint(
+            "exchange", "symbol", "interval", "timestamp", name="pk_market_data_ohlcv"
+        ),
     )
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    exchange = Column(String(32), nullable=False)
-    symbol = Column(String(64), nullable=False)
-    interval = Column(String(16), nullable=False)
-    timestamp = Column(DateTime(timezone=True), nullable=False)
+    exchange = Column(String(32), nullable=False, primary_key=True)
+    symbol = Column(String(64), nullable=False, primary_key=True)
+    interval = Column(String(16), nullable=False, primary_key=True)
+    timestamp = Column(DateTime(timezone=True), nullable=False, primary_key=True)
     open = Column(Float, nullable=False)
     high = Column(Float, nullable=False)
     low = Column(Float, nullable=False)
@@ -31,14 +39,15 @@ class MarketDataOHLCV(Base):
 class MarketDataTick(Base):
     __tablename__ = "market_data_ticks"
     __table_args__ = (
-        UniqueConstraint("exchange", "symbol", "timestamp", "source", name="uq_tick"),
+        PrimaryKeyConstraint(
+            "exchange", "symbol", "source", "timestamp", name="pk_market_data_ticks"
+        ),
     )
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    exchange = Column(String(32), nullable=False)
-    symbol = Column(String(64), nullable=False)
-    source = Column(String(32), nullable=False)
-    timestamp = Column(DateTime(timezone=True), nullable=False)
+    exchange = Column(String(32), nullable=False, primary_key=True)
+    symbol = Column(String(64), nullable=False, primary_key=True)
+    source = Column(String(32), nullable=False, primary_key=True)
+    timestamp = Column(DateTime(timezone=True), nullable=False, primary_key=True)
     price = Column(Float, nullable=False)
     size = Column(Float, nullable=True)
     side = Column(String(8), nullable=True)


### PR DESCRIPTION
## Summary
- replace surrogate ids on the market data hypertables with composite primary keys that include the timestamp partitioning column
- update the SQLAlchemy models and persistence helpers to target the new primary key names
- add a follow-up migration to drop legacy id columns, clean up sequences, and rerun hypertable creation for existing deployments

## Testing
- pytest services/market_data

------
https://chatgpt.com/codex/tasks/task_e_68df6777d6ac8332877444b434ea7eed