### PR TITLE
Migrate strategy identifiers to string identifiers

### DIFF
--- a/infra/migrations/versions/0a9b90ff8c8f_convert_strategy_ids_to_strings.py
+++ b/infra/migrations/versions/0a9b90ff8c8f_convert_strategy_ids_to_strings.py
@@ -1,0 +1,397 @@
+"""Convert strategy identifiers from integers to strings"""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+import sqlalchemy as sa
+from alembic import op
+
+from infra.strategy_models import (
+    StrategyBase,
+    Strategy,
+    StrategyBacktest,
+    StrategyExecution,
+    StrategyVersion,
+)
+
+revision = "0a9b90ff8c8f"
+down_revision = "1b70b7cb0c53"
+branch_labels = None
+depends_on = None
+
+
+STRATEGY_TABLE = "strategies"
+RELATED_TABLES: tuple[str, ...] = (
+    "strategy_versions",
+    "strategy_executions",
+    "strategy_backtests",
+)
+
+
+def _get_column_info(
+    bind: sa.engine.Connection, table: str, column: str
+) -> dict[str, object] | None:
+    inspector = sa.inspect(bind)
+    for info in inspector.get_columns(table):
+        if info["name"] == column:
+            return info
+    return None
+
+
+def _drop_strategy_foreign_keys(bind: sa.engine.Connection, table: str) -> None:
+    inspector = sa.inspect(bind)
+    for fk in inspector.get_foreign_keys(table):
+        if fk.get("name") and fk.get("referred_table") == STRATEGY_TABLE:
+            op.drop_constraint(fk["name"], table_name=table, type_="foreignkey")
+
+
+def _alter_to_string(
+    table: str,
+    column: str,
+    *,
+    nullable: bool,
+    dialect: str,
+    using: str | None = None,
+) -> None:
+    if dialect == "postgresql":
+        op.alter_column(
+            table,
+            column,
+            type_=sa.String(length=36),
+            existing_type=sa.Integer(),
+            existing_nullable=nullable,
+            server_default=None,
+            postgresql_using=using or f"{column}::text",
+        )
+    else:
+        with op.batch_alter_table(table, recreate="always") as batch_op:
+            batch_op.alter_column(
+                column,
+                type_=sa.String(length=36),
+                existing_type=sa.Integer(),
+                existing_nullable=nullable,
+                server_default=None,
+            )
+
+
+def _cast_column_textually(table: str, column: str) -> None:
+    op.execute(
+        sa.text(
+            f"UPDATE {table} "
+            f"SET {column} = CAST({column} AS TEXT) "
+            f"WHERE {column} IS NOT NULL"
+        )
+    )
+
+
+def _backfill_metadata(bind: sa.engine.Connection) -> None:
+    metadata = sa.MetaData()
+    strategies = sa.Table(STRATEGY_TABLE, metadata, autoload_with=bind)
+    session = sa.orm.Session(bind=bind)
+    try:
+        rows = session.execute(sa.select(strategies.c.id, strategies.c.metadata)).all()
+        for identifier, meta in rows:
+            value = meta
+            if isinstance(value, str):
+                try:
+                    value = json.loads(value)
+                except json.JSONDecodeError:
+                    value = {}
+            if not isinstance(value, dict):
+                value = {}
+            string_id = str(identifier) if identifier is not None else None
+            if not string_id:
+                continue
+            if value.get("strategy_id") != string_id:
+                value["strategy_id"] = string_id
+                session.execute(
+                    strategies.update()
+                    .where(strategies.c.id == identifier)
+                    .values({"metadata": value})
+                )
+        session.commit()
+    finally:
+        session.close()
+
+
+def _recreate_foreign_keys(table: str) -> None:
+    if table == "strategy_versions":
+        op.create_foreign_key(
+            "fk_strategy_versions_strategy",
+            source_table=table,
+            referent_table=STRATEGY_TABLE,
+            local_cols=["strategy_id"],
+            remote_cols=["id"],
+            ondelete="CASCADE",
+        )
+    elif table == "strategy_executions":
+        op.create_foreign_key(
+            "fk_strategy_executions_strategy",
+            source_table=table,
+            referent_table=STRATEGY_TABLE,
+            local_cols=["strategy_id"],
+            remote_cols=["id"],
+            ondelete="CASCADE",
+        )
+    elif table == "strategy_backtests":
+        op.create_foreign_key(
+            "fk_strategy_backtests_strategy",
+            source_table=table,
+            referent_table=STRATEGY_TABLE,
+            local_cols=["strategy_id"],
+            remote_cols=["id"],
+            ondelete="CASCADE",
+        )
+
+
+def _ensure_string_column(
+    bind: sa.engine.Connection,
+    dialect: str,
+    table: str,
+    column: str,
+) -> bool:
+    info = _get_column_info(bind, table, column)
+    if info is None:
+        return False
+    if isinstance(info["type"], sa.String):
+        return True
+    nullable = bool(info.get("nullable", True))
+    using_clause = f"{column}::text" if dialect == "postgresql" else None
+    _alter_to_string(table, column, nullable=nullable, dialect=dialect, using=using_clause)
+    if dialect != "postgresql":
+        _cast_column_textually(table, column)
+    return True
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind is None:
+        return
+    dialect = bind.dialect.name
+
+    inspector = sa.inspect(bind)
+    table_names = set(inspector.get_table_names())
+
+    if STRATEGY_TABLE not in table_names:
+        return
+
+    if dialect == "sqlite":
+        _upgrade_sqlite(bind, table_names)
+        _backfill_metadata(bind)
+        return
+
+    disable_fk = dialect == "sqlite"
+    if disable_fk:
+        op.execute(sa.text("PRAGMA foreign_keys=OFF"))
+
+    try:
+        # Drop foreign keys referencing strategies to allow column type changes
+        _drop_strategy_foreign_keys(bind, STRATEGY_TABLE)
+        for related in RELATED_TABLES:
+            if related in table_names:
+                _drop_strategy_foreign_keys(bind, related)
+
+        # Convert strategy identifiers and lineage references to strings
+        id_converted = _ensure_string_column(bind, dialect, STRATEGY_TABLE, "id")
+        has_derived_from = _ensure_string_column(bind, dialect, STRATEGY_TABLE, "derived_from")
+
+        # Convert foreign key columns in related tables
+        versions_has_fk = False
+        if "strategy_versions" in table_names:
+            versions_has_fk = _ensure_string_column(bind, dialect, "strategy_versions", "strategy_id")
+            _ensure_string_column(bind, dialect, "strategy_versions", "derived_from")
+
+        executions_has_fk = False
+        if "strategy_executions" in table_names:
+            executions_has_fk = _ensure_string_column(bind, dialect, "strategy_executions", "strategy_id")
+
+        backtests_has_fk = False
+        if "strategy_backtests" in table_names:
+            backtests_has_fk = _ensure_string_column(bind, dialect, "strategy_backtests", "strategy_id")
+
+        # Recreate foreign keys with the new type definitions
+        if has_derived_from:
+            op.create_foreign_key(
+                "fk_strategies_derived_from",
+                source_table=STRATEGY_TABLE,
+                referent_table=STRATEGY_TABLE,
+                local_cols=["derived_from"],
+                remote_cols=["id"],
+                ondelete="SET NULL",
+            )
+
+        if versions_has_fk:
+            _recreate_foreign_keys("strategy_versions")
+        if executions_has_fk:
+            _recreate_foreign_keys("strategy_executions")
+        if backtests_has_fk:
+            _recreate_foreign_keys("strategy_backtests")
+
+        # Backfill metadata so existing rows expose string identifiers
+        if id_converted:
+            _backfill_metadata(bind)
+    finally:
+        if disable_fk:
+            op.execute(sa.text("PRAGMA foreign_keys=ON"))
+
+
+def _upgrade_sqlite(bind: sa.engine.Connection, table_names: set[str]) -> None:
+    def _coerce_json(value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            try:
+                value = value.decode()
+            except Exception:
+                return None
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return None
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return value
+        return value
+
+    strategy_table = sa.Table(STRATEGY_TABLE, sa.MetaData(), autoload_with=bind)
+    strategy_rows = bind.execute(sa.select(strategy_table)).mappings().all()
+
+    def _clean_payload(payload: dict[str, object]) -> dict[str, object]:
+        return {key: value for key, value in payload.items() if value is not None}
+
+    version_rows = []
+    if "strategy_versions" in table_names:
+        versions = sa.Table("strategy_versions", sa.MetaData(), autoload_with=bind)
+        version_rows = bind.execute(sa.select(versions)).mappings().all()
+
+    execution_rows = []
+    if "strategy_executions" in table_names:
+        executions = sa.Table("strategy_executions", sa.MetaData(), autoload_with=bind)
+        execution_rows = bind.execute(sa.select(executions)).mappings().all()
+
+    backtest_rows = []
+    if "strategy_backtests" in table_names:
+        backtests = sa.Table("strategy_backtests", sa.MetaData(), autoload_with=bind)
+        backtest_rows = bind.execute(sa.select(backtests)).mappings().all()
+
+    json_columns: dict[str, tuple[str, ...]] = {
+        STRATEGY_TABLE: ("parameters", "tags", "metadata", "last_backtest"),
+        "strategy_versions": ("parameters", "tags", "metadata"),
+        "strategy_executions": ("payload",),
+        "strategy_backtests": ("equity_curve", "summary"),
+    }
+
+    op.execute(sa.text("PRAGMA foreign_keys=OFF"))
+    try:
+        StrategyBacktest.__table__.drop(bind=bind, checkfirst=True)
+        StrategyExecution.__table__.drop(bind=bind, checkfirst=True)
+        StrategyVersion.__table__.drop(bind=bind, checkfirst=True)
+        Strategy.__table__.drop(bind=bind, checkfirst=True)
+
+        Strategy.__table__.create(bind=bind)
+        StrategyVersion.__table__.create(bind=bind)
+        StrategyExecution.__table__.create(bind=bind)
+        StrategyBacktest.__table__.create(bind=bind)
+        try:
+            bind.commit()
+        except Exception:
+            pass
+        existing_tables = {
+            row[0]
+            for row in bind.execute(
+                sa.text("SELECT name FROM sqlite_master WHERE type='table'")
+            )
+        }
+        expected_tables = {
+            STRATEGY_TABLE,
+            "strategy_versions",
+            "strategy_executions",
+            "strategy_backtests",
+        }
+        missing_tables = expected_tables - existing_tables
+        if missing_tables:
+            raise RuntimeError(
+                f"Failed to recreate strategy tables: {', '.join(sorted(missing_tables))}"
+            )
+
+        strategy_payloads: list[dict[str, object]] = []
+        for row in strategy_rows:
+            payload = dict(row)
+            identifier = row.get("id")
+            if identifier is not None:
+                payload["id"] = str(identifier)
+            parent = row.get("derived_from")
+            if parent is not None:
+                payload["derived_from"] = str(parent)
+            for column in json_columns.get(STRATEGY_TABLE, ()):  # pragma: no branch
+                if column in payload:
+                    payload[column] = _coerce_json(payload[column])
+                    if (
+                        column == "metadata"
+                        and isinstance(payload[column], dict)
+                        and payload[column].get("strategy_id") is not None
+                    ):
+                        payload[column]["strategy_id"] = str(payload[column]["strategy_id"])
+            payload = _clean_payload(payload)
+            strategy_payloads.append(payload)
+            bind.execute(sa.insert(Strategy.__table__).values(**payload))
+
+        version_payloads: list[dict[str, object]] = []
+        for row in version_rows:
+            payload = dict(row)
+            identifier = row.get("strategy_id")
+            if identifier is not None:
+                payload["strategy_id"] = str(identifier)
+            parent = row.get("derived_from")
+            if parent is not None:
+                payload["derived_from"] = str(parent)
+            for column in json_columns.get("strategy_versions", ()):  # pragma: no branch
+                if column in payload:
+                    payload[column] = _coerce_json(payload[column])
+                    if (
+                        column == "metadata"
+                        and isinstance(payload[column], dict)
+                        and payload[column].get("strategy_id") is not None
+                    ):
+                        payload[column]["strategy_id"] = str(payload[column]["strategy_id"])
+            payload = _clean_payload(payload)
+            version_payloads.append(payload)
+            bind.execute(sa.insert(StrategyVersion.__table__).values(**payload))
+
+        execution_payloads: list[dict[str, object]] = []
+        for row in execution_rows:
+            payload = dict(row)
+            identifier = row.get("strategy_id")
+            if identifier is not None:
+                payload["strategy_id"] = str(identifier)
+            for column in json_columns.get("strategy_executions", ()):  # pragma: no branch
+                if column in payload:
+                    payload[column] = _coerce_json(payload[column])
+            payload = _clean_payload(payload)
+            execution_payloads.append(payload)
+            bind.execute(sa.insert(StrategyExecution.__table__).values(**payload))
+
+        backtest_payloads: list[dict[str, object]] = []
+        for row in backtest_rows:
+            payload = dict(row)
+            identifier = row.get("strategy_id")
+            if identifier is not None:
+                payload["strategy_id"] = str(identifier)
+            for column in json_columns.get("strategy_backtests", ()):  # pragma: no branch
+                if column in payload:
+                    payload[column] = _coerce_json(payload[column])
+            payload = _clean_payload(payload)
+            backtest_payloads.append(payload)
+            bind.execute(sa.insert(StrategyBacktest.__table__).values(**payload))
+        bind.commit()
+    finally:
+        op.execute(sa.text("PRAGMA foreign_keys=ON"))
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Downgrade not supported for identifier migration")

--- a/infra/migrations/versions/4d3f2c1f5b1a_retype_strategy_identifiers.py
+++ b/infra/migrations/versions/4d3f2c1f5b1a_retype_strategy_identifiers.py
@@ -1,0 +1,93 @@
+"""Ensure strategy identifiers use textual primary keys."""
+
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic import op
+
+base_migration = importlib.import_module(
+    "infra.migrations.versions.0a9b90ff8c8f_convert_strategy_ids_to_strings"
+)
+
+revision = "4d3f2c1f5b1a"
+down_revision = "0a9b90ff8c8f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind is None:
+        return
+
+    dialect = bind.dialect.name
+    inspector = sa.inspect(bind)
+    table_names = set(inspector.get_table_names())
+
+    if base_migration.STRATEGY_TABLE not in table_names:
+        return
+
+    if dialect == "sqlite":
+        base_migration._backfill_metadata(bind)
+        return
+
+    for table in (base_migration.STRATEGY_TABLE, *base_migration.RELATED_TABLES):
+        if table in table_names:
+            base_migration._drop_strategy_foreign_keys(bind, table)
+
+    id_converted = base_migration._ensure_string_column(
+        bind, dialect, base_migration.STRATEGY_TABLE, "id"
+    )
+    derived_converted = base_migration._ensure_string_column(
+        bind, dialect, base_migration.STRATEGY_TABLE, "derived_from"
+    )
+
+    versions_has_fk = False
+    if "strategy_versions" in table_names:
+        versions_has_fk = base_migration._ensure_string_column(
+            bind, dialect, "strategy_versions", "strategy_id"
+        )
+        base_migration._ensure_string_column(
+            bind, dialect, "strategy_versions", "derived_from"
+        )
+
+    executions_has_fk = False
+    if "strategy_executions" in table_names:
+        executions_has_fk = base_migration._ensure_string_column(
+            bind, dialect, "strategy_executions", "strategy_id"
+        )
+
+    backtests_has_fk = False
+    if "strategy_backtests" in table_names:
+        backtests_has_fk = base_migration._ensure_string_column(
+            bind, dialect, "strategy_backtests", "strategy_id"
+        )
+
+    if derived_converted:
+        op.create_foreign_key(
+            "fk_strategies_derived_from",
+            source_table=base_migration.STRATEGY_TABLE,
+            referent_table=base_migration.STRATEGY_TABLE,
+            local_cols=["derived_from"],
+            remote_cols=["id"],
+            ondelete="SET NULL",
+        )
+
+    if versions_has_fk:
+        base_migration._recreate_foreign_keys("strategy_versions")
+    if executions_has_fk:
+        base_migration._recreate_foreign_keys("strategy_executions")
+    if backtests_has_fk:
+        base_migration._recreate_foreign_keys("strategy_backtests")
+
+    if id_converted:
+        base_migration._backfill_metadata(bind)
+    else:
+        # Ensure metadata is backfilled even if conversion already occurred.
+        base_migration._backfill_metadata(bind)
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Downgrade not supported for identifier migration")

--- a/services/algo_engine/tests/test_execution_flow.py
+++ b/services/algo_engine/tests/test_execution_flow.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+import importlib
 from typing import Any, Dict, List
 from uuid import uuid4
 
 import httpx
 import pytest
+import sqlalchemy as sa
+from alembic import op as alembic_op
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from algo_engine.app.main import StrategyRecord, StrategyStatus, orchestrator, strategy_repository
 from algo_engine.app.orchestrator import Orchestrator
 from algo_engine.app.order_router_client import OrderRouterClientError
@@ -14,6 +19,7 @@ from algo_engine.app.repository import StrategyRepository
 from algo_engine.app.strategies.base import StrategyBase, StrategyConfig
 
 from libs.db.db import SessionLocal
+from sqlalchemy.orm import sessionmaker
 from schemas.market import ExecutionStatus, ExecutionVenue, OrderSide, OrderType
 
 
@@ -167,3 +173,207 @@ def test_strategy_execution_flow_updates_state_and_handles_errors(
     assert reports_idle == []
     assert strategy_repository.get(idle_id).status is StrategyStatus.PENDING
     assert orchestrator.get_state().trades_submitted == 0
+
+
+def test_strategy_repository_handles_legacy_integer_ids(tmp_path: Any) -> None:
+    """Migration converts legacy integer identifiers so repository initialises."""
+
+    legacy_db = tmp_path / "legacy_strategies.sqlite"
+    engine = sa.create_engine(f"sqlite:///{legacy_db}", isolation_level=None)
+
+    with engine.connect() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys=ON")
+        connection.execute(
+            sa.text(
+                """
+                CREATE TABLE strategies (
+                    id INTEGER PRIMARY KEY,
+                    name VARCHAR(255) NOT NULL,
+                    strategy_type VARCHAR(64) NOT NULL,
+                    version INTEGER NOT NULL DEFAULT 1,
+                    parameters TEXT NOT NULL,
+                    enabled BOOLEAN NOT NULL DEFAULT 0,
+                    tags TEXT NOT NULL,
+                    metadata TEXT,
+                    source_format VARCHAR(16),
+                    source TEXT,
+                    derived_from INTEGER REFERENCES strategies(id) ON DELETE SET NULL,
+                    status VARCHAR(16) NOT NULL DEFAULT 'PENDING',
+                    last_error TEXT,
+                    last_backtest TEXT,
+                    created_at DATETIME,
+                    updated_at DATETIME
+                )
+                """
+            )
+        )
+        connection.execute(sa.text("CREATE INDEX ix_strategies_enabled ON strategies(enabled)"))
+        connection.execute(sa.text("CREATE INDEX ix_strategies_status ON strategies(status)"))
+        connection.execute(sa.text("CREATE INDEX ix_strategies_strategy_type ON strategies(strategy_type)"))
+        connection.execute(
+            sa.text(
+                """
+                CREATE TABLE strategy_versions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    strategy_id INTEGER NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
+                    version INTEGER NOT NULL,
+                    name VARCHAR(255) NOT NULL,
+                    strategy_type VARCHAR(64) NOT NULL,
+                    parameters TEXT NOT NULL,
+                    metadata TEXT,
+                    tags TEXT NOT NULL,
+                    source_format VARCHAR(16),
+                    source TEXT,
+                    derived_from INTEGER,
+                    created_at DATETIME,
+                    created_by VARCHAR(128)
+                )
+                """
+            )
+        )
+        connection.execute(
+            sa.text(
+                "CREATE UNIQUE INDEX uq_strategy_versions_strategy_version "
+                "ON strategy_versions(strategy_id, version)"
+            )
+        )
+        connection.execute(
+            sa.text(
+                "CREATE INDEX ix_strategy_versions_strategy_id ON strategy_versions(strategy_id)"
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+                CREATE TABLE strategy_executions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    strategy_id INTEGER NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
+                    order_id VARCHAR(128) NOT NULL,
+                    status VARCHAR(32) NOT NULL,
+                    broker VARCHAR(64) NOT NULL,
+                    venue VARCHAR(64) NOT NULL,
+                    symbol VARCHAR(64) NOT NULL,
+                    side VARCHAR(16) NOT NULL,
+                    quantity FLOAT NOT NULL,
+                    filled_quantity FLOAT NOT NULL,
+                    avg_price FLOAT,
+                    submitted_at DATETIME NOT NULL,
+                    payload TEXT NOT NULL,
+                    created_at DATETIME
+                )
+                """
+            )
+        )
+        connection.execute(
+            sa.text(
+                "CREATE INDEX ix_strategy_executions_strategy_id ON "
+                "strategy_executions(strategy_id)"
+            )
+        )
+        connection.execute(
+            sa.text(
+                "CREATE INDEX ix_strategy_executions_strategy_submitted_at "
+                "ON strategy_executions(strategy_id, submitted_at)"
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+                CREATE TABLE strategy_backtests (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    strategy_id INTEGER NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
+                    ran_at DATETIME NOT NULL,
+                    initial_balance FLOAT NOT NULL,
+                    profit_loss FLOAT NOT NULL,
+                    total_return FLOAT NOT NULL,
+                    max_drawdown FLOAT NOT NULL,
+                    equity_curve TEXT,
+                    summary TEXT
+                )
+                """
+            )
+        )
+        connection.execute(
+            sa.text(
+                "CREATE INDEX ix_strategy_backtests_strategy_ran_at "
+                "ON strategy_backtests(strategy_id, ran_at)"
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO strategies (
+                    id, name, strategy_type, version, parameters, enabled, tags,
+                    metadata, source_format, source, derived_from, status,
+                    last_error, last_backtest, created_at, updated_at
+                ) VALUES
+                (1, 'Legacy One', 'static', 1, '{}', 1, '[]', '{"strategy_id": 1}',
+                 'python', 'code', NULL, 'PENDING', NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                (2, 'Legacy Two', 'static', 1, '{}', 1, '[]', '{"strategy_id": 2}',
+                 'python', 'code', 1, 'ACTIVE', NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO strategy_versions (
+                    strategy_id, version, name, strategy_type, parameters,
+                    metadata, tags, source_format, source, derived_from, created_at
+                ) VALUES
+                (1, 1, 'Legacy One', 'static', '{}', '{"strategy_id": 1}', '[]', 'python', 'code', NULL, CURRENT_TIMESTAMP),
+                (2, 1, 'Legacy Two', 'static', '{}', '{"strategy_id": 2}', '[]', 'python', 'code', 1, CURRENT_TIMESTAMP)
+                """
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO strategy_executions (
+                    strategy_id, order_id, status, broker, venue, symbol, side,
+                    quantity, filled_quantity, avg_price, submitted_at, payload, created_at
+                ) VALUES
+                (1, 'order-1', 'filled', 'paper', 'binance.spot', 'BTCUSDT', 'buy',
+                 1.0, 1.0, 25000.0, CURRENT_TIMESTAMP, '{"ok": true}', CURRENT_TIMESTAMP),
+                (2, 'order-2', 'filled', 'paper', 'binance.spot', 'BTCUSDT', 'buy',
+                 1.0, 1.0, 25000.0, CURRENT_TIMESTAMP, '{"ok": true}', CURRENT_TIMESTAMP)
+                """
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO strategy_backtests (
+                    strategy_id, ran_at, initial_balance, profit_loss, total_return,
+                    max_drawdown, equity_curve, summary
+                ) VALUES
+                (1, CURRENT_TIMESTAMP, 10000.0, 500.0, 0.05, 0.02, '[1,2,3]', '{"result": "ok"}'),
+                (2, CURRENT_TIMESTAMP, 10000.0, -100.0, -0.01, 0.03, '[1,2,3]', '{"result": "ok"}')
+                """
+            )
+        )
+
+        context = MigrationContext.configure(connection)
+        operations = Operations(context)
+        had_original_proxy = hasattr(alembic_op, "_proxy")
+        original_proxy = getattr(alembic_op, "_proxy", None)
+        alembic_op._proxy = operations  # type: ignore[attr-defined]
+        try:
+            for module_path in (
+                "infra.migrations.versions.0a9b90ff8c8f_convert_strategy_ids_to_strings",
+                "infra.migrations.versions.4d3f2c1f5b1a_retype_strategy_identifiers",
+            ):
+                migration = importlib.import_module(module_path)
+                migration.upgrade()
+        finally:
+            if had_original_proxy:
+                alembic_op._proxy = original_proxy  # type: ignore[attr-defined]
+            else:
+                delattr(alembic_op, "_proxy")
+
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    repository = StrategyRepository(session_factory)
+    records = sorted(repository.list(), key=lambda record: record.id)
+    assert [record.id for record in records] == ["1", "2"]
+    assert repository.get("2").derived_from == "1"
+    assert repository.get("1").metadata["strategy_id"] == "1"


### PR DESCRIPTION
## Summary
- refresh the strategy identifier migration to convert ids and foreign keys to strings across dialects while preserving metadata
- add a follow-up migration to enforce the string ids on non-SQLite databases and restore foreign key constraints
- extend the legacy identifier regression test to exercise both migrations and validate repository initialization

## Testing
- pytest services/algo_engine/tests/test_execution_flow.py::test_strategy_repository_handles_legacy_integer_ids -q

------
https://chatgpt.com/codex/tasks/task_e_68df63b158008332ae6b7ddf8c3f7d27