### PR TITLE
chore(web-dashboard): allow overriding native host

### DIFF
--- a/.env.native
+++ b/.env.native
@@ -10,3 +10,19 @@ RABBITMQ_URL=amqp://guest:guest@localhost:5672//
 PYTHONPATH=/app
 JWT_SECRET=dev-secret-change-me
 JWT_ALGO=HS256
+
+# Web dashboard + FastAPI service URLs for native development
+# Override WEB_DASHBOARD_NATIVE_HOST when localhost isn't reachable directly
+# (for example when accessing the stack via Tailscale or a reverse proxy).
+WEB_DASHBOARD_AUTH_SERVICE_URL=http://localhost:8011/
+AUTH_BASE_URL=http://localhost:8011/
+WEB_DASHBOARD_USER_SERVICE_URL=http://localhost:8012/
+WEB_DASHBOARD_ORDER_ROUTER_BASE_URL=http://localhost:8013/
+ORDER_ROUTER_BASE_URL=http://localhost:8013
+WEB_DASHBOARD_ALGO_ENGINE_URL=http://localhost:8014/
+ALGO_ENGINE_BASE_URL=http://localhost:8014
+MARKET_DATA_BASE_URL=http://localhost:8015
+WEB_DASHBOARD_REPORTS_BASE_URL=http://localhost:8016/
+REPORTS_BASE_URL=http://localhost:8016
+WEB_DASHBOARD_ALERT_ENGINE_URL=http://localhost:8017/
+

--- a/README.md
+++ b/README.md
@@ -104,6 +104,23 @@ Both the configuration service and the shared helpers use the
 `DATABASE_URL`, `REDIS_URL` and `RABBITMQ_URL` to target `localhost` while the
 Docker-based environments keep pointing at the internal container hostnames.
 
+The native `.env` also ships overrides for the web dashboard proxies so FastAPI
+targets the host services directly:
+
+- `WEB_DASHBOARD_AUTH_SERVICE_URL` / `AUTH_BASE_URL` → `http://localhost:8011`
+- `WEB_DASHBOARD_USER_SERVICE_URL` → `http://localhost:8012`
+- `WEB_DASHBOARD_ORDER_ROUTER_BASE_URL` / `ORDER_ROUTER_BASE_URL` →
+  `http://localhost:8013`
+- `WEB_DASHBOARD_ALGO_ENGINE_URL` / `ALGO_ENGINE_BASE_URL` →
+  `http://localhost:8014`
+- `MARKET_DATA_BASE_URL` → `http://localhost:8015`
+- `WEB_DASHBOARD_REPORTS_BASE_URL` / `REPORTS_BASE_URL` →
+  `http://localhost:8016`
+- `WEB_DASHBOARD_ALERT_ENGINE_URL` → `http://localhost:8017`
+- *(Optional)* `WEB_DASHBOARD_NATIVE_HOST` lets you swap `localhost` for a
+  custom host (for example when using Tailscale or a reverse proxy while still
+  running `ENVIRONMENT=native`).
+
 ### Demo Trading Stack
 
 To explore the monitoring and alerting services together, start the full demo stack:

--- a/services/web_dashboard/app/config.py
+++ b/services/web_dashboard/app/config.py
@@ -1,0 +1,62 @@
+"""Shared configuration helpers for the web dashboard service."""
+
+from __future__ import annotations
+
+import os
+
+from libs.env import is_native_environment
+
+
+def _ensure_trailing_slash(value: str, *, trailing_slash: bool) -> str:
+    """Normalise trailing slashes according to the desired style."""
+
+    trimmed = value.rstrip("/")
+    if trailing_slash:
+        return f"{trimmed}/"
+    return trimmed
+
+
+def _native_base_url(*, port: int, scheme: str = "http") -> str:
+    """Return the native base URL for the provided ``port``.
+
+    The hostname can be overridden via ``WEB_DASHBOARD_NATIVE_HOST`` when the
+    default ``localhost`` resolution is not desirable (e.g. containerised proxy
+    setups or Windows/WSL). Empty values fallback to ``localhost`` to avoid
+    returning malformed URLs.
+    """
+
+    host = os.getenv("WEB_DASHBOARD_NATIVE_HOST", "localhost").strip() or "localhost"
+    return f"{scheme}://{host}:{port}"
+
+
+def default_service_url(
+    container_url: str,
+    *,
+    native_port: int,
+    trailing_slash: bool = True,
+    native_scheme: str = "http",
+) -> str:
+    """Return a sane service URL depending on the current environment.
+
+    Parameters
+    ----------
+    container_url:
+        Default URL used when the stack runs inside Docker.
+    native_port:
+        Host port exposed by the docker-compose stack. When the environment is
+        marked as ``native`` we point the dashboard to ``WEB_DASHBOARD_NATIVE_HOST``
+        (``localhost`` by default).
+    trailing_slash:
+        Whether the returned URL should keep a trailing slash.
+    native_scheme:
+        Scheme used for native URLs. ``http`` works for most localhost setups
+        but can be overridden for HTTPS forwarders.
+
+    """
+
+    if is_native_environment():
+        return _ensure_trailing_slash(
+            _native_base_url(port=native_port, scheme=native_scheme),
+            trailing_slash=trailing_slash,
+        )
+    return _ensure_trailing_slash(container_url, trailing_slash=trailing_slash)

