### PR TITLE
Document dashboard navigation scope for modernization

### DIFF
--- a/docs/ui/dashboard-modernization.md
+++ b/docs/ui/dashboard-modernization.md
@@ -10,6 +10,64 @@ Align modernization efforts for the trading dashboard SPA with the foundation al
 
 The modernization scope must build on these assets instead of re-implementing navigation, routing, or context plumbing.
 
+## Active Navigation Inventory
+
+The current router and sidebar expose the following destinations. Each item is tagged to clarify whether the modernization effort must deliver a redesigned experience (`Redesign`) or preserve the existing UX with only integration polish (`Preserve`).
+
+| Path | Purpose | Source | Modernization status |
+| --- | --- | --- | --- |
+| `/dashboard` | Authenticated dashboard landing | `App.jsx` route, sidebar link | Redesign |
+| `/dashboard/followers` | Copy-trading follower metrics | `App.jsx` route, sidebar link | Redesign |
+| `/marketplace` | Strategy marketplace browser | `App.jsx` route, sidebar link | Redesign |
+| `/market` | Real-time market view | `App.jsx` route, sidebar link | Redesign |
+| `/trading/orders` | Orders management | `App.jsx` route, sidebar link | Redesign |
+| `/trading/positions` | Open positions monitoring | `App.jsx` route, sidebar link | Redesign |
+| `/trading/execute` | Order ticket execution | `App.jsx` route, sidebar link | Redesign |
+| `/alerts` | Alert configuration & feed | `App.jsx` route, sidebar link | Redesign |
+| `/reports` | Performance reports | `App.jsx` route, sidebar link | Redesign |
+| `/strategies` | Strategy portfolio overview | `App.jsx` route, sidebar link | Redesign |
+| `/strategies/new` | Strategy Express builder | `App.jsx` route, sidebar link | Redesign |
+| `/strategies/documentation` | Strategy documentation library | `App.jsx` route, sidebar link | Preserve |
+| `/help` | Help center & training hub | `App.jsx` route, sidebar link | Preserve |
+| `/status` | Service status dashboard | `App.jsx` route, sidebar link | Preserve |
+| `/account/settings` | Account & API management | `App.jsx` route, sidebar link | Redesign |
+| `/account` → `/account/settings` | Redirect to account settings | `App.jsx` redirect | Preserve |
+| `/account/login` | Public login | `App.jsx` route | Preserve |
+| `/account/register` | Public registration | `App.jsx` route | Preserve |
+| `*` | Not-found boundary | `App.jsx` catch-all | Preserve |
+
+### Navigation tree for modernization
+
+- **Dashboard**
+  - `/dashboard` (Redesign)
+  - `/dashboard/followers` (Redesign)
+- **Trading**
+  - `/trading/orders` (Redesign)
+  - `/trading/positions` (Redesign)
+  - `/trading/execute` (Redesign)
+- **Market Intelligence**
+  - `/market` (Redesign)
+  - `/alerts` (Redesign)
+  - `/reports` (Redesign)
+- **Strategies**
+  - `/strategies` (Redesign)
+  - `/strategies/new` (Redesign)
+  - `/strategies/documentation` (Preserve)
+- **Marketplace**
+  - `/marketplace` (Redesign)
+- **Support**
+  - `/help` (Preserve)
+  - `/status` (Preserve)
+- **Account**
+  - `/account/settings` (Redesign)
+  - `/account` redirect (Preserve)
+  - `/account/login` (Preserve)
+  - `/account/register` (Preserve)
+- **System**
+  - `*` not-found (Preserve)
+
+Retain all sidebar entries defined in `layouts/DashboardLayout.jsx` while applying the redesign treatments noted above to sections flagged for modernization.
+
 ## Gaps to Address
 1. **Visual refinements**
    - Harmonize spacing/typography with the design tokens in `docs/ui/README.md` and add missing dark-mode states for secondary panels.
@@ -31,10 +89,11 @@ The modernization scope must build on these assets instead of re-implementing na
 1. Updated UI components meeting the visual, performance, and observability requirements above.
 2. Documentation updates (component inventory, i18n checklist, performance instrumentation notes).
 3. QA checklist covering protected-route access, responsive layouts, and language persistence.
+4. Navigation audit sign-off from product and engineering confirming that all routes listed in the Active Navigation Inventory remain functional post-modernization.
 
 ## Stakeholders & Approval
 - **Product**: Emma Laurent
 - **Engineering**: Julien Martin (frontend), Sofia Benali (platform observability)
 - **Design**: Alice Moreau
 
-The revised specification must be reviewed and approved by the stakeholders above before work is scheduled. Record approvals in the communications log referenced below.
+The revised specification must be reviewed and approved by the stakeholders above before work is scheduled. As part of this review, product and engineering leads must explicitly revalidate the navigation scope outlined above to prevent accidental feature loss. Record approvals in the communications log referenced below.


### PR DESCRIPTION
## Summary
- document the current router destinations from App.jsx alongside the sidebar links
- extend the modernization spec with a navigation tree marking redesign vs preserve scope
- require product and engineering sign-off on the navigation audit to prevent scope regressions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68fbd689823083328db513fa1b62eff0