### PR TITLE
Add dashboard account page coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -r requirements/services-dev.txt
 
       - name: Install Playwright browsers
-        run: python -m playwright install --with-deps chromium
+        run: python -m playwright install --with-deps chromium firefox
       - name: Run tests
         run: pytest -q
       - name: Build config-service Docker image

--- a/services/web_dashboard/tests/e2e/test_account_page.py
+++ b/services/web_dashboard/tests/e2e/test_account_page.py
@@ -1,0 +1,46 @@
+"""End-to-end tests covering the account page user interactions."""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+playwright_async = pytest.importorskip("playwright.async_api")
+Page = playwright_async.Page
+expect = playwright_async.expect
+
+BROWSER_PROJECTS = [
+    pytest.param("chromium", id="chromium"),
+    pytest.param("firefox", id="firefox"),
+]
+
+
+@pytest.mark.parametrize("browser_name", BROWSER_PROJECTS)
+async def test_account_login_form_validation(
+    page: Page, browser_name: str, dashboard_base_url: str
+):
+    """The login form should surface HTML validation feedback before accepting inputs."""
+
+    await page.goto(f"{dashboard_base_url}/account", wait_until="networkidle")
+
+    await expect(page.get_by_role("heading", level=2, name="Connexion")).to_be_visible()
+
+    email_input = page.get_by_label("Adresse e-mail")
+    password_input = page.get_by_label("Mot de passe")
+    submit_button = page.get_by_role("button", name="Se connecter")
+
+    assert await email_input.evaluate("el.required")
+    assert await password_input.evaluate("el.required")
+
+    await email_input.fill("")
+    await password_input.fill("")
+    await submit_button.click()
+
+    assert await email_input.evaluate("el.validity.valueMissing")
+    assert await password_input.evaluate("el.validity.valueMissing")
+    await expect(email_input).to_be_focused()
+
+    await email_input.fill("trader@example.com")
+    await password_input.fill("Sup3rSecret!")
+
+    assert await email_input.evaluate("el.checkValidity()")
+    assert await password_input.evaluate("el.checkValidity()")

--- a/services/web_dashboard/tests/test_account_page.py
+++ b/services/web_dashboard/tests/test_account_page.py
@@ -1,0 +1,30 @@
+"""Tests for the account management page of the dashboard."""
+
+from fastapi.testclient import TestClient
+
+from .utils import load_dashboard_app
+
+
+def test_account_page_exposes_login_and_api_forms():
+    """The /account page should render the login and API key management forms."""
+
+    app = load_dashboard_app()
+    client = TestClient(app)
+
+    response = client.get("/account", headers={"accept-language": "fr-FR,fr;q=0.9"})
+
+    assert response.status_code == 200
+    assert response.headers.get("Content-Language") == "fr"
+
+    html = response.text
+
+    # The template should expose the correct lang attribute and login form inputs.
+    assert "<html lang=\"fr\"" in html
+    assert '<form class="form-grid" action="#" method="post">' in html
+    assert '<input type="email" name="email" autocomplete="email" required />' in html
+    assert '<input type="password" name="password" autocomplete="current-password" required />' in html
+
+    # The API key management form and its inputs must also be present.
+    assert '<select name="exchange">' in html
+    assert '<input type="text" name="public" autocomplete="off" required />' in html
+    assert '<input type="password" name="secret" autocomplete="off" required />' in html


### PR DESCRIPTION
## Summary
- add a FastAPI TestClient regression test that ensures the account page renders with the expected language metadata and form controls
- introduce a Playwright E2E scenario for the account login form that runs on both Chromium and Firefox projects
- update the CI workflow to install the additional Playwright browser required by the new coverage

## Testing
- python -m pytest services/web_dashboard/tests/test_account_page.py

------
https://chatgpt.com/codex/tasks/task_e_68df67ee88188332a58088ae54ad0256