### PR TITLE
Add python-multipart dependency to web dashboard

### DIFF
--- a/requirements/services.txt
+++ b/requirements/services.txt
@@ -2,9 +2,9 @@
 # Each entry references the service-specific requirements file to ensure
 # GitHub workflows and local automation install a consistent set of
 # third-party packages before running tests.
+-r ../services/ai_strategy_assistant/requirements.txt
 -r ../services/alert_engine/requirements.txt
 -r ../services/algo_engine/requirements.txt
--r ../services/ai_strategy_assistant/requirements.txt
 -r ../services/auth_service/requirements.txt
 -r ../services/billing_service/requirements.txt
 -r ../services/codex_gateway/requirements.txt

--- a/services/web_dashboard/README.md
+++ b/services/web_dashboard/README.md
@@ -94,7 +94,7 @@ La section « Setups en temps réel » propose un sélecteur de session (`Tout
 
 Pour lancer le service hors Docker, installez les dépendances Python via
 `pip install -r services/web_dashboard/requirements.txt`. Cette liste inclut désormais
-`python-multipart` (>=0.0.6) afin de permettre à FastAPI de parser les formulaires et
+`python-multipart` (>=0.0.7) afin de permettre à FastAPI de parser les formulaires et
 fichiers envoyés par le designer de stratégies.
 
 ## Tests

--- a/services/web_dashboard/requirements.txt
+++ b/services/web_dashboard/requirements.txt
@@ -4,4 +4,4 @@ jinja2>=3.1
 httpx>=0.26
 markdown==3.5.2
 python-jose>=3.3
-python-multipart>=0.0.6
+python-multipart>=0.0.7


### PR DESCRIPTION
## Summary
- bump the web dashboard's python-multipart requirement to ensure form upload parsing works reliably
- regenerate the aggregated services requirements reference list
- update the web dashboard manual installation docs with the new dependency floor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df6a577d008332add38123858511cb