### PR TITLE
Align web dashboard service URLs with compose hostnames

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -319,6 +319,9 @@ services:
       WEB_DASHBOARD_REPORTS_TIMEOUT: "5.0"
       WEB_DASHBOARD_ALERT_ENGINE_URL: http://alert_engine:8000
       WEB_DASHBOARD_ALERT_ENGINE_TIMEOUT: "5.0"
+      WEB_DASHBOARD_AUTH_SERVICE_URL: http://auth_service:8000/
+      WEB_DASHBOARD_ALGO_ENGINE_URL: http://algo_engine:8000/
+      WEB_DASHBOARD_ORDER_ROUTER_BASE_URL: http://order_router:8000/
       WEB_DASHBOARD_ALERTS_TOKEN: ${WEB_DASHBOARD_ALERTS_TOKEN:-demo-alerts-token}
       WEB_DASHBOARD_ALERT_EVENTS_DATABASE_URL: sqlite:////data/alert_events.db
     depends_on:

--- a/services/web_dashboard/app/data.py
+++ b/services/web_dashboard/app/data.py
@@ -52,11 +52,11 @@ REPORTS_BASE_URL = os.getenv("WEB_DASHBOARD_REPORTS_BASE_URL", "http://reports:8
 REPORTS_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_REPORTS_TIMEOUT", "5.0"))
 ORCHESTRATOR_BASE_URL = os.getenv(
     "WEB_DASHBOARD_ORCHESTRATOR_BASE_URL",
-    "http://algo-engine:8000/",
+    "http://algo_engine:8000/",
 )
 ORCHESTRATOR_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_ORCHESTRATOR_TIMEOUT", "5.0"))
 MAX_LOG_ENTRIES = int(os.getenv("WEB_DASHBOARD_MAX_LOG_ENTRIES", "100"))
-ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alert-engine:8000/")
+ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alert_engine:8000/")
 ALERT_ENGINE_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_ALERT_ENGINE_TIMEOUT", "5.0"))
 MAX_ALERTS = int(os.getenv("WEB_DASHBOARD_MAX_ALERTS", "20"))
 INPLAY_BASE_URL = os.getenv("WEB_DASHBOARD_INPLAY_BASE_URL", "http://inplay:8000/")
@@ -73,7 +73,7 @@ INPLAY_DEGRADED_MESSAGE = (
     "Flux InPlay partiellement disponible : certains instantanés proviennent du cache."
 )
 
-ORDER_ROUTER_BASE_URL = os.getenv("WEB_DASHBOARD_ORDER_ROUTER_BASE_URL", "http://order-router:8000/")
+ORDER_ROUTER_BASE_URL = os.getenv("WEB_DASHBOARD_ORDER_ROUTER_BASE_URL", "http://order_router:8000/")
 ORDER_ROUTER_TIMEOUT_SECONDS = float(
     os.getenv("WEB_DASHBOARD_ORDER_ROUTER_TIMEOUT", "5.0")
 )

--- a/services/web_dashboard/app/main.py
+++ b/services/web_dashboard/app/main.py
@@ -95,19 +95,19 @@ def _template_context(request: Request, extra: dict[str, object] | None = None) 
 STREAMING_BASE_URL = os.getenv("WEB_DASHBOARD_STREAMING_BASE_URL", "http://localhost:8001/")
 STREAMING_ROOM_ID = os.getenv("WEB_DASHBOARD_STREAMING_ROOM_ID", "public-room")
 STREAMING_VIEWER_ID = os.getenv("WEB_DASHBOARD_STREAMING_VIEWER_ID", "demo-viewer")
-ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alerts-engine:8000/")
+ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alert_engine:8000/")
 ALERT_ENGINE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_ALERT_ENGINE_TIMEOUT", "5.0"))
-ALGO_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALGO_ENGINE_URL", "http://algo-engine:8000/")
+ALGO_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALGO_ENGINE_URL", "http://algo_engine:8000/")
 ALGO_ENGINE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_ALGO_ENGINE_TIMEOUT", "5.0"))
 AI_ASSISTANT_BASE_URL = os.getenv(
     "WEB_DASHBOARD_AI_ASSISTANT_URL",
-    "http://ai-strategy-assistant:8085/",
+    "http://ai_strategy_assistant:8085/",
 )
 AI_ASSISTANT_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AI_ASSISTANT_TIMEOUT", "10.0"))
 DEFAULT_FOLLOWER_ID = os.getenv("WEB_DASHBOARD_DEFAULT_FOLLOWER_ID", "demo-investor")
 USER_SERVICE_BASE_URL = os.getenv(
     "WEB_DASHBOARD_USER_SERVICE_URL",
-    os.getenv("USER_SERVICE_URL", "http://user-service:8000/"),
+    os.getenv("USER_SERVICE_URL", "http://user_service:8000/"),
 )
 USER_SERVICE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_USER_SERVICE_TIMEOUT", "5.0"))
 USER_SERVICE_JWT_SECRET = os.getenv(
@@ -131,7 +131,7 @@ def _env_bool(value: str | None, default: bool) -> bool:
 
 AUTH_SERVICE_BASE_URL = os.getenv(
     "WEB_DASHBOARD_AUTH_SERVICE_URL",
-    os.getenv("AUTH_SERVICE_URL", "http://auth-service:8011/"),
+    os.getenv("AUTH_SERVICE_URL", "http://auth_service:8000/"),
 )
 AUTH_SERVICE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AUTH_SERVICE_TIMEOUT", "5.0"))
 AUTH_PUBLIC_BASE_URL = os.getenv("AUTH_BASE_URL") or AUTH_SERVICE_BASE_URL


### PR DESCRIPTION
## Summary
- update the web dashboard FastAPI defaults to use underscore compose hostnames for the auth, algo, alert, AI assistant, and user services
- align the dashboard data module defaults for orchestrator, alert engine, and order router services with the compose hostnames
- expose the dashboard service URLs in docker-compose so the container picks up the same defaults

## Testing
- pytest services/web_dashboard/tests/test_account_register.py *(fails: existing assertions for register form markup and mocked auth responses)*
- pytest services/web_dashboard/tests/test_status_page.py *(fails: RESPX mock missing for reports health endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbfff5200833285d1295056bafa38