### PR TITLE
Align dashboard URLs with WEB_DASHBOARD environment variables

### DIFF
--- a/services/web_dashboard/app/main.py
+++ b/services/web_dashboard/app/main.py
@@ -111,9 +111,10 @@ AI_ASSISTANT_BASE_URL = os.getenv(
 )
 AI_ASSISTANT_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AI_ASSISTANT_TIMEOUT", "10.0"))
 DEFAULT_FOLLOWER_ID = os.getenv("WEB_DASHBOARD_DEFAULT_FOLLOWER_ID", "demo-investor")
+USER_SERVICE_DEFAULT_BASE_URL = f"{default_service_url('user_service')}/"
 USER_SERVICE_BASE_URL = os.getenv(
     "WEB_DASHBOARD_USER_SERVICE_URL",
-    os.getenv("USER_SERVICE_URL", f"{default_service_url('user_service')}/"),
+    USER_SERVICE_DEFAULT_BASE_URL,
 )
 USER_SERVICE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_USER_SERVICE_TIMEOUT", "5.0"))
 USER_SERVICE_JWT_SECRET = os.getenv(
@@ -136,13 +137,15 @@ def _env_bool(value: str | None, default: bool) -> bool:
 
 
 AUTH_SERVICE_DEFAULT_BASE_URL = f"{default_service_url('auth_service')}/"
-AUTH_SERVICE_BASE_URL = (
-    os.getenv("WEB_DASHBOARD_AUTH_SERVICE_URL")
-    or os.getenv("AUTH_SERVICE_URL")
-    or AUTH_SERVICE_DEFAULT_BASE_URL
+AUTH_SERVICE_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_AUTH_SERVICE_URL",
+    AUTH_SERVICE_DEFAULT_BASE_URL,
 )
 AUTH_SERVICE_TIMEOUT = float(os.getenv("WEB_DASHBOARD_AUTH_SERVICE_TIMEOUT", "5.0"))
-AUTH_PUBLIC_BASE_URL = os.getenv("AUTH_BASE_URL") or AUTH_SERVICE_BASE_URL
+AUTH_PUBLIC_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_AUTH_PUBLIC_URL",
+    AUTH_SERVICE_BASE_URL,
+)
 ACCESS_TOKEN_COOKIE_NAME = os.getenv("WEB_DASHBOARD_ACCESS_COOKIE", "dashboard_access_token")
 REFRESH_TOKEN_COOKIE_NAME = os.getenv("WEB_DASHBOARD_REFRESH_COOKIE", "dashboard_refresh_token")
 ACCESS_TOKEN_MAX_AGE = int(os.getenv("WEB_DASHBOARD_ACCESS_TOKEN_MAX_AGE", str(15 * 60)))

--- a/services/web_dashboard/tests/conftest.py
+++ b/services/web_dashboard/tests/conftest.py
@@ -130,7 +130,7 @@ def dashboard_app(user_service_base_url, auth_service_base_url):
     os.environ.setdefault("USER_SERVICE_JWT_SECRET", TEST_JWT_SECRET)
     os.environ.setdefault("WEB_DASHBOARD_DEFAULT_USER_ID", "1")
     os.environ.setdefault("WEB_DASHBOARD_AUTH_SERVICE_URL", auth_service_base_url)
-    os.environ.setdefault("AUTH_SERVICE_URL", auth_service_base_url)
+    os.environ.setdefault("WEB_DASHBOARD_AUTH_PUBLIC_URL", auth_service_base_url)
     os.environ.setdefault("WEB_DASHBOARD_ALGO_ENGINE_URL", "http://algo-engine:8000/")
     os.environ.setdefault("WEB_DASHBOARD_REPORTS_BASE_URL", "http://reports:8000/")
     os.environ.setdefault("WEB_DASHBOARD_ORDER_ROUTER_BASE_URL", "http://order-router:8000/")

--- a/services/web_dashboard/tests/test_account_register.py
+++ b/services/web_dashboard/tests/test_account_register.py
@@ -13,7 +13,7 @@ from .utils import load_dashboard_app
 @pytest.fixture()
 def client(monkeypatch):
     load_dashboard_app.cache_clear()
-    monkeypatch.setenv("AUTH_BASE_URL", "http://auth.local/")
+    monkeypatch.setenv("WEB_DASHBOARD_AUTH_PUBLIC_URL", "http://auth.local/")
     monkeypatch.setenv("WEB_DASHBOARD_AUTH_SERVICE_URL", "http://auth.local/")
     app = load_dashboard_app()
     module = importlib.import_module("web_dashboard.app.main")

--- a/services/web_dashboard/tests/test_status_page.py
+++ b/services/web_dashboard/tests/test_status_page.py
@@ -13,7 +13,7 @@ from .utils import load_dashboard_app
 @pytest.fixture()
 def client(monkeypatch):
     load_dashboard_app.cache_clear()
-    monkeypatch.setenv("AUTH_BASE_URL", "http://auth.local/")
+    monkeypatch.setenv("WEB_DASHBOARD_AUTH_PUBLIC_URL", "http://auth.local/")
     monkeypatch.setenv("WEB_DASHBOARD_AUTH_SERVICE_URL", "http://auth.local/")
     monkeypatch.setenv("WEB_DASHBOARD_REPORTS_BASE_URL", "http://reports.local/")
     monkeypatch.setenv("WEB_DASHBOARD_ALGO_ENGINE_URL", "http://algo.local/")


### PR DESCRIPTION
## Summary
- update the dashboard auth and user service URL configuration to rely solely on the WEB_DASHBOARD_* settings with sensible defaults
- support a dedicated WEB_DASHBOARD_AUTH_PUBLIC_URL fallback while keeping helper resolution intact
- adjust dashboard fixtures and tests to seed the new environment variables instead of the legacy names

## Testing
- pytest services/web_dashboard/tests/test_account_auth.py -q
- pytest services/web_dashboard/tests -q *(fails: missing playwright dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdb1b22f483329f327053aa595e4d