### PR TITLE
Normalize auth service root path handling

### DIFF
--- a/services/auth_service/app/main.py
+++ b/services/auth_service/app/main.py
@@ -39,6 +39,23 @@ from libs.observability.metrics import setup_metrics
 configure_logging("auth-service")
 
 
+def _normalise_root_path(path: str | None) -> str:
+    """Ensure the configured root path is well-formed for FastAPI."""
+
+    if not path:
+        return ""
+
+    normalised = path.strip()
+    if not normalised:
+        return ""
+
+    normalised = normalised.strip("/")
+    if not normalised:
+        return "/"
+
+    return f"/{normalised}"
+
+
 def _auth_path(*segments: str) -> str:
     """Join one or more path segments onto the "/auth" prefix."""
 
@@ -93,7 +110,7 @@ def _get_enable_docs() -> bool:
 
 
 ENABLE_DOCS = _get_enable_docs()
-ROOT_PATH = os.getenv("ROOT_PATH", "")
+ROOT_PATH = _normalise_root_path(os.getenv("ROOT_PATH"))
 docs_url = "/docs" if ENABLE_DOCS else None
 redoc_url = "/redoc" if ENABLE_DOCS else None
 openapi_url = "/openapi.json" if ENABLE_DOCS else None

--- a/services/auth_service/tests/test_app_initialisation.py
+++ b/services/auth_service/tests/test_app_initialisation.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from services.auth_service.app.main import app
+
+
+def test_health_endpoint_is_available() -> None:
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": "auth_service"}

--- a/services/auth_service/tests/test_contract_auth.py
+++ b/services/auth_service/tests/test_contract_auth.py
@@ -67,7 +67,7 @@ def test_openapi_document_is_valid(api_schema):
 
 def test_contract_flows_cover_totp_cycle(client, session_factory, api_schema):
     email = f"contract-{secrets.token_hex(4)}@example.com"
-    password = "Passw0rd!"
+    password = "Passw0rd!xyz"
 
     register_payload = {"email": email, "password": password}
     register_response = client.post("/auth/register", json=register_payload)


### PR DESCRIPTION
## Summary
- add a local _normalise_root_path helper and normalise the configured root path before creating the FastAPI app
- add a regression test that instantiates the auth service app and asserts the /health endpoint responds successfully
- update the TOTP contract test to use a password that satisfies the documented password policy

## Testing
- pytest services/auth_service/tests

------
https://chatgpt.com/codex/tasks/task_e_68dfbffd8b708332bf5f77d5ca14d793