### PR TITLE
Clarify AI assistant activation defaults

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -46,7 +46,7 @@ trading-bot-open-source/
 
 | Domaine | Périmètre | Statut | Prérequis d'Activation |
 | --- | --- | --- | --- |
-| Stratégies & recherche | Strategy Designer visuel, imports déclaratifs, assistant IA, API de backtest | Livré (designer & backtests), Bêta opt-in (assistant) | `make demo-up`, `pip install -r services/algo_engine/requirements.txt`, `AI_ASSISTANT_ENABLED=1`, `OPENAI_API_KEY` |
+| Stratégies & recherche | Strategy Designer visuel, imports déclaratifs, assistant IA, API de backtest | Livré (designer & backtests), Bêta opt-in (assistant) | `make demo-up`, `pip install -r services/algo_engine/requirements.txt` (assistant activé par défaut), `OPENAI_API_KEY`; définissez `AI_ASSISTANT_ENABLED=0` pour le désactiver |
 | Trading & exécution | Routeur d'ordres sandbox, script bootstrap, connecteurs marché (Binance, IBKR, DTC) | Livré (sandbox + Binance/IBKR), Expérimental (DTC) | `scripts/dev/bootstrap_demo.py`, identifiants exchanges selon besoin |
 | Monitoring temps réel | Passerelle streaming, flux WebSocket InPlay, intégrations OBS/overlay | Livré (dashboard + alertes), Bêta (automatisation OBS) | Jetons de service (`reports`, `inplay`, `streaming`), secrets OAuth optionnels |
 | Reporting & analytics | API rapports quotidiens, exports PDF, métriques de risque | Livré (rapports), Enrichissement en cours (dashboards risque) | Répertoire `data/generated-reports/` accessible ; stack Prometheus/Grafana |
@@ -113,9 +113,17 @@ La commande construit les services FastAPI additionnels, applique les migrations
 
 ```bash
 pip install -r services/algo_engine/requirements.txt
-export AI_ASSISTANT_ENABLED=1
+# L'assistant s'active automatiquement une fois les dépendances installées.
+# Exportez AI_ASSISTANT_ENABLED=0 pour rester en mode sans assistant.
 export OPENAI_API_KEY="sk-votre-cle"
 ```
