### PR TITLE
feat: add one-click strategy backtesting flow

### DIFF
--- a/services/algo_engine/tests/test_backtests.py
+++ b/services/algo_engine/tests/test_backtests.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi.testclient import TestClient
+
+
+def _build_market_data() -> list[Dict[str, Any]]:
+    return [
+        {"close": 100.0, "trigger_buy": True},
+        {"close": 110.0, "trigger_sell": True},
+    ]
+
+
+def _build_strategy_payload(name: str = "Declarative Test") -> Dict[str, Any]:
+    return {
+        "name": name,
+        "strategy_type": "declarative",
+        "parameters": {
+            "definition": {
+                "rules": [
+                    {
+                        "when": {
+                            "field": "trigger_buy",
+                            "operator": "eq",
+                            "value": True,
+                        },
+                        "signal": {"action": "buy", "size": 1},
+                    },
+                    {
+                        "when": {
+                            "field": "trigger_sell",
+                            "operator": "eq",
+                            "value": True,
+                        },
+                        "signal": {"action": "sell", "size": 1},
+                    },
+                ]
+            }
+        },
+        "enabled": False,
+        "tags": ["test"],
+        "metadata": {"symbol": "BTCUSDT"},
+    }
+
+
+def test_create_and_fetch_backtest(main_module: Any, tmp_path: Path) -> None:
+    client = TestClient(main_module.app)
+    backtester = main_module.backtester
+    original_output = backtester.output_dir
+    backtester.output_dir = tmp_path
+    try:
+        create_response = client.post("/strategies", json=_build_strategy_payload())
+        assert create_response.status_code == 201
+        strategy = create_response.json()
+        strategy_id = strategy["id"]
+
+        run_response = client.post(
+            "/backtests",
+            json={
+                "strategy_id": strategy_id,
+                "market_data": _build_market_data(),
+                "initial_balance": 1_000.0,
+                "metadata": {"symbol": "BTCUSDT", "timeframe": "1h"},
+            },
+        )
+        assert run_response.status_code == 201
+        payload = run_response.json()
+        assert payload["strategy_id"] == strategy_id
+        assert isinstance(payload.get("id"), int)
+        assert payload.get("profit_loss") == 10.0
+        assert payload.get("equity_curve")
+        artifacts = payload.get("artifacts")
+        assert isinstance(artifacts, list) and artifacts
+
+        backtest_id = payload["id"]
+        detail_response = client.get(f"/backtests/{backtest_id}")
+        assert detail_response.status_code == 200
+        detail_payload = detail_response.json()
+        assert detail_payload["id"] == backtest_id
+        assert detail_payload["strategy_id"] == strategy_id
+        detail_artifacts = detail_payload.get("artifacts")
+        assert isinstance(detail_artifacts, list) and detail_artifacts
+        metrics_artifact = next(
+            (item for item in detail_artifacts if item.get("type") == "metrics"),
+            None,
+        )
+        assert metrics_artifact is not None
+        assert isinstance(metrics_artifact.get("content"), dict)
+    finally:
+        backtester.output_dir = original_output

--- a/services/web_dashboard/app/main.py
+++ b/services/web_dashboard/app/main.py
@@ -63,7 +63,7 @@ from .help_progress import (
 )
 from .strategy_presets import STRATEGY_PRESETS, STRATEGY_PRESET_SUMMARIES
 from .localization import LocalizationMiddleware, template_base_context
-from pydantic import BaseModel, Field, ConfigDict, EmailStr
+from pydantic import BaseModel, Field, ConfigDict, EmailStr, model_validator
 from schemas.order_router import PositionCloseRequest
 
 
@@ -536,11 +536,26 @@ def shutdown_alerts_client() -> None:
 
 
 class StrategySaveRequest(BaseModel):
-    """Payload accepted by the strategy import endpoint."""
+    """Payload accepted by the strategy save endpoint."""
 
     name: str = Field(..., min_length=1)
-    format: Literal["yaml", "python"]
-    code: str = Field(..., min_length=1)
+    format: Literal["yaml", "python"] | None = None
+    code: str | None = Field(default=None, min_length=1)
+    strategy_type: str | None = Field(default=None, min_length=1)
+    parameters: dict[str, Any] | None = None
+    enabled: bool = False
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_payload(self) -> "StrategySaveRequest":
+        has_source = bool(self.format and self.code)
+        has_structured = bool(self.strategy_type and self.parameters is not None)
+        if not has_source and not has_structured:
+            raise ValueError(
+                "Provide either format/code or strategy_type/parameters to save a strategy."
+            )
+        return self
 
 
 class StrategyGenerationRequestPayload(BaseModel):
@@ -642,6 +657,11 @@ class StrategyBacktestRunRequest(BaseModel):
     initial_balance: float = Field(10_000.0, gt=0)
 
 
+class BacktestRunRequest(StrategyBacktestRunRequest):
+    strategy_id: str = Field(..., min_length=1)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
 def _timeframe_to_minutes(timeframe: str) -> int:
     minutes = SUPPORTED_TIMEFRAMES.get(timeframe)
     if minutes is None:
