### PR TITLE
Add account registration form and routes to web dashboard

### DIFF
--- a/services/web_dashboard/app/templates/account.html
+++ b/services/web_dashboard/app/templates/account.html
@@ -25,6 +25,12 @@
         <div class="account-fallback" aria-live="polite">
           <p class="text text--muted">{{ _('Activez JavaScript pour gérer votre session.') }}</p>
 
+          {% if request.query_params.get('created') %}
+          <p class="text text--muted" role="status">
+            {{ _('Votre compte a été créé avec succès. Connectez-vous pour accéder au tableau de bord.') }}
+          </p>
+          {% endif %}
+
           <section class="card" aria-labelledby="login-title-fallback">
             <div class="card__header">
               <h2 id="login-title-fallback" class="heading heading--lg">{{ _('Connexion') }}</h2>
@@ -44,6 +50,10 @@
                 </label>
                 <button type="submit" class="button button--primary">{{ _('Se connecter') }}</button>
               </form>
+              <p class="text text--muted">
+                {{ _('Pas encore de compte ?') }}
+                <a href="{{ request.url_for('render_account_register') }}">{{ _('Créer mon compte') }}</a>
+              </p>
             </div>
           </section>
 

--- a/services/web_dashboard/app/templates/account/register.html
+++ b/services/web_dashboard/app/templates/account/register.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="{{ current_language }}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ _('Créer un compte') }}</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="layout__header">
+      {% include "_navigation.html" %}
+      <h1 class="heading heading--xl">{{ _('Créer un compte utilisateur') }}</h1>
+      <p class="text text--muted">
+        {{ _('Inscrivez-vous pour accéder au tableau de bord, gérer vos stratégies et configurer vos clés API.') }}
+      </p>
+    </header>
+    <main class="layout__main layout__main--narrow">
+      <section class="card" aria-labelledby="register-title">
+        <div class="card__header">
+          <h2 id="register-title" class="heading heading--lg">{{ _('Inscription') }}</h2>
+          <p class="text text--muted">
+            {{ _('Renseignez une adresse e-mail valide et un mot de passe respectant nos exigences de sécurité.') }}
+          </p>
+        </div>
+        <div class="card__body">
+          <form class="form-grid" action="{{ request.url_for('submit_account_register') }}" method="post">
+            <label class="designer-field">
+              <span class="designer-field__label text text--muted">{{ _('Adresse e-mail') }}</span>
+              <input type="email" name="email" autocomplete="email" required value="{{ form_email }}" />
+            </label>
+            <label class="designer-field">
+              <span class="designer-field__label text text--muted">{{ _('Mot de passe') }}</span>
+              <input type="password" name="password" autocomplete="new-password" required />
+            </label>
+            {% if error_message %}
+            <p class="text text--critical" role="alert">{{ error_message }}</p>
+            {% endif %}
+            <button type="submit" class="button button--primary">{{ _('Créer mon compte') }}</button>
+          </form>
+          <p class="text text--muted">
+            {{ _('Déjà inscrit ?') }}
+            <a href="{{ request.url_for('render_account_login') }}">{{ _('Se connecter') }}</a>
+          </p>
+        </div>
+      </section>
+    </main>
+    <footer class="layout__footer">
+      <p class="text text--muted">
+        {{ _('Vos informations d\'identification sont chiffrées avant synchronisation avec nos services sécurisés.') }}
+      </p>
+    </footer>
+    <script id="i18n-bootstrap" type="application/json">
+      {{ i18n_bundle|tojson }}
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a reusable helper for building service URLs and support for registration payloads
- expose GET/POST /account/register that renders the signup form and calls the auth service
- provide the account registration template and update login page links for the new flow

## Testing
- pytest services/web_dashboard/tests/test_account_register.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd424ae708332bf9fb955d1dd1212