### PR TITLE
Fix status router env var usage

### DIFF
--- a/services/web_dashboard/app/routes/status.py
+++ b/services/web_dashboard/app/routes/status.py
@@ -17,13 +17,14 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 AUTH_BASE_URL = (
     os.getenv("AUTH_BASE_URL")
+    or os.getenv("WEB_DASHBOARD_AUTH_SERVICE_URL")
     or os.getenv("AUTH_SERVICE_URL")
-    or "http://auth_service:8000"
+    or "http://auth-service:8011/"
 )
-REPORTS_BASE_URL = os.getenv("REPORTS_BASE_URL", "http://reports:8000")
-ALGO_BASE_URL = os.getenv("ALGO_ENGINE_BASE_URL", "http://algo_engine:8000")
-ROUTER_BASE_URL = os.getenv("ORDER_ROUTER_BASE_URL", "http://order_router:8000")
-MARKET_BASE_URL = os.getenv("MARKET_DATA_BASE_URL", "http://market_data:8000")
+REPORTS_BASE_URL = os.getenv("WEB_DASHBOARD_REPORTS_BASE_URL", "http://reports:8000/")
+ALGO_BASE_URL = os.getenv("WEB_DASHBOARD_ALGO_ENGINE_URL", "http://algo-engine:8000/")
+ROUTER_BASE_URL = os.getenv("WEB_DASHBOARD_ORDER_ROUTER_BASE_URL", "http://order-router:8000/")
+MARKET_BASE_URL = os.getenv("WEB_DASHBOARD_MARKETPLACE_URL", "http://marketplace:8000/")
 STATUS_TIMEOUT = float(os.getenv("WEB_DASHBOARD_STATUS_TIMEOUT", "5.0"))
 
 


### PR DESCRIPTION
## Summary
- make the status router reuse the web dashboard service URL environment variables
- fall back to the shared dashboard defaults so customised deployments work

## Testing
- pytest services/web_dashboard/tests/test_status_page.py -q *(fails: template expectations currently unmet)*

------
https://chatgpt.com/codex/tasks/task_e_68e75dd8c5588332a9034a967c5a150f