--- a/services/web_dashboard/app/data.py
+++ b/services/web_dashboard/app/data.py
@@ -46,17 +46,26 @@ from .schemas import (
 )
 
 
+from .config import default_service_url
+
+
 logger = logging.getLogger(__name__)
 
-REPORTS_BASE_URL = os.getenv("WEB_DASHBOARD_REPORTS_BASE_URL", "http://reports:8000/")
+REPORTS_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_REPORTS_BASE_URL",
+    default_service_url("http://reports:8000/", native_port=8016),
+)
 REPORTS_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_REPORTS_TIMEOUT", "5.0"))
 ORCHESTRATOR_BASE_URL = os.getenv(
     "WEB_DASHBOARD_ORCHESTRATOR_BASE_URL",
-    "http://algo_engine:8000/",
+    default_service_url("http://algo_engine:8000/", native_port=8014),
 )
 ORCHESTRATOR_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_ORCHESTRATOR_TIMEOUT", "5.0"))
 MAX_LOG_ENTRIES = int(os.getenv("WEB_DASHBOARD_MAX_LOG_ENTRIES", "100"))
-ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alert_engine:8000/")
+ALERT_ENGINE_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_ALERT_ENGINE_URL",
+    default_service_url("http://alert_engine:8000/", native_port=8017),
+)
 ALERT_ENGINE_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_ALERT_ENGINE_TIMEOUT", "5.0"))
 MAX_ALERTS = int(os.getenv("WEB_DASHBOARD_MAX_ALERTS", "20"))
 INPLAY_BASE_URL = os.getenv("WEB_DASHBOARD_INPLAY_BASE_URL", "http://inplay:8000/")
@@ -73,7 +82,10 @@ INPLAY_DEGRADED_MESSAGE = (
     "Flux InPlay partiellement disponible : certains instantanés proviennent du cache."
 )
 
-ORDER_ROUTER_BASE_URL = os.getenv("WEB_DASHBOARD_ORDER_ROUTER_BASE_URL", "http://order_router:8000/")
+ORDER_ROUTER_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_ORDER_ROUTER_BASE_URL",
+    default_service_url("http://order_router:8000/", native_port=8013),
+)
 ORDER_ROUTER_TIMEOUT_SECONDS = float(
     os.getenv("WEB_DASHBOARD_ORDER_ROUTER_TIMEOUT", "5.0")
 )

--- a/services/web_dashboard/app/main.py
+++ b/services/web_dashboard/app/main.py
@@ -33,6 +33,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from libs.alert_events import AlertEventBase, AlertEventRepository
 
+from .config import default_service_url
 from .data import (
     MARKETPLACE_BASE_URL,
     MARKETPLACE_TIMEOUT_SECONDS,
@@ -92,12 +93,20 @@ def _template_context(request: Request, extra: dict[str, object] | None = None) 
         context.update(extra)
     return context
 
-STREAMING_BASE_URL = os.getenv("WEB_DASHBOARD_STREAMING_BASE_URL", "http://localhost:8001/")
+STREAMING_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_STREAMING_BASE_URL", "http://localhost:8001/"
+)
 STREAMING_ROOM_ID = os.getenv("WEB_DASHBOARD_STREAMING_ROOM_ID", "public-room")
 STREAMING_VIEWER_ID = os.getenv("WEB_DASHBOARD_STREAMING_VIEWER_ID", "demo-viewer")
-ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alert_engine:8000/")
+ALERT_ENGINE_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_ALERT_ENGINE_URL",
+    default_service_url("http://alert_engine:8000/", native_port=8017),
+)
 ALERT_ENGINE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_ALERT_ENGINE_TIMEOUT", "5.0"))
