### PR TITLE
feat(web-dashboard): add account registration and status pages

### DIFF
--- a/services/web_dashboard/app/static/styles.css
+++ b/services/web_dashboard/app/static/styles.css
@@ -158,6 +158,83 @@ body {
   align-self: flex-start;
 }
 
+.flash {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+}
+
+.flash--success {
+  border-color: rgba(34, 197, 94, 0.4);
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--color-success);
+}
+
+.flash--error {
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-critical);
+}
+
+.status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.status-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  align-items: center;
+  flex-wrap: wrap;
+  padding: var(--space-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.status-list__meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.status-list__status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  white-space: nowrap;
+}
+
+.status-list__detail {
+  font-size: var(--font-size-sm);
+}
+
+.status-indicator {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  display: inline-block;
+  box-shadow: 0 0 0 rgba(255, 255, 255, 0.15);
+}
+
+.status-indicator--up {
+  background: var(--color-success);
+  box-shadow: 0 0 12px rgba(34, 197, 94, 0.7);
+}
+
+.status-indicator--down {
+  background: var(--color-critical);
+  box-shadow: 0 0 12px rgba(239, 68, 68, 0.7);
+}
+
 .onboarding {
   width: 100%;
 }

--- a/services/web_dashboard/app/templates/_navigation.html
+++ b/services/web_dashboard/app/templates/_navigation.html
@@ -42,6 +42,13 @@
           {{ _('Aide &amp; formation')|safe }}
         </a>
         <a
+          href="{{ request.url_for('render_status_page') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'status' else '' }}"
+          aria-current="{{ 'page' if active_page == 'status' else 'false' }}"
+        >
+          {{ _('Statut services') }}
+        </a>
+        <a
           href="{{ request.url_for('render_account') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'account' else '' }}"
           aria-current="{{ 'page' if active_page == 'account' else 'false' }}"

--- a/services/web_dashboard/app/templates/account.html
+++ b/services/web_dashboard/app/templates/account.html
@@ -33,6 +33,11 @@
               </p>
             </div>
             <div class="card__body">
+              {% if account_created %}
+              <div class="flash flash--success" role="status" aria-live="polite">
+                {{ _('Votre compte a été créé avec succès. Vous pouvez vous connecter dès maintenant !') }}
+              </div>
+              {% endif %}
               <form class="form-grid" action="{{ request.url_for('account_login') }}" method="post">
                 <label class="designer-field">
                   <span class="designer-field__label text text--muted">{{ _('Adresse e-mail') }}</span>
@@ -44,6 +49,10 @@
                 </label>
                 <button type="submit" class="button button--primary">{{ _('Se connecter') }}</button>
               </form>
+              <p class="text text--muted">
+                {{ _("Pas encore de compte ?") }}
+                <a href="{{ registration_url }}">{{ _('Créer un compte') }}</a>
+              </p>
             </div>
           </section>
 

--- a/services/web_dashboard/app/templates/account_register.html
+++ b/services/web_dashboard/app/templates/account_register.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="{{ current_language }}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ _('Créer un compte') }}</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="layout__header">
+      {% include "_navigation.html" %}
+      <h1 class="heading heading--xl">{{ _('Créer un compte utilisateur') }}</h1>
+      <p class="text text--muted">
+        {{ _('Activez votre accès au tableau de bord et obtenez une visibilité sur vos services hébergés.') }}
+      </p>
+    </header>
+    <main class="layout__main layout__main--wide">
+      <section class="card" aria-labelledby="register-title">
+        <div class="card__header">
+          <h2 id="register-title" class="heading heading--lg">{{ _('Informations de connexion') }}</h2>
+          <p class="text text--muted">
+            {{ _('Renseignez une adresse e-mail valide et un mot de passe robuste pour sécuriser votre compte.') }}
+          </p>
+        </div>
+        <div class="card__body">
+          {% if form_error %}
+          <div class="flash flash--error" role="alert" aria-live="assertive">
+            {{ form_error }}
+          </div>
+          {% endif %}
+          <form class="form-grid" action="{{ submit_endpoint }}" method="post">
+            <label class="designer-field">
+              <span class="designer-field__label text text--muted">{{ _('Adresse e-mail') }}</span>
+              <input type="email" name="email" autocomplete="email" value="{{ form_email }}" required />
+            </label>
+            <label class="designer-field">
+              <span class="designer-field__label text text--muted">{{ _('Mot de passe') }}</span>
+              <input type="password" name="password" autocomplete="new-password" minlength="8" required />
+            </label>
+            <button type="submit" class="button button--primary">{{ _('Créer mon compte') }}</button>
+          </form>
+          <p class="text text--muted">
+            {{ _('Déjà inscrit ?') }}
+            <a href="{{ login_url }}">{{ _('Se connecter') }}</a>
+          </p>
+        </div>
+      </section>
+    </main>
+    <footer class="layout__footer">
+      <p class="text text--muted">
+        {{ _('Vos identifiants sont stockés sur le service auth sécurisé et chiffré.') }}
+      </p>
+    </footer>
+    <script id="i18n-bootstrap" type="application/json">
+      {{ i18n_bundle|tojson }}
+    </script>
+  </body>
+</html>

