### PR TITLE
Fix IBKR symbol search invocation

### DIFF
--- a/services/market_data/app/main.py
+++ b/services/market_data/app/main.py
@@ -169,6 +169,8 @@ async def list_symbols(
 
     async def _load() -> list[dict[str, Any]]:
         if hasattr(connector, "list_symbols"):
+            if isinstance(connector, IBKRMarketConnector):
+                return await connector.list_symbols(pattern=search, limit=limit)
             return await connector.list_symbols(search=search, limit=limit)
         raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Not supported")
 


### PR DESCRIPTION
## Summary
- fix the market data symbols handler to call the IBKR connector with the correct pattern argument

## Testing
- pytest services/market_data/tests/test_market_data_api.py -k symbols -q

------
https://chatgpt.com/codex/tasks/task_e_68e75df2b2c88332a8eec8c90ec0c29b