### PR TITLE
Update auth service port mapping in override compose file

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,5 @@
 services:
   auth_service:
-    ports: ["8811:8000"]
+    ports: ["8011:8000"]
   web_dashboard:
     ports: ["8022:8000"]


### PR DESCRIPTION
## Summary
- update the auth_service port mapping in docker-compose.override.yml so the container is exposed on localhost:8011 as documented

## Testing
- make dev-up *(fails: docker: command not found in execution environment)*
- curl -f http://localhost:8011/health *(fails: connection refused because services are not running without Docker)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe7459cdc8332bc303959478b58fe