### PR TITLE
Implement DTC adapter handshake and tests

### DIFF
--- a/services/market_data/adapters/dtc.py
+++ b/services/market_data/adapters/dtc.py
@@ -1,55 +1,269 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import enum
 import logging
+import struct
 from dataclasses import dataclass
-from typing import Any, Iterable
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+class DTCMessageType(enum.IntEnum):
+    """Subset of message identifiers from the DTC specification."""
+
+    LOGON_REQUEST = 1
+    LOGON_RESPONSE = 2
+    HEARTBEAT = 3
+    LOGOFF = 5
+    MARKET_DATA_SUBSCRIBE = 101
+    MARKET_DATA_UNSUBSCRIBE = 102
+    MARKET_DATA_UPDATE_TRADE = 103
+
+
+@dataclass(slots=True)
 class DTCConfig:
     host: str
     port: int
     client_user_id: str = ""
+    client_password: str = ""
+    client_name: str = "market-data-service"
+    protocol_version: int = 8
+    heartbeat_interval: int = 15
+    default_exchange: str = ""
+
+
+@dataclass(slots=True)
+class _SymbolSubscription:
+    symbol_id: int
+    active: bool = False
 
 
 class DTCAdapter:
     """Stub adapter for the Sierra Chart Data and Trading Communications protocol."""
 
+    _SEND_TIMEOUT = 2.0
+
     def __init__(self, config: DTCConfig) -> None:
         self._config = config
-        self._lock = asyncio.Lock()
+        self._connection_lock = asyncio.Lock()
+        self._io_lock = asyncio.Lock()
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
         self._connected = False
+        self._next_symbol_id = 1
+        self._subscriptions: dict[str, _SymbolSubscription] = {}
 
     async def connect(self) -> None:
-        async with self._lock:
-            if self._connected:
-                return
-            logger.info(
-                "Establishing DTC connection to %s:%s for %s",
-                self._config.host,
-                self._config.port,
-                self._config.client_user_id or "anonymous",
-            )
-            # Real implementation would negotiate the binary protocol handshake here.
-            await asyncio.sleep(0)
-            self._connected = True
+        await self._ensure_connection(force=True)
 
     async def publish_ticks(self, ticks: Iterable[Any]) -> None:
-        if not self._connected:
-            raise RuntimeError("DTC connection has not been established")
-        # Placeholder for encoding and sending messages to Sierra Chart.
-        batch = tuple(ticks)
+        batch: list[Any] = list(ticks)
         if not batch:
             return
-        logger.debug("Publishing %s ticks to DTC", len(batch))
+        await self._ensure_connection()
+        for tick in batch:
+            payload = await self._encode_trade_update(tick)
+            await self._send_message(DTCMessageType.MARKET_DATA_UPDATE_TRADE, payload)
 
     async def close(self) -> None:
-        async with self._lock:
+        async with self._connection_lock:
             if not self._connected:
                 return
-            logger.info("Closing DTC connection")
-            await asyncio.sleep(0)
+            try:
+                await self._send_message(DTCMessageType.LOGOFF, b"", ensure_connected=False)
+            except Exception:  # noqa: BLE001 - ensure closure even on framing issues
+                logger.debug("Failed to send DTC logoff", exc_info=True)
+            if self._writer is not None:
+                self._writer.close()
+                with contextlib.suppress(Exception):
+                    await self._writer.wait_closed()
+            self._reader = None
+            self._writer = None
             self._connected = False
