### PR TITLE
Fix market data composite primary keys

### DIFF
--- a/infra/migrations/versions/0002_market_data.py
+++ b/infra/migrations/versions/0002_market_data.py
@@ -4,6 +4,9 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
+OHLCV_PK_COLUMNS = ("exchange", "symbol", "interval", "timestamp")
+TICKS_PK_COLUMNS = ("exchange", "symbol", "source", "timestamp")
+
 revision = "0002_market_data"
 down_revision = "0001_init"
 branch_labels = None
@@ -27,9 +30,7 @@ def upgrade() -> None:
         sa.Column("quote_volume", sa.Float, nullable=True),
         sa.Column("trades", sa.Integer, nullable=True),
         sa.Column("extra", postgresql.JSONB, nullable=True),
-        sa.PrimaryKeyConstraint(
-            "exchange", "symbol", "interval", "timestamp", name="pk_market_data_ohlcv"
-        ),
+        sa.PrimaryKeyConstraint(*OHLCV_PK_COLUMNS, name="pk_market_data_ohlcv"),
     )
     op.execute(
         "SELECT create_hypertable('market_data_ohlcv', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"
@@ -45,9 +46,7 @@ def upgrade() -> None:
         sa.Column("size", sa.Float, nullable=True),
         sa.Column("side", sa.String(length=8), nullable=True),
         sa.Column("extra", postgresql.JSONB, nullable=True),
-        sa.PrimaryKeyConstraint(
-            "exchange", "symbol", "source", "timestamp", name="pk_market_data_ticks"
-        ),
+        sa.PrimaryKeyConstraint(*TICKS_PK_COLUMNS, name="pk_market_data_ticks"),
     )
     op.execute(
         "SELECT create_hypertable('market_data_ticks', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"

--- a/infra/migrations/versions/a1b8c9d0e1f2_market_data_composite_pk.py
+++ b/infra/migrations/versions/a1b8c9d0e1f2_market_data_composite_pk.py
@@ -10,32 +10,72 @@ depends_on = None
 
 
 def upgrade() -> None:
-    with op.batch_alter_table("market_data_ohlcv", schema=None) as batch_op:
-        batch_op.drop_constraint("uq_ohlcv_bar", type_="unique")
-        batch_op.drop_constraint("market_data_ohlcv_pkey", type_="primary")
-        batch_op.drop_column("id")
-        batch_op.create_primary_key(
-            "pk_market_data_ohlcv", ["exchange", "symbol", "interval", "timestamp"]
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    table_names = set(inspector.get_table_names())
+
+    if "market_data_ohlcv" in table_names:
+        ohlcv_columns = {col["name"] for col in inspector.get_columns("market_data_ohlcv")}
+        ohlcv_unique = {uc["name"] for uc in inspector.get_unique_constraints("market_data_ohlcv")}
+        ohlcv_pk = inspector.get_pk_constraint("market_data_ohlcv")
+
+        with op.batch_alter_table("market_data_ohlcv", schema=None) as batch_op:
+            if "uq_ohlcv_bar" in ohlcv_unique:
+                batch_op.drop_constraint("uq_ohlcv_bar", type_="unique")
+
+            needs_primary_key = False
+            if ohlcv_pk and ohlcv_pk.get("name") == "market_data_ohlcv_pkey":
+                batch_op.drop_constraint("market_data_ohlcv_pkey", type_="primary")
+                needs_primary_key = True
+
+            if "id" in ohlcv_columns:
+                batch_op.drop_column("id")
+                needs_primary_key = True
+
+            if needs_primary_key:
+                batch_op.create_primary_key(
+                    "pk_market_data_ohlcv",
+                    ["exchange", "symbol", "interval", "timestamp"],
+                )
+
+        op.execute("DROP SEQUENCE IF EXISTS market_data_ohlcv_id_seq")
+
+    if "market_data_ticks" in table_names:
+        ticks_columns = {col["name"] for col in inspector.get_columns("market_data_ticks")}
+        ticks_unique = {uc["name"] for uc in inspector.get_unique_constraints("market_data_ticks")}
+        ticks_pk = inspector.get_pk_constraint("market_data_ticks")
+
+        with op.batch_alter_table("market_data_ticks", schema=None) as batch_op:
+            if "uq_tick" in ticks_unique:
+                batch_op.drop_constraint("uq_tick", type_="unique")
+
+            needs_primary_key = False
+            if ticks_pk and ticks_pk.get("name") == "market_data_ticks_pkey":
+                batch_op.drop_constraint("market_data_ticks_pkey", type_="primary")
+                needs_primary_key = True
+
+            if "id" in ticks_columns:
+                batch_op.drop_column("id")
+                needs_primary_key = True
+
+            if needs_primary_key:
+                batch_op.create_primary_key(
+                    "pk_market_data_ticks",
+                    ["exchange", "symbol", "source", "timestamp"],
+                )
+
+        op.execute("DROP SEQUENCE IF EXISTS market_data_ticks_id_seq")
+
+    if "market_data_ohlcv" in table_names:
+        op.execute(
+            "SELECT create_hypertable('market_data_ohlcv', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"
         )
 
-    op.execute("DROP SEQUENCE IF EXISTS market_data_ohlcv_id_seq")
-
-    with op.batch_alter_table("market_data_ticks", schema=None) as batch_op:
-        batch_op.drop_constraint("uq_tick", type_="unique")
-        batch_op.drop_constraint("market_data_ticks_pkey", type_="primary")
-        batch_op.drop_column("id")
-        batch_op.create_primary_key(
-            "pk_market_data_ticks", ["exchange", "symbol", "source", "timestamp"]
+    if "market_data_ticks" in table_names:
+        op.execute(
+            "SELECT create_hypertable('market_data_ticks', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"
         )
-
-    op.execute("DROP SEQUENCE IF EXISTS market_data_ticks_id_seq")
-
-    op.execute(
-        "SELECT create_hypertable('market_data_ohlcv', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"
-    )
-    op.execute(
-        "SELECT create_hypertable('market_data_ticks', 'timestamp', if_not_exists => TRUE, migrate_data => TRUE);"
-    )
 
 
 def downgrade() -> None:

--- a/services/market_data/app/tables.py
+++ b/services/market_data/app/tables.py
@@ -1,25 +1,19 @@
 from __future__ import annotations
 
-from sqlalchemy import (
-    Column,
-    DateTime,
-    Float,
-    Integer,
-    PrimaryKeyConstraint,
-    String,
-)
+from sqlalchemy import Column, DateTime, Float, Integer, PrimaryKeyConstraint, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 
+OHLCV_PK_COLUMNS = ("exchange", "symbol", "interval", "timestamp")
+TICKS_PK_COLUMNS = ("exchange", "symbol", "source", "timestamp")
+
 
 class MarketDataOHLCV(Base):
     __tablename__ = "market_data_ohlcv"
     __table_args__ = (
-        PrimaryKeyConstraint(
-            "exchange", "symbol", "interval", "timestamp", name="pk_market_data_ohlcv"
-        ),
+        PrimaryKeyConstraint(*OHLCV_PK_COLUMNS, name="pk_market_data_ohlcv"),
     )
 
     exchange = Column(String(32), nullable=False, primary_key=True)
@@ -39,9 +33,7 @@ class MarketDataOHLCV(Base):
 class MarketDataTick(Base):
     __tablename__ = "market_data_ticks"
     __table_args__ = (
-        PrimaryKeyConstraint(
-            "exchange", "symbol", "source", "timestamp", name="pk_market_data_ticks"
-        ),
+        PrimaryKeyConstraint(*TICKS_PK_COLUMNS, name="pk_market_data_ticks"),
     )
 
     exchange = Column(String(32), nullable=False, primary_key=True)


### PR DESCRIPTION
## Summary
- share named composite primary key definitions for market data tables across the base migration and ORM models
- harden the follow-up migration so it conditionally removes legacy id columns before recreating the hypertables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df6a4f546083328d973d2d33a3f6a4