-ALGO_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALGO_ENGINE_URL", "http://algo_engine:8000/")
+ALGO_ENGINE_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_ALGO_ENGINE_URL",
+    default_service_url("http://algo_engine:8000/", native_port=8014),
+)
 ALGO_ENGINE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_ALGO_ENGINE_TIMEOUT", "5.0"))
 AI_ASSISTANT_BASE_URL = os.getenv(
     "WEB_DASHBOARD_AI_ASSISTANT_URL",
@@ -107,7 +116,10 @@ AI_ASSISTANT_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AI_ASSISTANT_TIMEOUT", "10
 DEFAULT_FOLLOWER_ID = os.getenv("WEB_DASHBOARD_DEFAULT_FOLLOWER_ID", "demo-investor")
 USER_SERVICE_BASE_URL = os.getenv(
     "WEB_DASHBOARD_USER_SERVICE_URL",
-    os.getenv("USER_SERVICE_URL", "http://user_service:8000/"),
+    os.getenv(
+        "USER_SERVICE_URL",
+        default_service_url("http://user_service:8000/", native_port=8012),
+    ),
 )
 USER_SERVICE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_USER_SERVICE_TIMEOUT", "5.0"))
 USER_SERVICE_JWT_SECRET = os.getenv(
@@ -129,7 +141,9 @@ def _env_bool(value: str | None, default: bool) -> bool:
     return default
 
 
-AUTH_SERVICE_DEFAULT_BASE_URL = "http://auth_service:8000/"
+AUTH_SERVICE_DEFAULT_BASE_URL = default_service_url(
+    "http://auth_service:8000/", native_port=8011
+)
 AUTH_SERVICE_BASE_URL = (
     os.getenv("WEB_DASHBOARD_AUTH_SERVICE_URL")
     or os.getenv("AUTH_SERVICE_URL")

--- a/services/web_dashboard/app/routes/account.py
+++ b/services/web_dashboard/app/routes/account.py
@@ -10,6 +10,8 @@ from fastapi import APIRouter, Form, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
+from ..config import default_service_url
+
 router = APIRouter(tags=["Account"])
 
 TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
@@ -18,7 +20,9 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 AUTH_BASE_URL = (
     os.getenv("AUTH_BASE_URL")
     or os.getenv("AUTH_SERVICE_URL")
-    or "http://auth_service:8000"
+    or default_service_url(
+        "http://auth_service:8000", native_port=8011, trailing_slash=False
+    )
 )
 AUTH_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AUTH_SERVICE_TIMEOUT", "10.0"))
 

--- a/services/web_dashboard/app/routes/status.py
+++ b/services/web_dashboard/app/routes/status.py
@@ -10,6 +10,8 @@ from fastapi import APIRouter, Request, status as http_status
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from ..config import default_service_url
+
 router = APIRouter(tags=["Status"])
 
 TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
@@ -17,13 +19,32 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 AUTH_BASE_URL = (
     os.getenv("AUTH_BASE_URL")
+    or os.getenv("WEB_DASHBOARD_AUTH_SERVICE_URL")
     or os.getenv("AUTH_SERVICE_URL")
-    or "http://auth_service:8000"
+    or default_service_url(
+        "http://auth_service:8000", native_port=8011, trailing_slash=False
+    )
 )
-REPORTS_BASE_URL = os.getenv("REPORTS_BASE_URL", "http://reports:8000")
-ALGO_BASE_URL = os.getenv("ALGO_ENGINE_BASE_URL", "http://algo_engine:8000")
-ROUTER_BASE_URL = os.getenv("ORDER_ROUTER_BASE_URL", "http://order_router:8000")
-MARKET_BASE_URL = os.getenv("MARKET_DATA_BASE_URL", "http://market_data:8000")
+REPORTS_BASE_URL = (
+    os.getenv("REPORTS_BASE_URL")
+    or os.getenv("WEB_DASHBOARD_REPORTS_BASE_URL")
+    or default_service_url("http://reports:8000", native_port=8016, trailing_slash=False)
+)
+ALGO_BASE_URL = (
+    os.getenv("ALGO_ENGINE_BASE_URL")
+    or os.getenv("WEB_DASHBOARD_ALGO_ENGINE_URL")
+    or default_service_url("http://algo_engine:8000", native_port=8014, trailing_slash=False)
+)
+ROUTER_BASE_URL = (
+    os.getenv("ORDER_ROUTER_BASE_URL")
+    or os.getenv("WEB_DASHBOARD_ORDER_ROUTER_BASE_URL")
+    or default_service_url("http://order_router:8000", native_port=8013, trailing_slash=False)
+)
+MARKET_BASE_URL = (
+    os.getenv("MARKET_DATA_BASE_URL")
+    or os.getenv("WEB_DASHBOARD_MARKETPLACE_URL")
+    or default_service_url("http://market_data:8000", native_port=8015, trailing_slash=False)
+)
 STATUS_TIMEOUT = float(os.getenv("WEB_DASHBOARD_STATUS_TIMEOUT", "5.0"))
 
 


### PR DESCRIPTION
## Summary
- reuse the shared environment helper to pick localhost overrides and expose a `WEB_DASHBOARD_NATIVE_HOST` escape hatch
- document the optional host override in the native development instructions and sample env file
- make the status health checks honour the dashboard-specific base URL overrides when running natively

## Testing
- `pytest services/web_dashboard/tests/test_status_page.py -q` *(fails: existing template assertions expect different French copy)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc324ae388332af2fcddbeb9c3556