### PR TITLE
Use default service URLs for web dashboard fallbacks

### DIFF
--- a/services/web_dashboard/app/data.py
+++ b/services/web_dashboard/app/data.py
@@ -56,14 +56,20 @@ REPORTS_BASE_URL = os.getenv(
 REPORTS_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_REPORTS_TIMEOUT", "5.0"))
 ORCHESTRATOR_BASE_URL = os.getenv(
     "WEB_DASHBOARD_ORCHESTRATOR_BASE_URL",
-    "http://algo_engine:8000/",
+    f"{default_service_url('algo_engine')}/",
 )
 ORCHESTRATOR_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_ORCHESTRATOR_TIMEOUT", "5.0"))
 MAX_LOG_ENTRIES = int(os.getenv("WEB_DASHBOARD_MAX_LOG_ENTRIES", "100"))
-ALERT_ENGINE_BASE_URL = os.getenv("WEB_DASHBOARD_ALERT_ENGINE_URL", "http://alert_engine:8000/")
+ALERT_ENGINE_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_ALERT_ENGINE_URL",
+    f"{default_service_url('alert_engine')}/",
+)
 ALERT_ENGINE_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_ALERT_ENGINE_TIMEOUT", "5.0"))
 MAX_ALERTS = int(os.getenv("WEB_DASHBOARD_MAX_ALERTS", "20"))
-INPLAY_BASE_URL = os.getenv("WEB_DASHBOARD_INPLAY_BASE_URL", "http://inplay:8000/")
+INPLAY_BASE_URL = os.getenv(
+    "WEB_DASHBOARD_INPLAY_BASE_URL",
+    f"{default_service_url('inplay')}/",
+)
 INPLAY_TIMEOUT_SECONDS = float(os.getenv("WEB_DASHBOARD_INPLAY_TIMEOUT", "3.0"))
 INPLAY_WATCHLISTS = [
     watchlist.strip()


### PR DESCRIPTION
## Summary
- rely on the shared `default_service_url` helper for the orchestrator, alert engine, and in-play service fallbacks

## Testing
- pytest services/web_dashboard/tests -q *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68dfe3d192dc8332b5b1b6cc8cefc25b