### PR TITLE
Add billing service to demo stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ native-down:
 	./scripts/dev/native_down.sh
 
 demo-up:
-	docker compose up -d postgres redis
-	docker compose up -d --build auth_service user_service streaming streaming_gateway market_data \
-		order_router algo_engine reports alert_engine notification_service inplay web_dashboard \
-		prometheus grafana
+        docker compose up -d postgres redis
+        docker compose up -d --build auth_service user_service billing_service streaming streaming_gateway market_data \
+                order_router algo_engine reports alert_engine notification_service inplay web_dashboard \
+                prometheus grafana
 
 demo-down:
 	docker compose down -v

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ export OPENAI_API_KEY="sk-your-key"
 ```
 
 **Available Services:**
+- `8005` — `billing-service` (Stripe-style subscription orchestration and webhook replay tools)
 - `8013` — `order-router` (execution plans and simulated brokers)
 - `8014` — `algo-engine` (strategy catalogue, backtesting, optional AI assistant on `/strategies/generate`)
 - `8015` — `market_data` (spot quotes, orderbooks and TradingView webhooks)
@@ -148,7 +149,7 @@ Once the stack is running you can exercise the full onboarding → trading journ
 scripts/dev/bootstrap_demo.py BTCUSDT 0.25 --order-type market
 ```
 
-The command provisions a demo account, assigns entitlements, configures a strategy, routes an order, generates a PDF report, registers an alert and publishes a streaming event. The emitted JSON summarises all created identifiers (user, strategy, order, alert, report location) together with the JWT tokens associated to the demo profile.
+The command provisions a demo account, assigns entitlements, configures a strategy, routes an order, generates a PDF report, registers an alert, books a mock subscription in the billing API (available at `http://localhost:8005`) and publishes a streaming event. The emitted JSON summarises all created identifiers (user, strategy, order, alert, report location) together with the JWT tokens associated to the demo profile.
 
 `scripts/dev/run_mvp_flow.py` now simply wraps this command for backward compatibility.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,28 @@ services:
     ports:
       - "8012:8000"
 
+  billing_service:
+    build:
+      context: .
+      dockerfile: infra/docker/fastapi-service.Dockerfile
+      args:
+        SERVICE_DIR: billing_service
+        SERVICE_PACKAGE: billing_service
+        SERVICE_MODULE: app.main
+    env_file:
+      - .env.dev
+    environment:
+      DATABASE_URL: postgresql+psycopg2://trading:trading@postgres:5432/trading
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - postgres
+      - redis
+    volumes:
+      - ./infra/migrations:/app/infra/migrations:ro
+      - ./scripts:/app/scripts:ro
+    ports:
+      - "8005:8000"
+
   order_router:
     build:
       context: .


### PR DESCRIPTION
## Summary
- add the billing_service container to docker-compose so it mirrors the other FastAPI APIs and expose port 8005
- include billing_service in the demo-up Make target and document the new endpoint in the README

## Testing
- python scripts/dev/bootstrap_demo.py BTCUSDT 0.25 --order-type market *(fails: connection refused because the demo stack is not running in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e02587d2408332a48cd192d33038b8