--- a/services/web_dashboard/app/templates/status.html
+++ b/services/web_dashboard/app/templates/status.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="{{ current_language }}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ _('Statut des services') }}</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="layout__header">
+      {% include "_navigation.html" %}
+      <h1 class="heading heading--xl">{{ _('Surveillance des services') }}</h1>
+      <p class="text text--muted">
+        {{ _('Contrôlez en un coup d’œil la disponibilité de l’authentification, de la marketplace et des moteurs.')|safe }}
+      </p>
+    </header>
+    <main class="layout__main layout__main--wide">
+      <section class="card" aria-labelledby="status-title">
+        <div class="card__header">
+          <h2 id="status-title" class="heading heading--lg">{{ _('État temps réel') }}</h2>
+          <p class="text text--muted">
+            {{ _('Dernier contrôle le') }} {{ checked_at.strftime('%d/%m/%Y %H:%M:%S') }} UTC.
+          </p>
+        </div>
+        <div class="card__body">
+          <ul class="status-list" role="list">
+            {% for service in services %}
+            <li class="status-list__item" role="listitem">
+              <div class="status-list__meta">
+                <span class="heading heading--md">{{ service.label }}</span>
+                <p class="text text--muted">{{ service.description }}</p>
+                <p class="text text--muted">
+                  <span class="visually-hidden">Endpoint:</span>
+                  <code>{{ service.health_url }}</code>
+                </p>
+                {% if service.detail %}
+                <p class="text text--muted status-list__detail">
+                  {{ _('Détail :') }} {{ service.detail }}
+                </p>
+                {% endif %}
+              </div>
+              <span class="status-list__status badge badge--{{ service.badge_variant }}">
+                <span
+                  class="status-indicator status-indicator--{{ service.status }}"
+                  aria-hidden="true"
+                ></span>
+                {{ service.status_label }}
+              </span>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </section>
+    </main>
+    <footer class="layout__footer">
+      <p class="text text--muted">
+        {{ _('Des contrôles récurrents permettent de détecter rapidement les indisponibilités critiques.') }}
+      </p>
+    </footer>
+    <script id="i18n-bootstrap" type="application/json">
+      {{ i18n_bundle|tojson }}
+    </script>
+  </body>
+</html>

