### PR TITLE
Add merge revision to linearize migration heads

### DIFF
--- a/infra/migrations/versions/b3e1c2d4e5f6_merge_branches.py
+++ b/infra/migrations/versions/b3e1c2d4e5f6_merge_branches.py
@@ -1,0 +1,23 @@
+"""Merge strategy and market data heads
+
+Revision ID: b3e1c2d4e5f6
+Revises: 9f1741437496, a1b8c9d0e1f2
+Create Date: 2024-05-13 00:00:00
+
+"""
+
+from __future__ import annotations
+
+
+revision = "b3e1c2d4e5f6"
+down_revision = ("9f1741437496", "a1b8c9d0e1f2")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- add a merge migration that ties together the strategy and market data heads to linearize the history

## Testing
- alembic -c infra/migrations/alembic.ini heads

------
https://chatgpt.com/codex/tasks/task_e_68df6a5369ac833293d9c2a5268e1c4b