+            for subscription in self._subscriptions.values():
+                subscription.active = False
+
+    async def subscribe(self, symbol: str) -> int:
+        subscription = self._subscriptions.get(symbol)
+        if subscription is None:
+            subscription = _SymbolSubscription(symbol_id=self._next_symbol_id)
+            self._next_symbol_id += 1
+            self._subscriptions[symbol] = subscription
+        if subscription.active:
+            return subscription.symbol_id
+
+        payload = self._encode_subscription(symbol, subscription.symbol_id)
+        await self._send_message(DTCMessageType.MARKET_DATA_SUBSCRIBE, payload)
+        subscription.active = True
+        return subscription.symbol_id
+
+    async def _encode_trade_update(self, tick: Any) -> bytes:
+        data: Mapping[str, Any]
+        if isinstance(tick, Mapping):
+            data = tick
+        else:
+            data = getattr(tick, "__dict__", {})
+        symbol = str(data.get("symbol", ""))
+        if not symbol:
+            raise ValueError("Tick payload must include a symbol")
+        price_value = data.get("price")
+        price = float(price_value) if price_value is not None else 0.0
+        size_value = data.get("size")
+        size = float(size_value) if size_value is not None else 0.0
+        timestamp = data.get("timestamp")
+        if isinstance(timestamp, datetime):
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
+            timestamp = timestamp.astimezone(timezone.utc)
+            epoch = int(timestamp.timestamp() * 1_000_000)
+        elif timestamp is None:
+            epoch = int(datetime.now(timezone.utc).timestamp() * 1_000_000)
+        else:
+            epoch = int(timestamp)
+
+        symbol_id = await self.subscribe(symbol)
+        return struct.pack("<IddQ", symbol_id, price, size, epoch)
+
+    def _encode_subscription(self, symbol: str, symbol_id: int) -> bytes:
+        exchange = self._config.default_exchange
+        return (
+            struct.pack("<II", symbol_id, symbol_id)
+            + self._encode_string(symbol, 64)
+            + self._encode_string(exchange, 32)
+        )
+
+    async def _ensure_connection(self, *, force: bool = False) -> None:
+        if self._connected and not force and self._writer and not self._writer.is_closing():
+            return
+        async with self._connection_lock:
+            if self._connected and not force and self._writer and not self._writer.is_closing():
+                return
+            await self._open_connection()
+
+    async def _open_connection(self) -> None:
+        logger.info(
+            "Establishing DTC connection to %s:%s for %s",
+            self._config.host,
+            self._config.port,
+            self._config.client_user_id or "anonymous",
+        )
+        self._reader, self._writer = await asyncio.open_connection(
+            self._config.host, self._config.port
+        )
+        await self._perform_logon()
+        self._connected = True
+        for subscription in self._subscriptions.values():
+            subscription.active = False
+        await self._resubscribe()
+
+    async def _perform_logon(self) -> None:
+        payload = self._encode_logon_request()
+        await self._send_message(DTCMessageType.LOGON_REQUEST, payload, ensure_connected=False)
+        response_type, response_payload = await self._read_message()
+        if response_type != DTCMessageType.LOGON_RESPONSE:
+            raise ConnectionError(f"Unexpected DTC message {response_type} during logon")
+        result_code, message = self._decode_logon_response(response_payload)
+        if result_code != 1:
+            raise PermissionError(f"DTC logon rejected: {message or 'unknown error'}")
+
+    async def _resubscribe(self) -> None:
+        if not self._subscriptions:
+            return
+        for symbol, subscription in self._subscriptions.items():
+            payload = self._encode_subscription(symbol, subscription.symbol_id)
+            await self._send_message(DTCMessageType.MARKET_DATA_SUBSCRIBE, payload, retry=False)
+            subscription.active = True
+
+    async def _send_message(
+        self,
+        message_type: DTCMessageType,
+        payload: bytes,
+        *,
+        ensure_connected: bool = True,
+        retry: bool = True,
+    ) -> None:
+        if ensure_connected:
+            await self._ensure_connection()
+        writer = self._writer
+        if writer is None:
+            raise ConnectionError("DTC connection is not available")
+        message = self._frame_message(message_type, payload)
+        caught_exc: Exception | None = None
+        async with self._io_lock:
+            try:
+                writer.write(message)
+                await asyncio.wait_for(writer.drain(), timeout=self._SEND_TIMEOUT)
+            except (
+                ConnectionError,
+                asyncio.IncompleteReadError,
+                BrokenPipeError,
+                asyncio.TimeoutError,
+            ) as exc:
+                logger.warning("DTC send failed: %s", exc)
+                caught_exc = exc
+        if caught_exc is not None:
+            await self._handle_disconnect()
+            if retry:
+                await self._ensure_connection(force=True)
+                await self._send_message(
+                    message_type,
+                    payload,
+                    ensure_connected=False,
+                    retry=False,
+                )
+            else:
+                raise caught_exc
+
+    async def _handle_disconnect(self) -> None:
+        self._connected = False
+        if self._writer is not None:
+            self._writer.close()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(self._writer.wait_closed(), timeout=self._SEND_TIMEOUT)
+        self._reader = None
+        self._writer = None
+        for subscription in self._subscriptions.values():
+            subscription.active = False
+
+    async def _read_message(self) -> tuple[DTCMessageType, bytes]:
+        reader = self._reader
+        if reader is None:
+            raise ConnectionError("DTC connection is not available")
+        header = await reader.readexactly(4)
+        size, message_type = struct.unpack("<HH", header)
+        if size < 4:
+            raise ConnectionError("Invalid DTC message size")
+        payload = await reader.readexactly(size - 4)
+        return DTCMessageType(message_type), payload
+
+    def _encode_logon_request(self) -> bytes:
+        return (
+            struct.pack("<I", self._config.protocol_version)
+            + self._encode_string(self._config.client_user_id, 32)
+            + self._encode_string(self._config.client_password, 32)
+            + struct.pack("<H", self._config.heartbeat_interval)
+            + self._encode_string(self._config.client_name, 32)
+        )
+
+    @staticmethod
+    def _encode_string(value: str, length: int) -> bytes:
+        data = value.encode("utf-8")[: length - 1] if length > 0 else b""
+        return data + b"\x00" * (length - len(data))
+
+    @staticmethod
+    def _frame_message(message_type: DTCMessageType, payload: bytes) -> bytes:
+        size = 4 + len(payload)
+        return struct.pack("<HH", size, int(message_type)) + payload
+
+    @staticmethod
+    def _decode_logon_response(payload: bytes) -> tuple[int, str]:
+        if len(payload) < 2:
+            return 0, ""
+        result_code = struct.unpack_from("<H", payload, 0)[0]
+        text = payload[2:]
+        text = text.split(b"\x00", 1)[0].decode("utf-8", errors="ignore")
+        return result_code, text

