### PR TITLE
Add account page form coverage and E2E login test

### DIFF
--- a/.github/workflows/metrics-dashboard.yml
+++ b/.github/workflows/metrics-dashboard.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements/services-dev.txt
 
       - name: Install Playwright browsers
-        run: python -m playwright install --with-deps chromium
+        run: python -m playwright install --with-deps chromium firefox
 
       - name: Run unit tests with coverage
         id: unit-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           pip install -r requirements/services.txt
           pip install -r requirements/services-dev.txt
       - name: Install Playwright browsers
-        run: python -m playwright install --with-deps chromium
+        run: python -m playwright install --with-deps chromium firefox
       - name: Run Alembic migration test
         run: python -m pytest -m slow -k migrations
       - name: Run test suite

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ e2e-sh:
 	bash ./scripts/e2e/auth_e2e.sh
 
 web_dashboard-e2e:
-	python -m pytest services/web_dashboard/tests/e2e
+        python -m playwright install --with-deps chromium firefox
+        python -m pytest services/web_dashboard/tests/e2e
 
 migrate-generate:
 	@if [ -z "$(message)" ]; then \

--- a/services/web_dashboard/app/locales/en.json
+++ b/services/web_dashboard/app/locales/en.json
@@ -125,5 +125,21 @@
   "{rating} / 5": "{rating} / 5",
   "{value} / 5": "{value} / 5",
   "Aucun avis pour le moment.": "No reviews yet.",
-  "Aucune stratégie ne correspond à vos filtres.": "No strategies match your filters."
+  "Aucune stratégie ne correspond à vos filtres.": "No strategies match your filters.",
+  "Activez JavaScript pour gérer votre session.": "Enable JavaScript to manage your session.",
+  "Connexion": "Sign in",
+  "Authentifiez-vous pour débloquer les fonctions de sauvegarde et d'orchestration.": "Sign in to unlock orchestration and persistence features.",
+  "Adresse e-mail": "Email address",
+  "Mot de passe": "Password",
+  "Se connecter": "Log in",
+  "Clés API exchanges": "Exchange API keys",
+  "Stockez vos identifiants chiffrés. Ils seront synchronisés avec l'orchestrateur lors des déploiements.": "Store your credentials securely. They will sync with the orchestrator during deployments.",
+  "Sélectionnez un exchange": "Select an exchange",
+  "Exchange": "Exchange",
+  "Binance": "Binance",
+  "Coinbase Pro": "Coinbase Pro",
+  "Kraken": "Kraken",
+  "Clé publique": "Public key",
+  "Clé secrète": "Secret key",
+  "Associer la clé": "Link API key"
 }

--- a/services/web_dashboard/app/locales/fr.json
+++ b/services/web_dashboard/app/locales/fr.json
@@ -125,5 +125,21 @@
   "{rating} / 5": "{rating} / 5",
   "{value} / 5": "{value} / 5",
   "Aucun avis pour le moment.": "Aucun avis pour le moment.",
-  "Aucune stratégie ne correspond à vos filtres.": "Aucune stratégie ne correspond à vos filtres."
+  "Aucune stratégie ne correspond à vos filtres.": "Aucune stratégie ne correspond à vos filtres.",
+  "Activez JavaScript pour gérer votre session.": "Activez JavaScript pour gérer votre session.",
+  "Connexion": "Connexion",
+  "Authentifiez-vous pour débloquer les fonctions de sauvegarde et d'orchestration.": "Authentifiez-vous pour débloquer les fonctions de sauvegarde et d'orchestration.",
+  "Adresse e-mail": "Adresse e-mail",
+  "Mot de passe": "Mot de passe",
+  "Se connecter": "Se connecter",
+  "Clés API exchanges": "Clés API exchanges",
+  "Stockez vos identifiants chiffrés. Ils seront synchronisés avec l'orchestrateur lors des déploiements.": "Stockez vos identifiants chiffrés. Ils seront synchronisés avec l'orchestrateur lors des déploiements.",
+  "Sélectionnez un exchange": "Sélectionnez un exchange",
+  "Exchange": "Exchange",
+  "Binance": "Binance",
+  "Coinbase Pro": "Coinbase Pro",
+  "Kraken": "Kraken",
+  "Clé publique": "Clé publique",
+  "Clé secrète": "Clé secrète",
+  "Associer la clé": "Associer la clé"
 }

--- a/services/web_dashboard/app/templates/account.html
+++ b/services/web_dashboard/app/templates/account.html
@@ -21,7 +21,62 @@
         data-login-endpoint="{{ request.url_for('account_login') }}"
         data-logout-endpoint="{{ request.url_for('account_logout') }}"
       >
