### PR TITLE
Set default TradingView HMAC secret fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,5 @@ REDIS_URL=redis://redis:6379/0
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672//
 
 # Secrets
+# Change this shared secret in production deployments.
 TRADINGVIEW_HMAC_SECRET=demo-hmac-secret

--- a/services/market_data/app/config.py
+++ b/services/market_data/app/config.py
@@ -11,6 +11,9 @@ from libs.secrets import get_secret
 from libs.env import DEFAULT_POSTGRES_DSN_NATIVE
 
 
+DEFAULT_TRADINGVIEW_HMAC_SECRET = "demo-hmac-secret"
+
+
 def _default_database_url() -> str:
     for env_var in ("MARKET_DATA_DATABASE_URL", "DATABASE_URL", "POSTGRES_DSN"):
         value = os.getenv(env_var)
@@ -25,7 +28,7 @@ class Settings(BaseSettings):
         alias="MARKET_DATA_DATABASE_URL",
     )
     tradingview_hmac_secret: str = Field(
-        "demo-hmac-secret",
+        DEFAULT_TRADINGVIEW_HMAC_SECRET,
         alias="TRADINGVIEW_HMAC_SECRET",
     )
     binance_api_key: str | None = Field(None, alias="BINANCE_API_KEY")


### PR DESCRIPTION
## Summary
- add a shared constant for the TradingView HMAC secret default so the configuration matches the docker-compose fallback
- document the default secret in the sample `.env` file to prompt operators to change it in production

## Testing
- pytest services/market_data/tests -q *(fails: known test setup expectations for TopStep endpoints and SQLite schema during unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df6a58727c83328900436ee0017b6c