--- a/services/web_dashboard/tests/test_account_register.py
+++ b/services/web_dashboard/tests/test_account_register.py
@@ -1,0 +1,74 @@
+"""Tests covering the account creation flow exposed by the dashboard."""
+
+import importlib
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from httpx import Response as HTTPXResponse
+
+from .utils import load_dashboard_app
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    load_dashboard_app.cache_clear()
+    monkeypatch.setenv("AUTH_BASE_URL", "http://auth.local/")
+    monkeypatch.setenv("WEB_DASHBOARD_AUTH_SERVICE_URL", "http://auth.local/")
+    app = load_dashboard_app()
+    module = importlib.import_module("web_dashboard.app.main")
+    module.AUTH_PUBLIC_BASE_URL = "http://auth.local/"
+    module.AUTH_SERVICE_BASE_URL = "http://auth.local/"
+    test_client = TestClient(app)
+    yield test_client
+    load_dashboard_app.cache_clear()
+
+
+def test_register_page_displays_form(client):
+    response = client.get("/account/register", headers={"accept-language": "fr-FR,fr;q=0.9"})
+
+    assert response.status_code == 200
+    assert response.headers.get("Content-Language") == "fr"
+
+    html = response.text
+    form_action = f"{client.base_url}/account/register"
+    assert f'<form class="form-grid" action="{form_action}" method="post">' in html
+    assert '<input type="email" name="email" autocomplete="email"' in html
+    assert '<input type="password" name="password" autocomplete="new-password"' in html
+    assert "Créer mon compte" in html
+    assert "Se connecter" in html
+
+
+@respx.mock
+def test_register_success_redirects_to_login(client):
+    register_route = respx.post("http://auth.local/auth/register").mock(
+        return_value=HTTPXResponse(201, json={"id": 1})
+    )
+
+    response = client.post(
+        "/account/register",
+        data={"email": "new.user@example.com", "password": "StrongPwd42!"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].endswith("/account/login?created=1")
+    assert register_route.called
+
+
+@respx.mock
+def test_register_failure_renders_error_message(client):
+    respx.post("http://auth.local/auth/register").mock(
+        return_value=HTTPXResponse(400, json={"detail": "Mot de passe trop court"})
+    )
+
+    response = client.post(
+        "/account/register",
+        data={"email": "new.user@example.com", "password": "weak"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    html = response.text
+    assert "Mot de passe trop court" in html
+    assert 'value="new.user@example.com"' in html

--- a/services/web_dashboard/tests/test_status_page.py
+++ b/services/web_dashboard/tests/test_status_page.py
@@ -1,0 +1,67 @@
+"""Tests validating the service status page."""
+
+import importlib
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from httpx import Response as HTTPXResponse
+
+from .utils import load_dashboard_app
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    load_dashboard_app.cache_clear()
+    monkeypatch.setenv("AUTH_BASE_URL", "http://auth.local/")
+    monkeypatch.setenv("WEB_DASHBOARD_AUTH_SERVICE_URL", "http://auth.local/")
+    monkeypatch.setenv("WEB_DASHBOARD_REPORTS_BASE_URL", "http://reports.local/")
+    monkeypatch.setenv("WEB_DASHBOARD_ALGO_ENGINE_URL", "http://algo.local/")
+    monkeypatch.setenv("WEB_DASHBOARD_ORDER_ROUTER_BASE_URL", "http://router.local/")
+    monkeypatch.setenv("WEB_DASHBOARD_MARKETPLACE_URL", "http://market.local/")
+    app = load_dashboard_app()
+    module = importlib.import_module("web_dashboard.app.main")
+    module.AUTH_PUBLIC_BASE_URL = "http://auth.local/"
+    module.AUTH_SERVICE_BASE_URL = "http://auth.local/"
+    module.REPORTS_BASE_URL = "http://reports.local/"
+    module.ALGO_ENGINE_BASE_URL = "http://algo.local/"
+    module.ORDER_ROUTER_BASE_URL = "http://router.local/"
+    module.MARKETPLACE_BASE_URL = "http://market.local/"
+    test_client = TestClient(app)
+    yield test_client
+    load_dashboard_app.cache_clear()
+
+
+@respx.mock
+def test_status_page_displays_all_services(client):
+    respx.get("http://auth.local/health").mock(return_value=HTTPXResponse(200, json={"status": "ok"}))
+    respx.get("http://reports.local/health").mock(return_value=HTTPXResponse(200, json={"status": "healthy"}))
+    respx.get("http://algo.local/health").mock(return_value=HTTPXResponse(200, json={"status": "up"}))
+    respx.get("http://router.local/health").mock(return_value=HTTPXResponse(200, json={"status": "ok"}))
+    respx.get("http://market.local/health").mock(return_value=HTTPXResponse(200, json={"status": "up"}))
+
+    response = client.get("/status", headers={"accept-language": "fr-FR,fr;q=0.9"})
+
+    assert response.status_code == 200
+    assert response.headers.get("Content-Language") == "fr"
+    html = response.text
+    assert "Service d&#39;authentification" in html
+    assert "Service de rapports" in html
+    assert html.count("badge--success") >= 5
+
+
+@respx.mock
+def test_status_page_marks_failures(client):
+    respx.get("http://auth.local/health").mock(return_value=HTTPXResponse(200, json={"status": "ok"}))
+    respx.get("http://reports.local/health").mock(return_value=HTTPXResponse(503))
+    respx.get("http://algo.local/health").mock(return_value=HTTPXResponse(500, json={"status": "down"}))
+    respx.get("http://router.local/health").mock(return_value=HTTPXResponse(200, json={"status": "ok"}))
+    respx.get("http://market.local/health").mock(return_value=HTTPXResponse(200, json={"status": "ok"}))
+
+    response = client.get("/status")
+
+    assert response.status_code == 200
+    html = response.text
+    assert "HTTP 503" in html
+    assert "Indisponible" in html
+    assert "badge--critical" in html


### PR DESCRIPTION
## Summary
- add server-rendered account registration page with auth proxying and success flow
- surface service availability at /status with health checks and navigation link
- introduce supporting styles plus regression tests for registration and status pages

## Testing
- pytest services/web_dashboard/tests/test_account_register.py services/web_dashboard/tests/test_status_page.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb643e34c83329a02641cf1e3391b