-        <p class="text text--muted">{{ _('Activez JavaScript pour gérer votre session.') }}</p>
+        <div class="account-fallback" aria-live="polite">
+          <p class="text text--muted">{{ _('Activez JavaScript pour gérer votre session.') }}</p>
+
+          <section class="card" aria-labelledby="login-title-fallback">
+            <div class="card__header">
+              <h2 id="login-title-fallback" class="heading heading--lg">{{ _('Connexion') }}</h2>
+              <p class="text text--muted">
+                {{ _("Authentifiez-vous pour débloquer les fonctions de sauvegarde et d'orchestration.") }}
+              </p>
+            </div>
+            <div class="card__body">
+              <form class="form-grid" action="{{ request.url_for('account_login') }}" method="post">
+                <label class="designer-field">
+                  <span class="designer-field__label text text--muted">{{ _('Adresse e-mail') }}</span>
+                  <input type="email" name="email" autocomplete="email" required />
+                </label>
+                <label class="designer-field">
+                  <span class="designer-field__label text text--muted">{{ _('Mot de passe') }}</span>
+                  <input type="password" name="password" autocomplete="current-password" required />
+                </label>
+                <button type="submit" class="button button--primary">{{ _('Se connecter') }}</button>
+              </form>
+            </div>
+          </section>
+
+          <section class="card" aria-labelledby="api-keys-title-fallback">
+            <div class="card__header">
+              <h2 id="api-keys-title-fallback" class="heading heading--lg">{{ _('Clés API exchanges') }}</h2>
+              <p class="text text--muted">
+                {{ _("Stockez vos identifiants chiffrés. Ils seront synchronisés avec l'orchestrateur lors des déploiements.") }}
+              </p>
+            </div>
+            <div class="card__body">
+              <form class="form-grid" action="#" method="post">
+                <label class="designer-field">
+                  <span class="designer-field__label text text--muted">{{ _('Sélectionnez un exchange') }}</span>
+                  <select name="exchange" required>
+                    <option value="" disabled selected>{{ _('Exchange') }}</option>
+                    <option value="binance">{{ _('Binance') }}</option>
+                    <option value="coinbase">{{ _('Coinbase Pro') }}</option>
+                    <option value="kraken">{{ _('Kraken') }}</option>
+                  </select>
+                </label>
+                <label class="designer-field">
+                  <span class="designer-field__label text text--muted">{{ _('Clé publique') }}</span>
+                  <input type="text" name="public" autocomplete="off" required />
+                </label>
+                <label class="designer-field">
+                  <span class="designer-field__label text text--muted">{{ _('Clé secrète') }}</span>
+                  <input type="password" name="secret" autocomplete="off" required />
+                </label>
+                <button type="submit" class="button button--secondary">{{ _('Associer la clé') }}</button>
+              </form>
+            </div>
+          </section>
+        </div>
       </div>
     </main>
     <footer class="layout__footer">

--- a/services/web_dashboard/tests/e2e/test_account_page.py
+++ b/services/web_dashboard/tests/e2e/test_account_page.py
@@ -1,46 +1,101 @@
 """End-to-end tests covering the account page user interactions."""
 
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
 import pytest
 
 pytestmark = pytest.mark.asyncio
 
 playwright_async = pytest.importorskip("playwright.async_api")
-Page = playwright_async.Page
 expect = playwright_async.expect
 
 BROWSER_PROJECTS = [
-    pytest.param("chromium", id="chromium"),
-    pytest.param("firefox", id="firefox"),
+    pytest.param("chromium", {"width": 1440, "height": 900}, id="chromium-desktop"),
+    pytest.param("firefox", {"width": 1280, "height": 800}, id="firefox-desktop"),
 ]
 
+ANONYMOUS_SESSION: Dict[str, Any] = {"authenticated": False, "user": None}
+LOGIN_RESPONSE: Dict[str, Any] = {
+    "authenticated": True,
+    "user": {
+        "id": "42",
+        "email": "trader@example.com",
+        "scopes": ["dashboard:read"],
+    },
+}
 
-@pytest.mark.parametrize("browser_name", BROWSER_PROJECTS)
+
+@pytest.mark.parametrize("project_name,viewport", BROWSER_PROJECTS)
 async def test_account_login_form_validation(
-    page: Page, browser_name: str, dashboard_base_url: str
+    project_name: str, viewport: Dict[str, int], dashboard_base_url: str
 ):
-    """The login form should surface HTML validation feedback before accepting inputs."""
+    """The login form should display validation feedback and accept valid credentials."""
 
-    await page.goto(f"{dashboard_base_url}/account", wait_until="networkidle")
+    async with playwright_async.async_playwright() as playwright:
+        browser_type = getattr(playwright, project_name)
+        browser = await browser_type.launch()
+        context = await browser.new_context(locale="fr-FR", viewport=viewport)
 