--- a/services/market_data/app/config.py
+++ b/services/market_data/app/config.py
@@ -33,6 +33,13 @@ class Settings(BaseSettings):
     ibkr_host: str = Field("127.0.0.1", alias="IBKR_HOST")
     ibkr_port: int = Field(4001, alias="IBKR_PORT")
     ibkr_client_id: int = Field(1, alias="IBKR_CLIENT_ID")
+    dtc_host: str | None = Field(None, alias="DTC_HOST")
+    dtc_port: int | None = Field(None, alias="DTC_PORT")
+    dtc_user: str | None = Field(None, alias="DTC_USER")
+    dtc_password: str | None = Field(None, alias="DTC_PASSWORD")
+    dtc_client_name: str = Field("market-data-service", alias="DTC_CLIENT_NAME")
+    dtc_default_exchange: str = Field("", alias="DTC_DEFAULT_EXCHANGE")
+    dtc_heartbeat_interval: int = Field(15, alias="DTC_HEARTBEAT_INTERVAL")
     topstep_base_url: str = Field("https://api.topstep.com", alias="TOPSTEP_BASE_URL")
     topstep_client_id: str | None = Field(None, alias="TOPSTEP_CLIENT_ID")
     topstep_client_secret: str | None = Field(None, alias="TOPSTEP_CLIENT_SECRET")
@@ -47,6 +54,8 @@ _SECRET_KEYS = [
     "TRADINGVIEW_HMAC_SECRET",
     "BINANCE_API_KEY",
     "BINANCE_API_SECRET",
+    "DTC_USER",
+    "DTC_PASSWORD",
     "TOPSTEP_CLIENT_ID",
     "TOPSTEP_CLIENT_SECRET",
 ]

