### PR TITLE
Remove duplicate Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,6 @@ web_dashboard-e2e:
 	python -m playwright install --with-deps chromium firefox
 	python -m pytest services/web_dashboard/tests/e2e
 
-fix-makefile:
-	@python scripts/dev/fix_make_tabs.py Makefile
-
-# lance bootstrap dans le conteneur (robuste)
-demo-bootstrap:
-	docker compose exec auth_service python /app/scripts/dev/bootstrap_demo.py BTCUSDT 0.25 --order-type market
 
 migrate-generate:
 	@if [ -z "$(message)" ]; then \


### PR DESCRIPTION
## Summary
- remove the duplicate `fix-makefile` and `demo-bootstrap` target definitions from the Makefile to eliminate redundant executions

## Testing
- make fix-makefile
- make demo-bootstrap *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc24d022c8332938fe841691a74aa