-    await expect(page.get_by_role("heading", level=2, name="Connexion")).to_be_visible()
+        async def _mock_session(route, request):
+            if request.method == "GET":
+                await route.fulfill(
+                    status=200,
+                    headers={"content-type": "application/json"},
+                    body=json.dumps(ANONYMOUS_SESSION),
+                )
+            else:  # pragma: no cover - other verbs are unused but forwarded
+                await route.continue_()
 
-    email_input = page.get_by_label("Adresse e-mail")
-    password_input = page.get_by_label("Mot de passe")
-    submit_button = page.get_by_role("button", name="Se connecter")
+        async def _mock_login(route, request):
+            if request.method == "POST":
+                await route.fulfill(
+                    status=200,
+                    headers={"content-type": "application/json"},
+                    body=json.dumps(LOGIN_RESPONSE),
+                )
+            else:  # pragma: no cover - safeguard for unexpected verbs
+                await route.continue_()
 
-    assert await email_input.evaluate("el.required")
-    assert await password_input.evaluate("el.required")
+        await context.route("**/account/session", _mock_session)
+        await context.route("**/account/login", _mock_login)
 
-    await email_input.fill("")
-    await password_input.fill("")
-    await submit_button.click()
+        page = await context.new_page()
 
-    assert await email_input.evaluate("el.validity.valueMissing")
-    assert await password_input.evaluate("el.validity.valueMissing")
-    await expect(email_input).to_be_focused()
+        try:
+            await page.goto(f"{dashboard_base_url}/account", wait_until="networkidle")
 
-    await email_input.fill("trader@example.com")
-    await password_input.fill("Sup3rSecret!")
+            await expect(page.get_by_role("heading", level=2, name="Connexion")).to_be_visible()
 
-    assert await email_input.evaluate("el.checkValidity()")
-    assert await password_input.evaluate("el.checkValidity()")
+            email_input = page.get_by_label("Adresse e-mail")
+            password_input = page.get_by_label("Mot de passe")
+            submit_button = page.get_by_role("button", name="Se connecter")
+
+            assert await email_input.evaluate("element => element.required")
+            assert await password_input.evaluate("element => element.required")
+
+            await email_input.fill("")
+            await password_input.fill("")
+            await submit_button.click()
+
+            assert await email_input.evaluate("element => element.validity.valueMissing")
+            assert await password_input.evaluate("element => element.validity.valueMissing")
+            await expect(email_input).to_be_focused()
+
+            await email_input.fill("trader@example.com")
+            await password_input.fill("Sup3rSecret!")
+
+            assert await email_input.evaluate("element => element.checkValidity()")
+            assert await password_input.evaluate("element => element.checkValidity()")
+
+            async with page.expect_response("**/account/login") as login_response:
+                await submit_button.click()
+            response = await login_response.value
+            assert response.ok
+
+            await expect(page.get_by_role("status")).to_contain_text("trader@example.com")
+        finally:
+            await context.close()
+            await browser.close()

--- a/services/web_dashboard/tests/test_account_page.py
+++ b/services/web_dashboard/tests/test_account_page.py
@@ -20,11 +20,14 @@ def test_account_page_exposes_login_and_api_forms():
 
     # The template should expose the correct lang attribute and login form inputs.
     assert "<html lang=\"fr\"" in html
-    assert '<form class="form-grid" action="#" method="post">' in html
+    login_url = f"{client.base_url}/account/login"
+    assert f'data-login-endpoint="{login_url}"' in html
+    assert f'<form class="form-grid" action="{login_url}" method="post">' in html
     assert '<input type="email" name="email" autocomplete="email" required />' in html
     assert '<input type="password" name="password" autocomplete="current-password" required />' in html
 
     # The API key management form and its inputs must also be present.
-    assert '<select name="exchange">' in html
+    assert '<form class="form-grid" action="#" method="post">' in html
+    assert '<select name="exchange" required>' in html
     assert '<input type="text" name="public" autocomplete="off" required />' in html
     assert '<input type="password" name="secret" autocomplete="off" required />' in html


### PR DESCRIPTION
## Summary
- render fallback login and API key forms in the account template with localized labels for server-side checks
- add a FastAPI TestClient test that validates the /account response status, language headers, and rendered form fields
- cover the /account login flow with a multi-browser Playwright test while updating the Makefile and CI workflows to install Chromium and Firefox

## Testing
- pytest services/web_dashboard/tests/test_account_page.py -q
- pytest services/web_dashboard/tests/e2e/test_account_page.py -q

------
https://chatgpt.com/codex/tasks/task_e_68df6a751fc8833295eb8e9ea7e4a0d1