+
+> ℹ️ Installer `services/algo_engine/requirements.txt` ne fait que préparer les
+> dépendances de l'assistant. Le flag `AI_ASSISTANT_ENABLED` (lu dans
+> [`services/algo_engine/app/main.py`](services/algo_engine/app/main.py)) décide
+> ensuite du démarrage de la fonctionnalité. Laissez-le non défini pour garder le
+> comportement activé par défaut ou positionnez `AI_ASSISTANT_ENABLED=0` pour la
+> désactiver même avec les dépendances disponibles.
 
 **Services Disponibles :**
 - `8013` — `order-router` (plans d'exécution et courtiers simulés)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ trading-bot-open-source/
 
 | Domain | Scope | Status | Activation Prerequisites |
 | --- | --- | --- | --- |
-| Strategies & research | Visual Strategy Designer, declarative imports, AI assistant, backtesting API | Delivered (designer & backtests), Beta opt-in (assistant) | `make demo-up`, `pip install -r services/algo_engine/requirements.txt`, `AI_ASSISTANT_ENABLED=1`, `OPENAI_API_KEY` |
+| Strategies & research | Visual Strategy Designer, declarative imports, AI assistant, backtesting API | Delivered (designer & backtests), Beta opt-in (assistant) | `make demo-up`, `pip install -r services/algo_engine/requirements.txt` (assistant auto-enabled), `OPENAI_API_KEY`; set `AI_ASSISTANT_ENABLED=0` to disable |
 | Trading & execution | Sandbox order router, strategy bootstrap script, market connectors (Binance, IBKR, DTC stub) | Delivered (sandbox + Binance/IBKR), Experimental (DTC) | `scripts/dev/bootstrap_demo.py`, connector credentials when available |
 | Real-time monitoring | Streaming gateway, InPlay WebSocket feed, OBS/overlay integrations | Delivered (dashboard + alerts), Beta (OBS automation) | Service tokens (`reports`, `inplay`, `streaming`), optional OAuth secrets |
 | Reporting & analytics | Daily reports API, PDF exports, risk metrics | Delivered (reports), In progress (extended risk dashboards) | Ensure `data/generated-reports/` is writable; enable Prometheus/Grafana stack |
@@ -116,9 +116,17 @@ The command builds the additional FastAPI services, applies Alembic migrations a
 
 ```bash
 pip install -r services/algo_engine/requirements.txt
-export AI_ASSISTANT_ENABLED=1
+# Assistant runs by default once the optional dependencies are installed.
+# Export AI_ASSISTANT_ENABLED=0 to opt out if you prefer to keep it disabled.
 export OPENAI_API_KEY="sk-your-key"
 ```
+
+> ℹ️ Installing `services/algo_engine/requirements.txt` only makes the assistant
+> dependencies available; the runtime flag `AI_ASSISTANT_ENABLED` (read in
+> [`services/algo_engine/app/main.py`](services/algo_engine/app/main.py))
+> controls whether the feature starts. Leave it unset for the default enabled
+> behaviour or export `AI_ASSISTANT_ENABLED=0` to disable it even with the
+> dependencies present.
 
 **Available Services:**
 - `8005` — `billing-service` (Stripe-style subscription orchestration and webhook replay tools)

--- a/docs/algo-engine.md
+++ b/docs/algo-engine.md
@@ -7,7 +7,7 @@ Le service **Algo Engine** fournit un registre de stratégies extensible grâce 
 | Fonctionnalité | Statut | Prérequis |
 | --- | --- | --- |
 | Registre de stratégies & imports déclaratifs | ✅ Livré | `/strategies` et `/strategies/import` disponibles par défaut |
-| Assistant IA | 🟡 Bêta opt-in | `pip install -r services/algo-engine/requirements.txt`, `AI_ASSISTANT_ENABLED=1`, `OPENAI_API_KEY` |
+| Assistant IA | 🟡 Bêta opt-in | `pip install -r services/algo-engine/requirements.txt` (assistant activé par défaut), `OPENAI_API_KEY`; définissez `AI_ASSISTANT_ENABLED=0` pour le désactiver |
 | Backtests | ✅ Livré | Dossier `data/backtests/` accessible en écriture |
 | Visual Designer (via web-dashboard) | 🟡 Bêta | Service `web-dashboard` actif, tokens entitlements |
 
@@ -53,7 +53,19 @@ et ses dépendances (`langchain`, `langchain-openai`, `openai`, ...). Ces paquet
 sont maintenant déclarés dans `services/algo-engine/requirements.txt` afin que
 `pip install -r services/algo-engine/requirements.txt` prépare l'environnement.
 
-Le service reste néanmoins fonctionnel sans ces dépendances. Pour désactiver explicitement l'assistant, définissez `AI_ASSISTANT_ENABLED=0` avant de lancer `uvicorn app.main:app`. Grâce au module de bootstrap partagé (`services._bootstrap`) importé par chaque service FastAPI, cette commande fonctionne directement depuis `services/algo_engine`. Vous pouvez également utiliser le chemin de module complet : `uvicorn services.algo_engine.app.main:app`. Dans ce cas, `/strategies/generate` renverra un HTTP 503 indiquant que la fonctionnalité est désactivée. Le tutoriel `docs/tutorials/backtest-sandbox.ipynb` fournit un exemple d'appel complet.
+Le service reste néanmoins fonctionnel sans ces dépendances. Une fois les paquets
+installés, l'assistant démarre automatiquement sauf si le flag
+`AI_ASSISTANT_ENABLED` est positionné à `0` (voir
+[`services/algo_engine/app/main.py`](../services/algo_engine/app/main.py) pour la
+logique de lecture). Pour désactiver explicitement l'assistant, définissez
+`AI_ASSISTANT_ENABLED=0` avant de lancer `uvicorn app.main:app`. Grâce au module de
+bootstrap partagé (`services._bootstrap`) importé par chaque service FastAPI, cette
+commande fonctionne directement depuis `services/algo_engine`. Vous pouvez
+également utiliser le chemin de module complet :
+`uvicorn services.algo_engine.app.main:app`. Dans ce cas,
+`/strategies/generate` renverra un HTTP 503 indiquant que la fonctionnalité est
+désactivée. Le tutoriel `docs/tutorials/backtest-sandbox.ipynb` fournit un exemple
+d'appel complet.
 
 Le middleware d'entitlements vérifie la capacité `can.manage_strategies` et expose la limite de stratégies actives (`max_active_strategies`). L'orchestrateur interne applique les limites journalières.
 

--- a/docs/strategies/README.md
+++ b/docs/strategies/README.md
@@ -8,7 +8,7 @@ The algo engine now accepts declarative strategies that can be defined either in
 | --- | --- | --- |
 | Declarative imports | General availability | Available by default via `/strategies/import` |
 | Visual Strategy Designer | Beta in the web dashboard | Access `/strategies` route on `web-dashboard`; enable streaming tokens |
-| AI Strategy Assistant | Opt-in beta | `pip install -r services/algo-engine/requirements.txt`, set `AI_ASSISTANT_ENABLED=1`, `OPENAI_API_KEY` |
+| AI Strategy Assistant | Opt-in beta | `pip install -r services/algo-engine/requirements.txt` (assistant auto-enabled), `OPENAI_API_KEY`; set `AI_ASSISTANT_ENABLED=0` to disable |
 | Backtesting API | General availability | Ensure `data/backtests/` is writable; run via `/strategies/{id}/backtest` |
 
 ## Declarative schema
@@ -94,7 +94,7 @@ block validation remains consistent when adding new components.
 The `ai-strategy-assistant` microservice leverages LangChain and OpenAI to transform natural language prompts into declarative or Python strategies. This capability is opt-in and requires the following configuration before calling `/strategies/generate`:
 
 - Install optional dependencies via `pip install -r services/algo-engine/requirements.txt`.
-- Export `AI_ASSISTANT_ENABLED=1` for the algo engine service.
+- The assistant starts automatically once those dependencies are present; export `AI_ASSISTANT_ENABLED=0` if you want the algo engine to stay in non-assistant mode.
 - Provide a valid `OPENAI_API_KEY` to the assistant microservice.
 
 The algo engine exposes
@@ -114,8 +114,11 @@ payload to the algo engine.
 > ℹ️ **Runtime requirements** – Installing
 > `pip install -r services/algo-engine/requirements.txt` now pulls the optional
 > `langchain`, `langchain-openai` and `openai` dependencies needed by the assistant.
-> Set `AI_ASSISTANT_ENABLED=0` to boot the algo engine without the feature; in that
-> case `/strategies/generate` returns HTTP 503 with a clear message.
+> The feature is enabled by default once those packages are available; toggle it via
+> the `AI_ASSISTANT_ENABLED` environment flag handled in
+> [`services/algo_engine/app/main.py`](../../services/algo_engine/app/main.py). Set
+> `AI_ASSISTANT_ENABLED=0` to boot the algo engine without the feature; in that case
+> `/strategies/generate` returns HTTP 503 with a clear message.
 
 ## Simulation & artefacts
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -9,8 +9,11 @@ with contributors and customer-facing teams.
 - Scope: runs `scripts/dev/bootstrap_demo.py` end-to-end against the demo stack,
   inspects `data/backtests/` outputs and demonstrates how to import the generated
   strategy into the algo engine.
-- Prerequisites: `pip install -r services/algo-engine/requirements.txt` and set
-  `AI_ASSISTANT_ENABLED=1` to reuse assistant-powered drafts when needed.
+- Prerequisites: `pip install -r services/algo-engine/requirements.txt`
+  (assistant auto-enabled) and an `OPENAI_API_KEY`; export
+  `AI_ASSISTANT_ENABLED=0` if you prefer to keep the assistant disabled while
+  following the notebook. See [`services/algo_engine/app/main.py`](../../services/algo_engine/app/main.py)
+  for the environment flag logic.
 
 ## Strategy designer screencast
 


### PR DESCRIPTION
## Summary
- update activation prerequisite tables to explain the AI assistant is enabled by default once optional dependencies are installed and can be disabled with AI_ASSISTANT_ENABLED=0
- add notes in the READMEs and algo engine guide clarifying the difference between installing dependencies and toggling the environment flag, with references to the implementation in services/algo_engine/app/main.py
- align the strategies and tutorials guides with the new wording so they point to the same default-on behaviour

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e02c02a5b48332b494d91d6cb88129