### PR TITLE
feat: add demo e2e flow and observability updates

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,5 +45,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+          pip install -r services/web_dashboard/requirements-dev.txt
+          python -m playwright install --with-deps chromium
+      - name: Run web dashboard Playwright E2E
+        run: pytest services/web_dashboard/tests/e2e/test_demo_journey.py -vv
       - name: Run bootstrap demo end-to-end test
         run: pytest services/tests/test_bootstrap_demo_flow.py -m end_to_end -vv

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,120 @@
+# Run Demo Guide
+
+This guide walks you through spinning up the full Trading-Bot stack and executing the demo
+scenario from registration to your first backtest. It covers workstation, WSL and
+Codespaces setups and finishes with troubleshooting tips.
+
+## Prerequisites
+
+- **Docker** with Compose plugin (Docker Desktop on macOS/Windows, `docker-ce` on Linux).
+- **Python 3.11+** for running helper scripts and tests locally.
+- **Node.js 18+** *(optional)* if you plan to hack on the dashboard assets.
+- At least 8 GB of RAM available for the containers.
+
+## 1. Clone and bootstrap the repository
+
+```bash
+git clone https://github.com/<your-org>/trading-bot-open-source.git
+cd trading-bot-open-source
+python -m venv .venv && source .venv/bin/activate   # optional but recommended
+pip install --upgrade pip
+pip install -r requirements-dev.txt
+```
+
+If you intend to exercise the web dashboard end-to-end tests, install Playwright assets once:
+
+```bash
+pip install -r services/web_dashboard/requirements-dev.txt
+python -m playwright install --with-deps chromium
+```
+
+## 2. Start the demo stack
+
+The `demo-up` target builds and launches every service required for the walkthrough, plus
+Prometheus and Grafana for observability.
+
+```bash
+make demo-up
+```
+
+Services expose the following ports by default:
+
+| Service | URL |
+| ------- | --- |
+| Web dashboard | http://localhost:8022 |
+| Auth service | http://localhost:8011 |
+| User service | http://localhost:8004 |
+| Algo engine | http://localhost:8020 |
+| Grafana | http://localhost:3000 (admin/admin) |
+| Prometheus | http://localhost:9090 |
+
+Verify health probes once containers are up:
+
+```bash
+curl http://localhost:8022/health
+curl http://localhost:8011/health
+curl http://localhost:8004/health
+```
+
+All endpoints should return `{ "status": "ok" }`.
+
+## 3. Walk through the demo
+
+1. **Register** – call the auth service to provision credentials:
+   ```bash
+   curl -X POST http://localhost:8011/auth/register \
+     -H 'Content-Type: application/json' \
+     -d '{"email":"demo@example.com","password":"ValidPass123!"}'
+   ```
+2. **Create the user profile** – register the same email with user-service:
+   ```bash
+   export DEMO_TOKEN=$(python -c 'from datetime import datetime, timezone; from jose import jwt; print(jwt.encode({"sub": "auth-service", "iat": int(datetime.now(timezone.utc).timestamp())}, "test-onboarding-secret", algorithm="HS256"))')
+   curl -X POST http://localhost:8004/users/register \
+     -H "Authorization: Bearer $DEMO_TOKEN" \
+     -H 'Content-Type: application/json' \
+     -d '{"email":"demo@example.com","first_name":"Demo","last_name":"Trader"}'
+   ```
+3. **Login through the dashboard** – open http://localhost:8022/account and sign in with
+   the credentials created in step 1. The “Connecté en tant que …” banner confirms the session.
+4. **Onboarding dry-run** – navigate to http://localhost:8022/dashboard?user_id=<USER_ID> using the
+   identifier returned by user-service. Click through “Connexion broker”, “Créer une stratégie” and
+   “Premier backtest” to complete the checklist.
+5. **Strategy & Backtest** – head to http://localhost:8022/strategies. Select the “ORB” strategy,
+   choose your asset (e.g. ETHUSDT), tweak the inputs and trigger “Lancer le backtest”. A success
+   toast and updated history confirm the run.
+6. **Observe metrics** – browse to http://localhost:3000, open the *Trading-Bot Overview* dashboard
+   and confirm request rates, latency and error panels are populated.
+
+Shut everything down with `make demo-down` when you are done.
+
+## Running inside WSL
+
+1. Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/) and enable
+   integration for your WSL distribution.
+2. From your WSL shell, follow the same steps as the Linux walkthrough (`make demo-up`, curl health
+   endpoints, open the dashboard via `http://localhost:8022` from Windows or WSL).
+3. If browsers cannot reach the services, ensure the WSL firewall allows inbound connections and
+   that Docker Desktop is running.
+
+## Running in GitHub Codespaces
+
+1. Create a Codespace from the repository – the devcontainer already ships with Docker-in-Docker.
+2. Inside the Codespace terminal run `make demo-up` and wait for all services to report healthy.
+3. Use **Ports** forwarding to expose 8022 (dashboard), 8011 (auth) and 3000 (Grafana). The
+   forwarded URLs appear automatically.
+4. Execute the walkthrough exactly like on a workstation. You can also run the automated flow with
+   `pytest services/web_dashboard/tests/e2e/test_demo_journey.py -vv` once Playwright browsers are
+   installed.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| ------- | --- |
+| `curl` to `/health` hangs | Verify containers are running (`docker compose ps`). Restart an unhealthy service with `docker compose restart <service>`.
+| Login fails with 401 | Ensure you registered the user in both auth-service and user-service and that the JWT secret matches (`JWT_SECRET=test-onboarding-secret`).
+| Playwright complains about missing browsers | Run `python -m playwright install --with-deps chromium` in your virtualenv.
+| Ports already in use | Edit `docker-compose.yml` port mappings or stop the conflicting process.
+| Grafana dashboard empty | Check Prometheus scrape targets at http://localhost:9090/targets and confirm services expose `/metrics`.
+
+With the stack healthy and the demo flow complete you now have a baseline environment for building
+new trading strategies or extending the platform.

