### PR TITLE
Ensure bootstrap demo script resolves top-level packages

### DIFF
--- a/scripts/dev/bootstrap_demo.py
+++ b/scripts/dev/bootstrap_demo.py
@@ -8,12 +8,17 @@ import hmac
 import json
 import os
 import sys
+from pathlib import Path
 import time
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import Any, Iterable, Mapping
 
 import httpx
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from schemas.market import ExecutionVenue, OrderSide, OrderType
 from schemas.order_router import ExecutionIntent, ExecutionReport, RiskOverrides


### PR DESCRIPTION
## Summary
- add the repository root to `sys.path` in the bootstrap demo script so top-level packages import reliably from any working directory
- retain the shebang entry point by marking the script as executable for direct invocation

## Testing
- python scripts/dev/bootstrap_demo.py BTCUSDT 0.1 --help
- docker compose exec auth_service python /app/scripts/dev/bootstrap_demo.py BTCUSDT 0.1 --help *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb13e06d883329f66a3e2fe4a834e