### PR TITLE
Configure Codespaces compose overrides for auth domains

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -10,9 +10,10 @@ PYTHONPATH=/app
 JWT_SECRET=dev-secret-change-me
 JWT_ALGO=HS256
 BROKER_CREDENTIALS_ENCRYPTION_KEY=DporwBLoKCv6He99t-KfX5zaFw6dfCfZy9I1z1c6Y_M=
-AUTH_SERVICE_ALLOWED_ORIGINS=https://cs-8022.app.github.dev,http://localhost:3000,http://localhost:8022
+# Codespaces users should run scripts/dev/codespaces_setup.sh to generate overrides.
+AUTH_SERVICE_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8022
 AUTH_SERVICE_ALLOW_CREDENTIALS=true
 AUTH_COOKIE_SAMESITE=None
-AUTH_COOKIE_SECURE=true
+AUTH_COOKIE_SECURE=false
 ENABLE_DOCS=true
 WEB_DASHBOARD_AUTH_SERVICE_URL=http://auth_service:8000/

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -1,5 +1,13 @@
 services:
   auth_service:
-    ports: ["8811:8000"]
+    ports:
+      - "{{AUTH_SERVICE_PORT}}:8000"
+    environment:
+      AUTH_SERVICE_ALLOWED_ORIGINS: "{{AUTH_SERVICE_ALLOWED_ORIGINS}}"
   web_dashboard:
-    ports: ["8022:8000"]
+    ports:
+      - "{{WEB_DASHBOARD_PORT}}:8000"
+    environment:
+      WEB_DASHBOARD_AUTH_SERVICE_URL: "{{WEB_DASHBOARD_AUTH_SERVICE_URL}}"
+      WEB_DASHBOARD_AUTH_COOKIE_SECURE: "{{WEB_DASHBOARD_AUTH_COOKIE_SECURE}}"
+      WEB_DASHBOARD_AUTH_COOKIE_DOMAIN: "{{WEB_DASHBOARD_AUTH_COOKIE_DOMAIN}}"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,13 @@
 services:
   auth_service:
-    ports: ["8011:8000"]
+    ports:
+      - "8811:8000"
+    environment:
+      AUTH_SERVICE_ALLOWED_ORIGINS: "http://localhost:8022,http://localhost:8811,https://*.app.github.dev"
   web_dashboard:
-    ports: ["8022:8000"]
+    ports:
+      - "8022:8000"
+    environment:
+      WEB_DASHBOARD_AUTH_SERVICE_URL: "http://localhost:8811"
+      WEB_DASHBOARD_AUTH_COOKIE_SECURE: "false"
+      WEB_DASHBOARD_AUTH_COOKIE_DOMAIN: ""


### PR DESCRIPTION
## Summary
- add the placeholder tokens that scripts/dev/codespaces_setup.sh replaces in docker-compose.codespaces.yml
- include the generated auth and cookie environment overrides in docker-compose.override.yml
- clean up .env.dev to default to local origins and point Codespaces users to the setup script

## Testing
- pytest services/web_dashboard/tests/test_account_auth.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e013624f3883328f1401933fba68ed