### PR TITLE
Add migration for user broker credentials

### DIFF
--- a/infra/migrations/versions/a2cba7eee9aa_add_user_broker_credentials_table.py
+++ b/infra/migrations/versions/a2cba7eee9aa_add_user_broker_credentials_table.py
@@ -1,0 +1,55 @@
+"""add user broker credentials table
+
+Revision ID: a2cba7eee9aa
+Revises: 4d3f2c1f5b1a, b3e1c2d4e5f6
+Create Date: 2025-10-03 11:18:45.120338
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a2cba7eee9aa"
+down_revision = ("4d3f2c1f5b1a", "b3e1c2d4e5f6")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_broker_credentials",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("broker", sa.String(length=64), nullable=False),
+        sa.Column("api_key_encrypted", sa.String(length=1024), nullable=True),
+        sa.Column("api_secret_encrypted", sa.String(length=1024), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            server_onupdate=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "broker",
+            name="uq_user_broker_credentials",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_broker_credentials")


### PR DESCRIPTION
## Summary
- add an Alembic migration that creates the user_broker_credentials table with the expected columns and constraints
- merge the prior Alembic heads so the new revision can sit atop a single head

## Testing
- alembic upgrade head *(fails: upstream migrations try to recreate the reportjobstatus enum type)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb0d79084833284b1e60532cd8646