@@ -655,6 +675,8 @@ def _generate_synthetic_market_data(
     lookback_days: int,
     *,
     max_candles: int = 500,
+    fast_length: int = 5,
+    slow_length: int = 20,
 ) -> List[Dict[str, Any]]:
     """Create deterministic OHLC data for backtests when real data is unavailable."""
 
@@ -665,6 +687,7 @@ def _generate_synthetic_market_data(
     start_time = datetime.now() - timedelta(days=lookback_days)
     equity: List[Dict[str, Any]] = []
     amplitude = max(1.0, base_price * 0.015)
+    closes: List[float] = []
 
     for index in range(candle_count):
         progress = index / max(1, candle_count - 1)
@@ -676,6 +699,13 @@ def _generate_synthetic_market_data(
         high = max(close, open_price) + amplitude * 0.1
         low = min(close, open_price) - amplitude * 0.1
         timestamp = start_time + timedelta(minutes=index * minutes)
+        closes.append(close)
+        window_fast = closes[-max(1, fast_length) :]
+        window_slow = closes[-max(1, slow_length) :]
+        sma_fast = sum(window_fast) / len(window_fast)
+        sma_slow = sum(window_slow) / len(window_slow)
+        above_fast = close >= sma_fast
+        trend_up = sma_fast >= sma_slow
         equity.append(
             {
                 "timestamp": timestamp.isoformat(),
@@ -684,6 +714,12 @@ def _generate_synthetic_market_data(
                 "low": round(low, 4),
                 "close": round(close, 4),
                 "volume": round(abs(math.cos(angle)) * 10_000, 3),
+                "sma_fast": round(sma_fast, 4),
+                "sma_slow": round(sma_slow, 4),
+                "trend_up": trend_up,
+                "trend_down": not trend_up,
+                "above_fast_ma": above_fast,
+                "below_fast_ma": not above_fast,
             }
         )
     return equity
@@ -996,6 +1032,85 @@ async def run_strategy_backtest(
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=message) from error
 
 
+@app.post("/backtests/run", name="run_backtest")
+async def run_backtest(payload: BacktestRunRequest) -> dict[str, Any]:
+    """Trigger a backtest run for a freshly created strategy."""
+
+    def _coerce_period(value: Any, default: int) -> int:
+        try:
+            period = int(value)
+        except (TypeError, ValueError):
+            return default
+        return max(1, period)
+
+    metadata: dict[str, Any] = {
+        "symbol": payload.symbol,
+        "timeframe": payload.timeframe,
+        "lookback_days": payload.lookback_days,
+    }
+    metadata.update(payload.metadata or {})
+    fast_length = _coerce_period(metadata.get("fast_length"), 5)
+    slow_length = _coerce_period(metadata.get("slow_length"), 20)
+
+    market_data = _generate_synthetic_market_data(
+        payload.symbol,
+        payload.timeframe,
+        payload.lookback_days,
+        fast_length=fast_length,
+        slow_length=slow_length,
+    )
+    target_url = urljoin(ALGO_ENGINE_BASE_URL, "backtests")
+    request_payload = {
+        "strategy_id": payload.strategy_id,
+        "market_data": market_data,
+        "initial_balance": payload.initial_balance,
+        "metadata": metadata,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=ALGO_ENGINE_TIMEOUT) as client:
+            response = await client.post(
+                target_url,
+                json=request_payload,
+                headers={"Accept": "application/json"},
+            )
+    except httpx.HTTPError as error:  # pragma: no cover - network failure
+        message = "Algo-engine indisponible pour lancer le backtest."
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=message) from error
+
+    if response.status_code >= 400:
+        detail = _safe_json(response)
+        raise HTTPException(status_code=response.status_code, detail=detail)
+
+    try:
+        return response.json()
+    except ValueError as error:  # pragma: no cover - invalid payload
+        message = "Réponse invalide du moteur de stratégies."
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=message) from error
+
+
+@app.get("/backtests/{backtest_id}", name="get_backtest")
+async def get_backtest(backtest_id: int) -> dict[str, Any]:
+    """Retrieve backtest details and artifacts."""
+
+    target_url = urljoin(ALGO_ENGINE_BASE_URL, f"backtests/{backtest_id}")
+    try:
+        async with httpx.AsyncClient(timeout=ALGO_ENGINE_TIMEOUT) as client:
+            response = await client.get(target_url, headers={"Accept": "application/json"})
+    except httpx.HTTPError as error:  # pragma: no cover - network failure
+        message = "Algo-engine indisponible pour récupérer le backtest."
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=message) from error
+
+    if response.status_code >= 400:
+        detail = _safe_json(response)
+        raise HTTPException(status_code=response.status_code, detail=detail)
+
+    try:
+        return response.json()
+    except ValueError as error:  # pragma: no cover - invalid payload
+        message = "Réponse invalide du moteur de stratégies."
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=message) from error
+
+
 @app.get(
     "/api/strategies/{strategy_id}/backtest/ui",
     name="get_strategy_backtest_ui",
@@ -1059,16 +1174,32 @@ async def list_strategy_backtests(
 async def save_strategy(payload: StrategySaveRequest) -> dict[str, object]:
     """Relay strategy definitions to the algo-engine import endpoint."""
 
-    target_url = urljoin(ALGO_ENGINE_BASE_URL, "strategies/import")
+    if payload.format and payload.code:
+        target_url = urljoin(ALGO_ENGINE_BASE_URL, "strategies/import")
+        request_payload: dict[str, Any] = {
+            "name": payload.name,
+            "format": payload.format,
+            "content": payload.code,
+        }
+    else:
+        target_url = urljoin(ALGO_ENGINE_BASE_URL, "strategies")
+        request_payload = {
+            "name": payload.name,
+            "strategy_type": payload.strategy_type,
+            "parameters": payload.parameters or {},
+            "enabled": payload.enabled,
+            "tags": payload.tags,
+            "metadata": payload.metadata,
+        }
+        if payload.format:
+            request_payload["source_format"] = payload.format
+        if payload.code:
+            request_payload["source"] = payload.code
     try:
         async with httpx.AsyncClient(timeout=ALGO_ENGINE_TIMEOUT) as client:
             response = await client.post(
                 target_url,
-                json={
-                    "name": payload.name,
-                    "format": payload.format,
-                    "content": payload.code,
-                },
+                json=request_payload,
                 headers={"Accept": "application/json"},
             )
     except httpx.HTTPError as error:  # pragma: no cover - network failure
@@ -1470,6 +1601,40 @@ def render_strategies(request: Request) -> HTMLResponse:
     """Render the visual strategy designer page."""
 
     return _render_strategies_page(request)
+
+
+@app.get("/strategies/new", response_class=HTMLResponse)
+def render_one_click_strategy(request: Request) -> HTMLResponse:
+    """Expose the one-click strategy creation workflow."""
+
+    save_endpoint = request.url_for("save_strategy")
+    run_endpoint = request.url_for("run_backtest")
+    backtest_detail_template = request.url_for("get_backtest", backtest_id="__id__")
+    history_endpoint_template = request.url_for(
+        "list_strategy_backtests", strategy_id="__id__"
+    )
+    defaults = {
+        "name": "Tendance BTCUSDT",
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "lookback_days": 60,
+        "initial_balance": 10_000,
+        "fast_length": 5,
+        "slow_length": 20,
+        "position_size": 1,
+    }
+    context = {
+        "save_endpoint": save_endpoint,
+        "run_endpoint": run_endpoint,
+        "backtest_detail_template": backtest_detail_template,
+        "history_endpoint_template": history_endpoint_template,
+        "defaults": defaults,
+        "active_page": "strategies-new",
+    }
+    return templates.TemplateResponse(
+        "strategies_new.html",
+        _template_context(request, context),
+    )
 
 
 @app.get("/strategies/documentation", response_class=HTMLResponse)

--- a/services/web_dashboard/app/templates/_navigation.html
+++ b/services/web_dashboard/app/templates/_navigation.html
@@ -28,6 +28,13 @@
           {{ _('Stratégies') }}
         </a>
         <a
+          href="{{ request.url_for('render_one_click_strategy') }}"
+          class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategies-new' else '' }}"
+          aria-current="{{ 'page' if active_page == 'strategies-new' else 'false' }}"
+        >
+          {{ _('Stratégie express') }}
+        </a>
+        <a
           href="{{ request.url_for('render_strategy_documentation') }}"
           class="app-nav__link {{ 'app-nav__link--active' if active_page == 'strategy-docs' else '' }}"
           aria-current="{{ 'page' if active_page == 'strategy-docs' else 'false' }}"

--- a/services/web_dashboard/app/templates/strategies_new.html
+++ b/services/web_dashboard/app/templates/strategies_new.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="{{ current_language }}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stratégie express</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="layout__header">
+      {% include "_navigation.html" %}
+      <h1 class="heading heading--xl">{{ _('Stratégie "one-click"') }}</h1>
+      <p class="text text--muted">
+        {{ _('Configurez un plan simple, enregistrez-le et lancez immédiatement un backtest sur BTCUSDT.') }}
+      </p>
+    </header>
+    <main class="layout__main layout__main--wide">
+      <section class="card" aria-labelledby="one-click-card-title">
+        <div class="card__header">
+          <h2 id="one-click-card-title" class="heading heading--lg">{{ _('Création & backtest') }}</h2>
+          <p class="text text--muted">
+            {{ _('Choisissez vos paramètres de tendance, nous générons la stratégie et lançons le backtest pour vous.') }}
+          </p>
+        </div>
+        <div class="card__body">
+          <div
+            id="strategy-one-click-root"
+            data-save-endpoint="{{ save_endpoint }}"
+            data-run-endpoint="{{ run_endpoint }}"
+            data-history-endpoint-template="{{ history_endpoint_template }}"
+            data-backtest-detail-template="{{ backtest_detail_template }}"
+            data-defaults='{{ defaults | tojson }}'
+          >
+            <noscript>
+              <p class="text text--muted">{{ _('Activez JavaScript pour créer et backtester votre stratégie.') }}</p>
+            </noscript>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="layout__footer">
+      <p class="text text--muted">{{ _('Les métriques et journaux sont stockés dans data/backtests/ pour consultation ultérieure.') }}</p>
+    </footer>
+    <script id="i18n-bootstrap" type="application/json">
+      {{ i18n_bundle|tojson }}
+    </script>
+    <script type="module" src="/static/dist/portfolio-chart.js"></script>
+  </body>
+</html>

--- a/services/web_dashboard/src/main.jsx
+++ b/services/web_dashboard/src/main.jsx
@@ -7,6 +7,7 @@ import ReportsList from "./reports/ReportsList.jsx";
 import { AIStrategyAssistant } from "./strategies/assistant/index.js";
 import { StrategyDesigner, STRATEGY_PRESETS } from "./strategies/designer/index.js";
 import { StrategyBacktestConsole } from "./strategies/backtest/index.js";
+import { OneClickStrategyBuilder } from "./strategies/simple/index.js";
 import MarketplaceApp from "./marketplace/MarketplaceApp.jsx";
 import OnboardingApp from "./onboarding/OnboardingApp.jsx";
 import { I18nextProvider, useTranslation } from "react-i18next";
@@ -185,6 +186,33 @@ if (strategyDesignerRoot) {
       defaultFormat={initialFormat}
       presets={presetCatalog}
       initialStrategy={initialStrategy}
+    />
+  );
+}
+
+const oneClickRoot = document.getElementById("strategy-one-click-root");
+if (oneClickRoot) {
+  const dataset = oneClickRoot.dataset || {};
+  let defaults = {};
+  if (dataset.defaults) {
+    try {
+      const parsed = JSON.parse(dataset.defaults);
+      if (parsed && typeof parsed === "object") {
+        defaults = parsed;
+      }
+    } catch (error) {
+      console.error("Impossible de parser les valeurs par défaut de la stratégie one-click", error);
+    }
+  }
+  const root = createRoot(oneClickRoot);
+  renderWithI18n(
+    root,
+    <OneClickStrategyBuilder
+      saveEndpoint={dataset.saveEndpoint || "/strategies/save"}
+      runEndpoint={dataset.runEndpoint || "/backtests/run"}
+      historyEndpointTemplate={dataset.historyEndpointTemplate || ""}
+      backtestDetailTemplate={dataset.backtestDetailTemplate || ""}
+      defaults={defaults}
     />
   );
 }

--- a/services/web_dashboard/src/strategies/simple/OneClickStrategyBuilder.jsx
+++ b/services/web_dashboard/src/strategies/simple/OneClickStrategyBuilder.jsx
@@ -1,0 +1,663 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
+
+const TIMEFRAME_OPTIONS = [
+  { value: "15m", label: "15 minutes" },
+  { value: "1h", label: "1 heure" },
+  { value: "4h", label: "4 heures" },
+  { value: "1d", label: "1 jour" },
+];
+
+function buildEndpoint(template, identifier) {
+  if (!template || !identifier) {
+    return "";
+  }
+  return template.replace("__id__", encodeURIComponent(identifier));
+}
+
+function normaliseSummary(summary) {
+  if (!summary || typeof summary !== "object") {
+    return null;
+  }
+  const equityCurve = Array.isArray(summary.equity_curve)
+    ? summary.equity_curve
+    : [];
+  const pnl =
+    typeof summary.pnl === "number"
+      ? summary.pnl
+      : typeof summary.profit_loss === "number"
+      ? summary.profit_loss
+      : 0;
+  const drawdown =
+    typeof summary.drawdown === "number"
+      ? summary.drawdown
+      : typeof summary.max_drawdown === "number"
+      ? summary.max_drawdown
+      : 0;
+  const totalReturn =
+    typeof summary.total_return === "number" ? summary.total_return : 0;
+  const initialBalance =
+    typeof summary.initial_balance === "number"
+      ? summary.initial_balance
+      : 0;
+  const identifier =
+    typeof summary.id === "number" || typeof summary.id === "string"
+      ? summary.id
+      : null;
+  const artifacts = Array.isArray(summary.artifacts)
+    ? summary.artifacts
+    : [];
+  return {
+    ...summary,
+    equity_curve: equityCurve,
+    pnl,
+    drawdown,
+    total_return: totalReturn,
+    initial_balance: initialBalance,
+    id: identifier,
+    artifacts,
+  };
+}
+
+function formatCurrency(value, currency = "USD") {
+  try {
+    return new Intl.NumberFormat("fr-FR", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 2,
+    }).format(value || 0);
+  } catch (error) {
+    return `${(value || 0).toFixed(2)} ${currency}`;
+  }
+}
+
+function formatPercent(ratio) {
+  const value = typeof ratio === "number" ? ratio * 100 : 0;
+  return `${value.toFixed(2)} %`;
+}
+
+function buildParameters(fastLength, slowLength, positionSize) {
+  const size = Math.max(0.001, Number.parseFloat(positionSize) || 1);
+  return {
+    definition: {
+      rules: [
+        {
+          when: {
+            all: [
+              { field: "trend_up", operator: "eq", value: true },
+              { field: "above_fast_ma", operator: "eq", value: true },
+            ],
+          },
+          signal: { action: "buy", size },
+        },
+        {
+          when: {
+            any: [
+              { field: "trend_up", operator: "eq", value: false },
+              { field: "below_fast_ma", operator: "eq", value: true },
+            ],
+          },
+          signal: { action: "sell", size },
+        },
+      ],
+    },
+    fast_length: fastLength,
+    slow_length: slowLength,
+    position_size: size,
+  };
+}
+
+function buildMetadata(formValues) {
+  return {
+    symbol: formValues.symbol,
+    timeframe: formValues.timeframe,
+    lookback_days: formValues.lookbackDays,
+    fast_length: formValues.fastLength,
+    slow_length: formValues.slowLength,
+    position_size: formValues.positionSize,
+    strategy_name: formValues.name,
+  };
+}
+
+function parseArtifacts(artifacts) {
+  if (!Array.isArray(artifacts)) {
+    return [];
+  }
+  return artifacts
+    .map((artifact) => {
+      if (!artifact || typeof artifact !== "object") {
+        return null;
+      }
+      const type = artifact.type || "artifact";
+      const path = artifact.path || "";
+      const contentType = artifact.content_type || "text/plain";
+      const content = artifact.content ?? "";
+      return { type, path, contentType, content };
+    })
+    .filter(Boolean);
+}
+
+function OneClickStrategyBuilder({
+  saveEndpoint,
+  runEndpoint,
+  historyEndpointTemplate,
+  backtestDetailTemplate,
+  defaults,
+}) {
+  const [formValues, setFormValues] = useState(() => ({
+    name: (defaults && defaults.name) || "Tendance BTCUSDT",
+    symbol: (defaults && defaults.symbol) || "BTCUSDT",
+    timeframe: (defaults && defaults.timeframe) || "1h",
+    lookbackDays: (defaults && defaults.lookback_days) || 60,
+    initialBalance: (defaults && defaults.initial_balance) || 10000,
+    fastLength: (defaults && defaults.fast_length) || 5,
+    slowLength: (defaults && defaults.slow_length) || 20,
+    positionSize: (defaults && defaults.position_size) || 1,
+  }));
+  const [status, setStatus] = useState({ phase: "idle", message: "" });
+  const [error, setError] = useState(null);
+  const [strategyId, setStrategyId] = useState("");
+  const [lastRun, setLastRun] = useState(null);
+  const [artifacts, setArtifacts] = useState([]);
+  const [history, setHistory] = useState({ items: [], total: 0, page: 1 });
+  const [historyStatus, setHistoryStatus] = useState("idle");
+
+  const canSubmit = Boolean(saveEndpoint && runEndpoint);
+
+  const chartData = useMemo(() => {
+    if (!lastRun || !Array.isArray(lastRun.equity_curve)) {
+      return [];
+    }
+    return lastRun.equity_curve.map((value, index) => ({
+      index,
+      equity: typeof value === "number" ? value : Number.parseFloat(value) || 0,
+    }));
+  }, [lastRun]);
+
+  const currency = useMemo(() => {
+    if (lastRun && lastRun.metadata && lastRun.metadata.currency) {
+      return lastRun.metadata.currency;
+    }
+    return "USD";
+  }, [lastRun]);
+
+  const loadHistory = useCallback(
+    async (id) => {
+      if (!id || !historyEndpointTemplate) {
+        setHistory({ items: [], total: 0, page: 1 });
+        return;
+      }
+      const endpoint = buildEndpoint(historyEndpointTemplate, id);
+      if (!endpoint) {
+        return;
+      }
+      setHistoryStatus("loading");
+      try {
+        const response = await fetch(endpoint, {
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json();
+        const items = Array.isArray(payload.items)
+          ? payload.items.map((item) => normaliseSummary(item)).filter(Boolean)
+          : [];
+        setHistory({
+          items,
+          total: typeof payload.total === "number" ? payload.total : items.length,
+          page: 1,
+        });
+        setHistoryStatus("ready");
+      } catch (loadError) {
+        console.error("Impossible de charger l'historique des backtests", loadError);
+        setHistoryStatus("error");
+      }
+    },
+    [historyEndpointTemplate]
+  );
+
+  const handleSelectBacktest = useCallback(
+    async (backtestId) => {
+      if (!backtestId || !backtestDetailTemplate) {
+        return;
+      }
+      const endpoint = buildEndpoint(backtestDetailTemplate, backtestId);
+      if (!endpoint) {
+        return;
+      }
+      try {
+        const response = await fetch(endpoint, {
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json();
+        const normalised = normaliseSummary(payload);
+        if (normalised) {
+          setLastRun(normalised);
+          setArtifacts(parseArtifacts(normalised.artifacts));
+        }
+      } catch (loadError) {
+        console.error("Impossible de récupérer le backtest", loadError);
+        setError(loadError);
+      }
+    },
+    [backtestDetailTemplate]
+  );
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      if (!canSubmit) {
+        setError(new Error("Configuration incomplète."));
+        return;
+      }
+      setStatus({ phase: "saving", message: "Enregistrement de la stratégie…" });
+      setError(null);
+      try {
+        const symbol = formValues.symbol.trim().toUpperCase();
+        const name = formValues.name.trim() || "Stratégie tendance";
+        const fastLength = Math.max(1, Number.parseInt(formValues.fastLength, 10) || 5);
+        const slowLength = Math.max(
+          fastLength + 1,
+          Number.parseInt(formValues.slowLength, 10) || fastLength + 5
+        );
+        const positionSize = Math.max(
+          0.001,
+          Number.parseFloat(formValues.positionSize) || 1
+        );
+        const parameters = buildParameters(fastLength, slowLength, positionSize);
+        const metadata = buildMetadata({
+          ...formValues,
+          symbol,
+          name,
+          fastLength,
+          slowLength,
+          positionSize,
+        });
+        const saveResponse = await fetch(saveEndpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({
+            name,
+            strategy_type: "declarative",
+            parameters: {
+              definition: parameters.definition,
+              fast_length: parameters.fast_length,
+              slow_length: parameters.slow_length,
+              position_size: parameters.position_size,
+            },
+            metadata,
+            enabled: false,
+            tags: ["one-click"],
+          }),
+        });
+        if (!saveResponse.ok) {
+          const detail = await saveResponse.json().catch(() => null);
+          const message = detail && detail.detail ? detail.detail : `HTTP ${saveResponse.status}`;
+          throw new Error(
+            Array.isArray(message)
+              ? message.map((item) => item.msg || item.detail).join("; ")
+              : typeof message === "string"
+              ? message
+              : "Échec de l'enregistrement de la stratégie."
+          );
+        }
+        const savedPayload = await saveResponse.json().catch(() => ({}));
+        const createdId = savedPayload.id || savedPayload.strategy_id || savedPayload.strategy?.id;
+        if (!createdId) {
+          throw new Error("Identifiant de stratégie introuvable dans la réponse.");
+        }
+        setStrategyId(String(createdId));
+        setStatus({ phase: "running", message: "Backtest en cours…" });
+        const runResponse = await fetch(runEndpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({
+            strategy_id: createdId,
+            symbol,
+            timeframe: formValues.timeframe,
+            lookback_days: formValues.lookbackDays,
+            initial_balance: formValues.initialBalance,
+            metadata,
+          }),
+        });
+        if (!runResponse.ok) {
+          const detail = await runResponse.json().catch(() => null);
+          const message = detail && detail.detail ? detail.detail : `HTTP ${runResponse.status}`;
+          throw new Error(
+            typeof message === "string"
+              ? message
+              : "Échec de l'exécution du backtest."
+          );
+        }
+        const runPayload = await runResponse.json();
+        const normalised = normaliseSummary(runPayload);
+        if (normalised) {
+          setLastRun(normalised);
+          setArtifacts(parseArtifacts(normalised.artifacts));
+        }
+        setStatus({ phase: "success", message: "Backtest exécuté avec succès." });
+        await loadHistory(String(createdId));
+      } catch (submitError) {
+        console.error("Impossible de lancer le backtest one-click", submitError);
+        setError(submitError);
+        setStatus({ phase: "error", message: "Une erreur est survenue." });
+      }
+    },
+    [canSubmit, formValues, loadHistory, runEndpoint, saveEndpoint]
+  );
+
+  useEffect(() => {
+    if (strategyId) {
+      loadHistory(strategyId);
+    }
+  }, [strategyId, loadHistory]);
+
+  return (
+    <div className="backtest-console">
+      <form className="backtest-console__form" onSubmit={handleSubmit}>
+        <div className="designer-field-grid">
+          <label className="designer-field">
+            <span className="designer-field__label text text--muted">Nom</span>
+            <input
+              type="text"
+              value={formValues.name}
+              onChange={(event) =>
+                setFormValues((prev) => ({ ...prev, name: event.target.value }))
+              }
+              placeholder="Stratégie tendance"
+            />
+          </label>
+          <label className="designer-field">
+            <span className="designer-field__label text text--muted">Actif</span>
+            <input
+              type="text"
+              value={formValues.symbol}
+              onChange={(event) =>
+                setFormValues((prev) => ({
+                  ...prev,
+                  symbol: event.target.value.toUpperCase(),
+                }))
+              }
+              placeholder="BTCUSDT"
+            />
+          </label>
+          <label className="designer-field">
+            <span className="designer-field__label text text--muted">Période</span>
+            <select
+              value={formValues.timeframe}
+              onChange={(event) =>
+                setFormValues((prev) => ({ ...prev, timeframe: event.target.value }))
+              }
+            >
+              {TIMEFRAME_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="designer-field">
+            <span className="designer-field__label text text--muted">Fenêtre (jours)</span>
+            <input
+              type="number"
+              min="1"
+              max="180"
+              value={formValues.lookbackDays}
+              onChange={(event) =>
+                setFormValues((prev) => ({
+                  ...prev,
+                  lookbackDays: Math.max(
+                    1,
+                    Number.parseInt(event.target.value, 10) || prev.lookbackDays
+                  ),
+                }))
+              }
+            />
+          </label>
+          <label className="designer-field">
+            <span className="designer-field__label text text--muted">Capital initial</span>
+            <input
+              type="number"
+              min="100"
+              step="100"
+              value={formValues.initialBalance}
+              onChange={(event) =>
+                setFormValues((prev) => ({
+                  ...prev,
+                  initialBalance:
+                    Number.parseFloat(event.target.value) || prev.initialBalance,
+                }))
+              }
+            />
+          </label>
+          <label className="designer-field">
+            <span className="designer-field__label text text--muted">MA courte</span>
+            <input
+              type="number"
+              min="1"
+              value={formValues.fastLength}
+              onChange={(event) =>
+                setFormValues((prev) => ({
+                  ...prev,
+                  fastLength: Math.max(
+                    1,
+                    Number.parseInt(event.target.value, 10) || prev.fastLength
+                  ),
+                }))
+              }
+            />
+          </label>
+          <label className="designer-field">
+            <span className="designer-field__label text text--muted">MA longue</span>
+            <input
+              type="number"
+              min={Number(formValues.fastLength) + 1}
+              value={formValues.slowLength}
+              onChange={(event) =>
+                setFormValues((prev) => ({
+                  ...prev,
+                  slowLength: Math.max(
+                    Number(prev.fastLength) + 1,
+                    Number.parseInt(event.target.value, 10) || prev.slowLength
+                  ),
+                }))
+              }
+            />
+          </label>
+          <label className="designer-field">
+            <span className="designer-field__label text text--muted">Taille de position</span>
+            <input
+              type="number"
+              min="0.001"
+              step="0.001"
+              value={formValues.positionSize}
+              onChange={(event) =>
+                setFormValues((prev) => ({
+                  ...prev,
+                  positionSize:
+                    Number.parseFloat(event.target.value) || prev.positionSize,
+                }))
+              }
+            />
+          </label>
+        </div>
+        <div className="backtest-console__actions">
+          <button
+            type="submit"
+            className="button button--primary"
+            disabled={status.phase === "saving" || status.phase === "running" || !canSubmit}
+          >
+            {status.phase === "saving"
+              ? "Enregistrement…"
+              : status.phase === "running"
+              ? "Backtest en cours…"
+              : "Enregistrer et backtester"}
+          </button>
+        </div>
+      </form>
+
+      {status.message && (
+        <div className="backtest-console__message" role="status">
+          {status.message}
+        </div>
+      )}
+      {error && (
+        <div className="backtest-console__error" role="alert">
+          {error.message || "Une erreur est survenue lors du backtest."}
+        </div>
+      )}
+
+      <section className="backtest-console__results" aria-labelledby="one-click-results">
+        <h3 id="one-click-results" className="heading heading--md">
+          Résultat du dernier backtest
+        </h3>
+        {!lastRun && (
+          <p className="text text--muted">
+            Lancez un backtest pour visualiser l'équity et les performances.
+          </p>
+        )}
+        {lastRun && (
+          <>
+            <ul className="backtest-console__metrics">
+              <li>
+                <strong>P&amp;L</strong>
+                <span>{formatCurrency(lastRun.pnl, currency)}</span>
+              </li>
+              <li>
+                <strong>Rendement</strong>
+                <span>{formatPercent(lastRun.total_return)}</span>
+              </li>
+              <li>
+                <strong>Max drawdown</strong>
+                <span>{formatPercent(lastRun.drawdown)}</span>
+              </li>
+            </ul>
+            {chartData.length > 0 ? (
+              <div className="backtest-console__chart" role="img" aria-label="Équity du backtest">
+                <ResponsiveContainer width="100%" height={240}>
+                  <LineChart data={chartData} margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="index" tickFormatter={(value) => `#${value}`} />
+                    <YAxis tickFormatter={(value) => formatCurrency(value, currency)} />
+                    <Tooltip
+                      formatter={(value) => formatCurrency(value, currency)}
+                      labelFormatter={(value) => `Point ${value}`}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="equity"
+                      stroke="#38bdf8"
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <p className="text text--muted">
+                Les données d'équity ne sont pas disponibles pour ce backtest.
+              </p>
+            )}
+            <section
+              className="backtest-console__artifacts"
+              aria-labelledby="one-click-artifacts"
+            >
+              <h4 id="one-click-artifacts" className="heading heading--md">
+                Artefacts
+              </h4>
+              {artifacts.length === 0 ? (
+                <p className="text text--muted">
+                  Aucun artefact disponible pour ce backtest.
+                </p>
+              ) : (
+                <ul className="backtest-console__history-list">
+                  {artifacts.map((artifact, index) => (
+                    <li key={`${artifact.type}-${index}`}>
+                      <div>
+                        <strong>{artifact.type}</strong>
+                        {artifact.path && (
+                          <span className="text text--muted"> — {artifact.path}</span>
+                        )}
+                      </div>
+                      <pre className="designer-preview">
+                        {typeof artifact.content === "object"
+                          ? JSON.stringify(artifact.content, null, 2)
+                          : String(artifact.content || "")}
+                      </pre>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </>
+        )}
+      </section>
+
+      <section className="backtest-console__history" aria-labelledby="one-click-history">
+        <h3 id="one-click-history" className="heading heading--md">
+          Historique des backtests
+        </h3>
+        {historyStatus === "error" && (
+          <p className="text text--muted" role="alert">
+            Impossible de charger l'historique pour le moment.
+          </p>
+        )}
+        {history.items.length === 0 && historyStatus !== "error" ? (
+          <p className="text text--muted">
+            Aucun backtest enregistré pour cette stratégie.
+          </p>
+        ) : (
+          <ul className="backtest-console__history-list" aria-live="polite">
+            {history.items.map((item) => (
+              <li key={`${item.id || item.ran_at}`}> 
+                <div>
+                  <strong>
+                    {item.metadata && item.metadata.symbol
+                      ? item.metadata.symbol
+                      : "Backtest"}
+                  </strong>
+                  <span className="text text--muted">
+                    {item.ran_at ? ` — ${new Date(item.ran_at).toLocaleString()}` : ""}
+                  </span>
+                </div>
+                <div className="backtest-console__history-metrics">
+                  <span>{formatCurrency(item.pnl, currency)}</span>
+                  <span>{formatPercent(item.total_return)}</span>
+                  {item.id && (
+                    <button
+                      type="button"
+                      className="button button--secondary"
+                      onClick={() => handleSelectBacktest(item.id)}
+                    >
+                      Voir
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default OneClickStrategyBuilder;

--- a/services/web_dashboard/src/strategies/simple/index.js
+++ b/services/web_dashboard/src/strategies/simple/index.js
@@ -1,0 +1,1 @@
+export { default as OneClickStrategyBuilder } from "./OneClickStrategyBuilder.jsx";

--- a/services/web_dashboard/tests/test_strategy_one_click.py
+++ b/services/web_dashboard/tests/test_strategy_one_click.py
@@ -1,0 +1,94 @@
+import json
+import pytest
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from .utils import load_dashboard_app
+
+respx = pytest.importorskip("respx")
+
+
+def _load_main_module():
+    load_dashboard_app()
+    return __import__("web_dashboard.app.main", fromlist=["app"])
+
+
+@respx.mock
+def test_save_strategy_structured_payload(monkeypatch):
+    main_module = _load_main_module()
+    monkeypatch.setattr(main_module, "ALGO_ENGINE_BASE_URL", "http://algo.local/")
+    route = respx.post("http://algo.local/strategies").mock(
+        return_value=Response(201, json={"id": "strat-1", "status": "created"})
+    )
+    client = TestClient(load_dashboard_app())
+    payload = {
+        "name": "Stratégie rapide",
+        "strategy_type": "declarative",
+        "parameters": {"definition": {"rules": []}},
+        "metadata": {"symbol": "BTCUSDT"},
+        "enabled": False,
+        "tags": ["one-click"],
+    }
+
+    response = client.post("/strategies/save", json=payload)
+
+    assert response.status_code == 200
+    assert route.called
+    forwarded = json.loads(route.calls.last.request.content)
+    assert forwarded["name"] == "Stratégie rapide"
+    assert forwarded["strategy_type"] == "declarative"
+    assert forwarded["metadata"]["symbol"] == "BTCUSDT"
+
+
+@respx.mock
+def test_backtest_run_proxy_and_detail(monkeypatch):
+    main_module = _load_main_module()
+    monkeypatch.setattr(main_module, "ALGO_ENGINE_BASE_URL", "http://algo.local/")
+
+    run_route = respx.post("http://algo.local/backtests").mock(
+        return_value=Response(
+            201,
+            json={
+                "id": 42,
+                "strategy_id": "strat-1",
+                "equity_curve": [1000, 1010],
+                "profit_loss": 10,
+                "artifacts": [],
+            },
+        )
+    )
+    detail_route = respx.get("http://algo.local/backtests/42").mock(
+        return_value=Response(
+            200,
+            json={"id": 42, "strategy_id": "strat-1", "artifacts": []},
+        )
+    )
+
+    client = TestClient(load_dashboard_app())
+    run_payload = {
+        "strategy_id": "strat-1",
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "lookback_days": 30,
+        "initial_balance": 10_000,
+        "metadata": {"fast_length": 5, "slow_length": 20},
+    }
+
+    response = client.post("/backtests/run", json=run_payload)
+    assert response.status_code == 200
+    assert run_route.called
+    forwarded = json.loads(run_route.calls.last.request.content)
+    assert forwarded["strategy_id"] == "strat-1"
+    assert forwarded["metadata"]["symbol"] == "BTCUSDT"
+    assert isinstance(forwarded.get("market_data"), list)
+
+    detail_response = client.get("/backtests/42")
+    assert detail_response.status_code == 200
+    assert detail_route.called
+
+
+def test_render_one_click_page_contains_root():
+    client = TestClient(load_dashboard_app())
+    response = client.get("/strategies/new")
+    assert response.status_code == 200
+    assert "strategy-one-click-root" in response.text


### PR DESCRIPTION
## Summary
- expose dedicated `/backtests` API endpoints in the algo engine with artifact support
- add a one-click strategy creation page with a React builder and new backtest proxy endpoints
- cover the new workflow with targeted unit tests for both services

## Testing
- pytest services/algo_engine/tests/test_backtests.py
- pytest services/web_dashboard/tests/test_strategy_one_click.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb65a74b08332a53810369a0fbfdc