### PR TITLE
Refine web dashboard service defaults

### DIFF
--- a/services/web_dashboard/app/data.py
+++ b/services/web_dashboard/app/data.py
@@ -19,6 +19,7 @@ import httpx
 from schemas.order_router import OrderRecord
 from libs.portfolio import encode_portfolio_key, encode_position_key
 
+from .config import default_service_url
 from .order_router_client import OrderRouterClient, OrderRouterError
 from .schemas import (
     Alert,
@@ -48,7 +49,10 @@ from .schemas import (
 
 logger = logging.getLogger(__name__)
 
-REPORTS_BASE_URL = os.getenv("WEB_DASHBOARD_REPORTS_BASE_URL", "http://reports:8000/")
+REPORTS_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_REPORTS_BASE_URL",
+    f"{default_service_url('reports')}/",
+)
 REPORTS_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_REPORTS_TIMEOUT", "5.0"))
 ORCHESTRATOR_BASE_URL = os.getenv(
     "WEB_DASHBOARD_ORCHESTRATOR_BASE_URL",
@@ -73,13 +77,19 @@ INPLAY_DEGRADED_MESSAGE = (
     "Flux InPlay partiellement disponible : certains instantanés proviennent du cache."
 )
 
-ORDER_ROUTER_BASE_URL = os.getenv("WEB_DASHBOARD_ORDER_ROUTER_BASE_URL", "http://order_router:8000/")
+ORDER_ROUTER_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_ORDER_ROUTER_BASE_URL",
+    f"{default_service_url('order_router')}/",
+)
 ORDER_ROUTER_TIMEOUT_SECONDS = float(
     os.getenv("WEB_DASHBOARD_ORDER_ROUTER_TIMEOUT", "5.0")
 )
 ORDER_ROUTER_LOG_LIMIT = int(os.getenv("WEB_DASHBOARD_ORDER_LOG_LIMIT", "200"))
 MAX_TRANSACTIONS = int(os.getenv("WEB_DASHBOARD_MAX_TRANSACTIONS", "25"))
-MARKETPLACE_BASE_URL = os.getenv("WEB_DASHBOARD_MARKETPLACE_URL", "http://marketplace:8000/")
+MARKETPLACE_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_MARKETPLACE_URL",
+    f"{default_service_url('marketplace')}/",
+)
 MARKETPLACE_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_MARKETPLACE_TIMEOUT", "5.0"))
 FOLLOWER_FALLBACK_MESSAGE = (
     "Marketplace indisponible pour récupérer vos copies."

--- a/services/web_dashboard/app/main.py
+++ b/services/web_dashboard/app/main.py
@@ -51,6 +51,7 @@ from .data import (
 )
 from .order_router_client import OrderRouterClient, OrderRouterError
 from .alerts_client import AlertsEngineClient, AlertsEngineError
+from .config import default_service_url
 from .schemas import (
     Alert,
     AlertCreateRequest,
@@ -94,9 +95,15 @@ def _template_context(request: Request, extra: dict[str, object] | None = None) 
 STREAMING_BASE_URL = os.getenv("WEB_DASHBOARD_STREAMING_BASE_URL", "http://localhost:8001/")
 STREAMING_ROOM_ID = os.getenv("WEB_DASHBOARD_STREAMING_ROOM_ID", "public-room")
 STREAMING_VIEWER_ID = os.getenv("WEB_DASHBOARD_STREAMING_VIEWER_ID", "demo-viewer")
-ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alert_engine:8000/")
+ALERT_ENGINE_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_ALERT_ENGINE_URL",
+    f"{default_service_url('alert_engine')}/",
+)
 ALERT_ENGINE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_ALERT_ENGINE_TIMEOUT", "5.0"))
-ALGO_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALGO_ENGINE_URL", "http://algo_engine:8000/")
+ALGO_ENGINE_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_ALGO_ENGINE_URL",
+    f"{default_service_url('algo_engine')}/",
+)
 ALGO_ENGINE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_ALGO_ENGINE_TIMEOUT", "5.0"))
 AI_ASSISTANT_BASE_URL = os.getenv(
     "WEB_DASHBOARD_AI_ASSISTANT_URL",
@@ -106,7 +113,7 @@ AI_ASSISTANT_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AI_ASSISTANT_TIMEOUT", "10
 DEFAULT_FOLLOWER_ID = os.getenv("WEB_DASHBOARD_DEFAULT_FOLLOWER_ID", "demo-investor")
 USER_SERVICE_BASE_URL = os.getenv(
     "WEB_DASHBOARD_USER_SERVICE_URL",
-    os.getenv("USER_SERVICE_URL", "http://user_service:8000/"),
+    os.getenv("USER_SERVICE_URL", f"{default_service_url('user_service')}/"),
 )
 USER_SERVICE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_USER_SERVICE_TIMEOUT", "5.0"))
 USER_SERVICE_JWT_SECRET = os.getenv(
@@ -128,7 +135,7 @@ def _env_bool(value: str | None, default: bool) -> bool:
     return default
 
 
-AUTH_SERVICE_DEFAULT_BASE_URL = "http://auth_service:8000/"
+AUTH_SERVICE_DEFAULT_BASE_URL = f"{default_service_url('auth_service')}/"
 AUTH_SERVICE_BASE_URL = (
     os.getenv("WEB_DASHBOARD_AUTH_SERVICE_URL")
     or os.getenv("AUTH_SERVICE_URL")


### PR DESCRIPTION
## Summary
- add a reusable helper that builds service URLs compatible with native and docker hosts
- switch dashboard fallbacks for reports, order router, marketplace, auth, user, alert, and algo services to the helper to avoid hyphenated hostnames

## Testing
- pytest services/web_dashboard/tests/test_status_page.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd64a8054833284ae086446873e96