--- a/services/market_data/app/main.py
+++ b/services/market_data/app/main.py
@@ -6,7 +6,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from hashlib import sha256
-from typing import Any, AsyncIterator, Awaitable, Callable, TypeVar
+from typing import Any, AsyncIterator, Awaitable, Callable, Iterable, TypeVar
 
 from fastapi import (
     BackgroundTasks,
@@ -29,7 +29,13 @@ from schemas.market import ExecutionVenue
 
 import httpx
 
-from ..adapters import BinanceMarketConnector, IBKRMarketConnector, TopStepAdapter
+from ..adapters import (
+    BinanceMarketConnector,
+    DTCAdapter,
+    DTCConfig,
+    IBKRMarketConnector,
+    TopStepAdapter,
+)
 from .config import Settings, get_settings
 from .database import session_scope
 from .persistence import persist_ticks
@@ -52,6 +58,10 @@ app.add_middleware(RequestContextMiddleware, service_name="market-data")
 setup_metrics(app, service_name="market-data")
 
 
+_dtc_adapter: DTCAdapter | None = None
+_dtc_adapter_lock = asyncio.Lock()
+
+
 def get_binance_adapter(settings: Settings = Depends(get_settings)) -> BinanceMarketConnector:
     return BinanceMarketConnector(
         api_key=settings.binance_api_key,
@@ -65,6 +75,27 @@ def get_ibkr_adapter(settings: Settings = Depends(get_settings)) -> IBKRMarketCo
         port=settings.ibkr_port,
         client_id=settings.ibkr_client_id,
     )
+
+
+async def get_dtc_adapter(settings: Settings = Depends(get_settings)) -> DTCAdapter | None:
+    if not settings.dtc_host or not settings.dtc_port:
+        return None
+
+    global _dtc_adapter
+    if _dtc_adapter is None:
+        async with _dtc_adapter_lock:
+            if _dtc_adapter is None:
+                config = DTCConfig(
+                    host=settings.dtc_host,
+                    port=settings.dtc_port,
+                    client_user_id=settings.dtc_user or "",
+                    client_password=settings.dtc_password or "",
+                    client_name=settings.dtc_client_name,
+                    heartbeat_interval=settings.dtc_heartbeat_interval,
+                    default_exchange=settings.dtc_default_exchange,
+                )
+                _dtc_adapter = DTCAdapter(config)
+    return _dtc_adapter
 
 
 async def get_topstep_adapter(
@@ -93,6 +124,14 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.on_event("shutdown")
+async def _shutdown_dtc() -> None:
+    global _dtc_adapter
+    if _dtc_adapter is not None:
+        await _dtc_adapter.close()
+        _dtc_adapter = None
+
+
 def _resolve_connector(
     venue: ExecutionVenue,
     *,
@@ -106,8 +145,8 @@ def _resolve_connector(
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported venue")
 
 
-async def _persist_tradingview_tick(signal: TradingViewSignal) -> None:
-    tick = PersistedTick(
+def _tick_from_tradingview_signal(signal: TradingViewSignal) -> PersistedTick:
+    return PersistedTick(
         exchange=signal.exchange,
         symbol=signal.symbol,
         source="tradingview",
@@ -117,6 +156,9 @@ async def _persist_tradingview_tick(signal: TradingViewSignal) -> None:
         side=signal.direction,
         extra={"strategy": signal.strategy, **signal.metadata},
     )
+
+
+def _persist_tick_record(tick: PersistedTick) -> None:
     with session_scope() as session:
         persist_ticks(
             session,
@@ -135,12 +177,30 @@ async def _persist_tradingview_tick(signal: TradingViewSignal) -> None:
         )
 
 
+async def publish_ticks_to_dtc(dtc: DTCAdapter, ticks: Iterable[PersistedTick]) -> None:
+    payload = [
+        {
+            "exchange": tick.exchange,
+            "symbol": tick.symbol,
+            "source": tick.source,
+            "timestamp": tick.timestamp,
+            "price": tick.price,
+            "size": tick.size,
+            "side": tick.side,
+        }
+        for tick in ticks
+    ]
+    if payload:
+        await dtc.publish_ticks(payload)
+
+
 @app.post("/webhooks/tradingview", status_code=202)
 async def tradingview_webhook(
     request: Request,
     background_tasks: BackgroundTasks,
     signature: str = Header(..., alias="X-Signature"),
     settings: Settings = Depends(get_settings),
+    dtc: DTCAdapter | None = Depends(get_dtc_adapter),
 ) -> dict[str, str]:
     body = await request.body()
     expected = hmac.new(
@@ -157,7 +217,10 @@ async def tradingview_webhook(
         raise HTTPException(status_code=400, detail="Invalid JSON payload") from exc
 
     signal = TradingViewSignal(**payload)
-    background_tasks.add_task(_persist_tradingview_tick, signal)
+    tick = _tick_from_tradingview_signal(signal)
+    background_tasks.add_task(_persist_tick_record, tick)
+    if dtc is not None:
+        await publish_ticks_to_dtc(dtc, [tick])
     return {"status": "accepted"}
 
 

--- a/services/market_data/tests/test_dtc_adapter.py
+++ b/services/market_data/tests/test_dtc_adapter.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+import struct
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from services.market_data.adapters.dtc import DTCAdapter, DTCConfig, DTCMessageType
+
+
+def _encode_string(value: str, length: int) -> bytes:
+    if length <= 0:
+        return b""
+    encoded = value.encode("utf-8")[: length - 1]
+    return encoded + b"\x00" * (length - len(encoded))
+
+
+def _frame(message_type: DTCMessageType, payload: bytes) -> bytes:
+    return struct.pack("<HH", 4 + len(payload), int(message_type)) + payload
+
+
+def _decode_string(buffer: bytes) -> str:
+    return buffer.split(b"\x00", 1)[0].decode("utf-8")
+
+
+def _decode_logon(payload: bytes) -> Dict[str, Any]:
+    version = struct.unpack_from("<I", payload, 0)[0]
+    username = _decode_string(payload[4:36])
+    password = _decode_string(payload[36:68])
+    heartbeat = struct.unpack_from("<H", payload, 68)[0]
+    client_name = _decode_string(payload[70:102])
+    return {
+        "version": version,
+        "username": username,
+        "password": password,
+        "heartbeat": heartbeat,
+        "client_name": client_name,
+    }
+
+
+def _decode_subscription(payload: bytes) -> Dict[str, Any]:
+    request_id, symbol_id = struct.unpack_from("<II", payload, 0)
+    symbol = _decode_string(payload[8:72])
+    exchange = _decode_string(payload[72:104])
+    return {
+        "request_id": request_id,
+        "symbol_id": symbol_id,
+        "symbol": symbol,
+        "exchange": exchange,
+    }
+
+
+def _decode_trade_update(payload: bytes) -> Dict[str, Any]:
+    symbol_id, price, size, epoch = struct.unpack("<IddQ", payload)
+    return {
+        "symbol_id": symbol_id,
+        "price": price,
+        "size": size,
+        "epoch": epoch,
+    }
+
+
+class MockDTCServer:
+    def __init__(
+        self,
+        *,
+        drop_after_subscribe: bool = False,
+        drop_after_update: bool = False,
+    ) -> None:
+        self.drop_after_subscribe = drop_after_subscribe
+        self.drop_after_update = drop_after_update
+        self.logons: List[Dict[str, Any]] = []
+        self.subscriptions: List[Dict[str, Any]] = []
+        self.updates: List[Dict[str, Any]] = []
+        self.logoffs: int = 0
+        self.connections = 0
+        self._server: asyncio.AbstractServer | None = None
+        self.port: int | None = None
+        self._dropped_after_update = False
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle_connection, "127.0.0.1", 0)
+        sockets = self._server.sockets or []
+        if not sockets:
+            raise RuntimeError("failed to open mock DTC socket")
+        self.port = sockets[0].getsockname()[1]
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self.connections += 1
+        connection_index = self.connections
+        try:
+            while True:
+                header = await reader.readexactly(4)
+                size, message_type = struct.unpack("<HH", header)
+                payload = await reader.readexactly(size - 4)
+                message = DTCMessageType(message_type)
+                if message == DTCMessageType.LOGON_REQUEST:
+                    self.logons.append(_decode_logon(payload))
+                    writer.write(
+                        _frame(
+                            DTCMessageType.LOGON_RESPONSE,
+                            struct.pack("<H", 1) + _encode_string("ok", 64),
+                        )
+                    )
+                    await writer.drain()
+                elif message == DTCMessageType.MARKET_DATA_SUBSCRIBE:
+                    self.subscriptions.append(_decode_subscription(payload))
+                    if self.drop_after_subscribe and connection_index == 1:
+                        writer.transport.abort()
+                        return
+                elif message == DTCMessageType.MARKET_DATA_UPDATE_TRADE:
+                    self.updates.append(_decode_trade_update(payload))
+                    if self.drop_after_update and not self._dropped_after_update:
+                        self._dropped_after_update = True
+                        writer.transport.abort()
+                        return
+                elif message == DTCMessageType.LOGOFF:
+                    self.logoffs += 1
+                    writer.close()
+                    await writer.wait_closed()
+                    return
+        except asyncio.IncompleteReadError:
+            return
+
+
+def test_dtc_adapter_handshake_and_publish() -> None:
+    async def run() -> None:
+        server = MockDTCServer()
+        await server.start()
+        assert server.port is not None
+
+        adapter = DTCAdapter(
+            DTCConfig(
+                host="127.0.0.1",
+                port=server.port,
+                client_user_id="demo",
+                client_password="secret",
+                client_name="tester",
+                default_exchange="CME",
+            )
+        )
+
+        await adapter.connect()
+        timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        await adapter.publish_ticks(
+            [
+                {
+                    "symbol": "ESZ4",
+                    "price": 4200.25,
+                    "size": 2.0,
+                    "timestamp": timestamp,
+                }
+            ]
+        )
+        await asyncio.sleep(0.05)
+        await adapter.close()
+        await asyncio.sleep(0.05)
+        await server.close()
+
+        assert len(server.logons) == 1
+        assert server.logons[0]["username"] == "demo"
+        assert server.logons[0]["password"] == "secret"
+        assert server.logons[0]["client_name"] == "tester"
+        assert len(server.subscriptions) == 1
+        assert server.subscriptions[0]["symbol"] == "ESZ4"
+        assert server.subscriptions[0]["exchange"] == "CME"
+        assert len(server.updates) == 1
+        assert server.updates[0]["symbol_id"] == server.subscriptions[0]["symbol_id"]
+        assert server.updates[0]["price"] == 4200.25
+        assert server.updates[0]["size"] == 2.0
+        assert server.logoffs == 1
+
+    asyncio.run(run())
+
+
+def test_dtc_adapter_reconnects_after_disconnect() -> None:
+    async def run() -> None:
+        server = MockDTCServer()
+        await server.start()
+        assert server.port is not None
+
+        adapter = DTCAdapter(
+            DTCConfig(host="127.0.0.1", port=server.port, client_user_id="reconnect")
+        )
+
+        first_timestamp = datetime.now(timezone.utc)
+        await adapter.publish_ticks(
+            [
+                {
+                    "symbol": "NQZ4",
+                    "price": 18000.5,
+                    "size": 1.0,
+                    "timestamp": first_timestamp,
+                }
+            ]
+        )
+        await asyncio.sleep(0.05)
+
+        await adapter.close()
+        await asyncio.sleep(0.05)
+
+        second_timestamp = datetime.now(timezone.utc)
+        await adapter.publish_ticks(
+            [
+                {
+                    "symbol": "NQZ4",
+                    "price": 18001.0,
+                    "size": 1.5,
+                    "timestamp": second_timestamp,
+                }
+            ]
+        )
+        await asyncio.sleep(0.05)
+        await adapter.close()
+        await asyncio.sleep(0.05)
+        await server.close()
+
+        assert server.connections >= 2
+        assert len(server.logons) >= 2
+        assert len(server.subscriptions) >= 2
+        assert len(server.updates) == 2
+        assert server.updates[-1]["price"] == 18001.0
+
+    asyncio.run(run())

--- a/services/market_data/workers/collector.py
+++ b/services/market_data/workers/collector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import AbstractContextManager
 from datetime import datetime, timezone
-from typing import Callable, Iterable, Mapping
+from typing import Awaitable, Callable, Iterable, Mapping
 
 from sqlalchemy.orm import Session
 
@@ -21,11 +21,13 @@ class MarketDataCollector:
         binance: BinanceMarketConnector,
         ibkr: IBKRMarketConnector,
         session_factory: Callable[[], AbstractContextManager[Session]],
+        tick_publishers: Iterable[Callable[[Iterable[PersistedTick]], Awaitable[None]]] | None = None,
     ) -> None:
         self._binance = binance
         self._ibkr = ibkr
         self._session_factory = session_factory
         self._stop_event = asyncio.Event()
+        self._tick_publishers = list(tick_publishers or [])
 
     async def collect_binance_ohlcv(self, symbol: str, interval: str) -> None:
         while not self._stop_event.is_set():
@@ -64,7 +66,9 @@ class MarketDataCollector:
                 side=None,
                 extra={"bid": getattr(ticker, "bid", None), "ask": getattr(ticker, "ask", None)},
             )
-            self._persist_ticks([row])
+            ticks = [row]
+            self._persist_ticks(ticks)
+            await self._publish_ticks(ticks)
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -110,3 +114,11 @@ class MarketDataCollector:
             return
         with self._session_factory() as session:
             persist_ticks(session, payload)
+
+    async def _publish_ticks(self, ticks: Iterable[PersistedTick]) -> None:
+        if not self._tick_publishers:
+            return
+        batch = list(ticks)
+        if not batch:
+            return
+        await asyncio.gather(*(publisher(batch) for publisher in self._tick_publishers))


### PR DESCRIPTION
## Summary
- implement the DTC TCP handshake, message framing, and reconnect logic in the adapter while translating ticks into trade updates
- expose DTC configuration hooks in the market data service and forward persisted ticks to the adapter when configured
- add optional tick publisher plumbing in the collector and cover the adapter with mocked DTC server tests

## Testing
- pytest services/market_data/tests/test_dtc_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68df6a692e808332992c31400508662d