--- a/infra/grafana/provisioning/dashboards/trading-bot-overview.json
+++ b/infra/grafana/provisioning/dashboards/trading-bot-overview.json
@@ -1,0 +1,250 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 168,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never"
+          },
+          "unit": "req/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (service) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, service) (rate(http_request_latency_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "req/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum by (service) (rate(http_requests_total{status=~\"5..\"}[5m]))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 5xx Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (service) (increase(http_requests_total{status!~\"5..\"}[1h]))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Hourly Successful Requests",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "trading-bot",
+    "overview"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m"
+    ],
+    "time_options": [
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h"
+    ]
+  },
+  "timezone": "",
+  "title": "Trading-Bot Overview",
+  "uid": "trading-bot-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/services/ai_strategy_assistant/ai_strategy_assistant_service/app/main.py
+++ b/services/ai_strategy_assistant/ai_strategy_assistant_service/app/main.py
@@ -18,6 +18,13 @@ app = FastAPI(title="AI Strategy Assistant", version="0.1.0")
 assistant = AIStrategyAssistant()
 
 
+@app.get("/health", tags=["system"])
+async def health() -> dict[str, str]:
+    """Expose a simple readiness probe for orchestration and monitoring."""
+
+    return {"status": "ok"}
+
+
 @app.post("/generate", response_model=StrategyGenerationResponse)
 async def generate_strategy(payload: StrategyGenerationRequest) -> StrategyGenerationResponse:
     """Generate a draft strategy from a natural language description."""

--- a/services/alert_engine/app/main.py
+++ b/services/alert_engine/app/main.py
@@ -97,6 +97,12 @@ def create_app(
             for client in app.state.clients:
                 await client.aclose()
 
+    @app.get("/health", tags=["system"])
+    async def health() -> dict[str, str]:
+        """Expose a minimal readiness check for orchestrators and dashboards."""
+
+        return {"status": "ok"}
+
     def get_engine() -> AlertEngine:
         return app.state.alert_engine
 

--- a/services/streaming/app/main.py
+++ b/services/streaming/app/main.py
@@ -49,6 +49,12 @@ def create_app() -> FastAPI:
     app.include_router(ingest.router)
     app.include_router(moderation.router)
 
+    @app.get("/health", tags=["system"])
+    async def health() -> dict[str, str]:
+        """Expose a readiness probe for liveness checks."""
+
+        return {"status": "ok"}
+
     @app.websocket("/ws/rooms/{room_id}")
     async def websocket_room(websocket: WebSocket, room_id: str):
         authorizer: WebsocketAuthorizer = app.state.websocket_authorizer

--- a/services/web_dashboard/tests/conftest.py
+++ b/services/web_dashboard/tests/conftest.py
@@ -4,14 +4,33 @@ import os
 import sys
 import threading
 import time
+import asyncio
 from typing import Generator
 
 import pytest
 import uvicorn
 
-from .utils import load_dashboard_app, load_user_service_app, load_user_service_module
+from .utils import (
+    AUTH_SERVICE_PACKAGE_NAME,
+    load_auth_service_app,
+    load_auth_service_module,
+    load_dashboard_app,
+    load_user_service_app,
+    load_user_service_module,
+)
 
 TEST_JWT_SECRET = "test-onboarding-secret"
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Provide a session-scoped event loop compatible with pytest-asyncio strict mode."""
+
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
 
 
 @pytest.fixture(scope="session")
@@ -54,12 +73,65 @@ def user_service_base_url(tmp_path_factory) -> Generator[str, None, None]:
 
 
 @pytest.fixture(scope="session")
-def dashboard_app(user_service_base_url):
+def auth_service_base_url(tmp_path_factory) -> Generator[str, None, None]:
+    """Launch auth-service with a temporary SQLite database for account flows."""
+
+    db_path = tmp_path_factory.mktemp("auth-service") / "auth.db"
+    previous_db = os.environ.get("DATABASE_URL")
+    previous_secret = os.environ.get("JWT_SECRET")
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    os.environ["JWT_SECRET"] = TEST_JWT_SECRET
+    os.environ.setdefault("ENTITLEMENTS_BYPASS", "1")
+    sys.modules.pop("libs.db.db", None)
+
+    module = load_auth_service_module()
+    db_module = importlib.import_module("libs.db.db")
+    models_module = importlib.import_module(f"{AUTH_SERVICE_PACKAGE_NAME}.app.models")
+    models_module.Base.metadata.create_all(bind=db_module.engine)
+
+    app = load_auth_service_app()
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="warning")
+    sock = config.bind_socket()
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, kwargs={"sockets": [sock]}, daemon=True)
+    thread.start()
+
+    start_time = time.time()
+    while not server.started:
+        if time.time() - start_time > 10:
+            raise RuntimeError("Auth service test server failed to start in time")
+        time.sleep(0.05)
+
+    host, port = sock.getsockname()[:2]
+    base_url = f"http://{host}:{port}"
+
+    try:
+        yield base_url
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+        with contextlib.suppress(Exception):
+            sock.close()
+        if previous_db is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous_db
+        if previous_secret is None:
+            os.environ.pop("JWT_SECRET", None)
+        else:
+            os.environ["JWT_SECRET"] = previous_secret
+
+
+@pytest.fixture(scope="session")
+def dashboard_app(user_service_base_url, auth_service_base_url):
     """Expose the FastAPI application for integration and E2E tests."""
 
     os.environ.setdefault("WEB_DASHBOARD_USER_SERVICE_URL", user_service_base_url)
     os.environ.setdefault("USER_SERVICE_JWT_SECRET", TEST_JWT_SECRET)
     os.environ.setdefault("WEB_DASHBOARD_DEFAULT_USER_ID", "1")
+    os.environ.setdefault("WEB_DASHBOARD_AUTH_SERVICE_URL", auth_service_base_url)
+    os.environ.setdefault("AUTH_SERVICE_URL", auth_service_base_url)
+    load_dashboard_app.cache_clear()
     return load_dashboard_app()
 
 

--- a/services/web_dashboard/tests/e2e/test_demo_journey.py
+++ b/services/web_dashboard/tests/e2e/test_demo_journey.py
@@ -1,0 +1,181 @@
+"""End-to-end user journey covering registration to backtest."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import httpx
+import pytest
+from jose import jwt
+
+pytestmark = pytest.mark.asyncio
+
+respx = pytest.importorskip("respx")
+playwright_async = pytest.importorskip("playwright.async_api")
+Page = playwright_async.Page
+expect = playwright_async.expect
+
+TEST_JWT_SECRET = "test-onboarding-secret"
+
+
+def _service_token() -> str:
+    now = int(datetime.now(timezone.utc).timestamp())
+    return jwt.encode({"sub": "auth-service", "iat": now}, TEST_JWT_SECRET, algorithm="HS256")
+
+
+async def _register_user_in_user_service(user_service_base_url: str, email: str) -> int:
+    async with httpx.AsyncClient(base_url=user_service_base_url) as client:
+        response = await client.post(
+            "/users/register",
+            headers={"Authorization": f"Bearer {_service_token()}"},
+            json={
+                "email": email,
+                "first_name": "Demo",
+                "last_name": "Trader",
+                "phone": None,
+            },
+        )
+    response.raise_for_status()
+    payload = response.json()
+    return int(payload["id"])
+
+
+async def _register_user_in_auth_service(auth_service_base_url: str, email: str, password: str) -> dict:
+    async with httpx.AsyncClient(base_url=auth_service_base_url) as client:
+        response = await client.post(
+            "/auth/register",
+            json={"email": email, "password": password},
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+async def test_demo_user_journey(
+    page: Page,
+    dashboard_base_url: str,
+    user_service_base_url: str,
+    auth_service_base_url: str,
+):
+    """Walk through the demo journey from registration to a successful backtest."""
+
+    email = f"demo-{uuid4().hex[:8]}@example.com"
+    password = "ValidPass123!"
+
+    auth_payload = await _register_user_in_auth_service(auth_service_base_url, email, password)
+    assert auth_payload["email"] == email
+
+    user_id = await _register_user_in_user_service(user_service_base_url, email)
+
+    await page.goto(f"{dashboard_base_url}/account", wait_until="networkidle")
+
+    await page.get_by_label("Adresse e-mail").fill(email)
+    await page.get_by_label("Mot de passe").fill(password)
+
+    async with page.expect_response("**/account/login") as login_response_info:
+        await page.get_by_role("button", name=re.compile("Se connecter", re.I)).click()
+    login_response = await login_response_info.value
+    assert login_response.ok
+
+    await expect(
+        page.get_by_role("status").filter(has_text=re.compile("Connecté en tant que", re.I))
+    ).to_contain_text(email)
+
+    await page.goto(f"{dashboard_base_url}/dashboard?user_id={user_id}", wait_until="networkidle")
+
+    summary = page.locator("#onboarding-root").get_by_role("status").nth(0)
+    await expect(summary).to_have_text(re.compile(r"0 / 3"))
+
+    steps_list = page.get_by_role("list", name="Parcours d'onboarding")
+
+    broker_step = steps_list.get_by_role("listitem").filter(has_text="Connexion broker").nth(0)
+    await broker_step.get_by_role("button", name=re.compile("Connexion broker", re.I)).click()
+    await expect(summary).to_have_text(re.compile(r"1 / 3"))
+
+    strategy_step = steps_list.get_by_role("listitem").filter(has_text="Créer une stratégie").nth(0)
+    await strategy_step.get_by_role("button", name=re.compile("Créer une stratégie", re.I)).click()
+    await expect(summary).to_have_text(re.compile(r"2 / 3"))
+
+    backtest_step = steps_list.get_by_role("listitem").filter(has_text="Premier backtest").nth(0)
+    await backtest_step.get_by_role("button", name=re.compile("Premier backtest", re.I)).click()
+    await expect(summary).to_have_text(re.compile(r"3 / 3"))
+    await expect(summary).to_have_text(re.compile("Parcours terminé", re.I))
+
+    initial_metrics = {
+        "strategy_id": "strat-1",
+        "strategy_name": "ORB",
+        "equity_curve": [10_000, 10_500, 11_200],
+        "profit_loss": 1_200.0,
+        "total_return": 0.12,
+        "max_drawdown": 0.04,
+        "initial_balance": 10_000.0,
+        "metadata": {"symbol": "BTCUSDT", "timeframe": "1h"},
+        "ran_at": "2024-04-04T10:00:00Z",
+    }
+    updated_metrics = {
+        **initial_metrics,
+        "equity_curve": [10_000, 10_800, 11_800],
+        "profit_loss": 1_800.0,
+        "total_return": 0.18,
+        "max_drawdown": 0.03,
+        "metadata": {"symbol": "ETHUSDT", "timeframe": "4h"},
+        "ran_at": "2024-04-05T15:30:00Z",
+    }
+
+    history_initial = {
+        "items": [initial_metrics],
+        "total": 1,
+        "page": 1,
+        "page_size": 5,
+    }
+    history_updated = {
+        "items": [updated_metrics],
+        "total": 1,
+        "page": 1,
+        "page_size": 5,
+    }
+
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get("http://algo-engine:8000/strategies").mock(
+            return_value=httpx.Response(
+                200,
+                json={"items": [{"id": "strat-1", "name": "ORB", "strategy_type": "orb"}]},
+            )
+        )
+        mock.get("http://algo-engine:8000/strategies/strat-1/backtest/ui").mock(
+            side_effect=[httpx.Response(200, json=initial_metrics), httpx.Response(200, json=updated_metrics)]
+        )
+        mock.get("http://algo-engine:8000/strategies/strat-1/backtests").mock(
+            side_effect=[httpx.Response(200, json=history_initial), httpx.Response(200, json=history_updated)]
+        )
+        mock.post("http://algo-engine:8000/strategies/strat-1/backtest").mock(
+            return_value=httpx.Response(200, json=updated_metrics)
+        )
+
+        await page.goto(f"{dashboard_base_url}/strategies", wait_until="networkidle")
+
+        await expect(page.get_by_role("heading", name="Backtests")).to_be_visible()
+
+        await page.get_by_label("Actif").fill("ETHUSDT")
+        await page.get_by_label("Période").select_option("4h")
+        await page.get_by_label("Fenêtre (jours)").fill("45")
+        await page.get_by_label("Capital initial").fill("15000")
+
+        async with page.expect_request("**/api/strategies/**/backtest") as backtest_request_info:
+            await page.get_by_role("button", name="Lancer le backtest").click()
+        backtest_request = await backtest_request_info.value
+        payload = json.loads(backtest_request.post_data or "{}")
+        assert payload == {
+            "symbol": "ETHUSDT",
+            "timeframe": "4h",
+            "lookback_days": 45,
+            "initial_balance": 15000,
+        }
+
+        await expect(page.get_by_text("Backtest exécuté avec succès.")).to_be_visible()
+        await expect(page.get_by_role("img", name="Équity du backtest")).to_be_visible()
+        await expect(
+            page.locator(".backtest-console__history-list li").first
+        ).to_contain_text("ETHUSDT")


### PR DESCRIPTION
## Summary
- add explicit /health endpoints to AI assistant, alert engine, and streaming services
- provision a Trading-Bot Overview Grafana dashboard and document the end-to-end demo walkthrough
- introduce a Playwright demo journey test and wire it into the e2e GitHub Actions workflow

## Testing
- `pytest services/web_dashboard/tests/e2e/test_demo_journey.py -vv --asyncio-mode=auto` *(fails in strict mode locally due to asyncio runner overlap)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb663dbb08332a10caef360eb5be9