### PR TITLE
feat(web-dashboard): add UI primitives and stories

### DIFF
--- a/services/web_dashboard/src/components/ui/__tests__/primitives.test.jsx
+++ b/services/web_dashboard/src/components/ui/__tests__/primitives.test.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  Select,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  TabTrigger,
+  ToastProvider,
+  useToast,
+} from "../index.js";
+
+function ToastTester() {
+  const { show, toasts } = useToast();
+  return (
+    <>
+      <Button onClick={() => show({ title: "Bonjour", description: "Toast de test", duration: 100 })}>
+        Afficher un toast
+      </Button>
+      <span data-testid="toast-count">{toasts.length}</span>
+    </>
+  );
+}
+
+describe("UI primitives", () => {
+  it("renders input and propagates change", () => {
+    const handleChange = vi.fn();
+    render(<Input aria-label="Email" onChange={handleChange} />);
+    const input = screen.getByLabelText("Email");
+    fireEvent.change(input, { target: { value: "test@example.com" } });
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it("renders select options", () => {
+    const handleChange = vi.fn();
+    render(
+      <Select aria-label="Tri" defaultValue="recent" onChange={handleChange}>
+        <option value="recent">Récent</option>
+        <option value="ancien">Ancien</option>
+      </Select>,
+    );
+    const select = screen.getByLabelText("Tri");
+    fireEvent.change(select, { target: { value: "ancien" } });
+    expect(handleChange).toHaveBeenCalled();
+    expect(select.value).toBe("ancien");
+  });
+
+  it("closes modal when clicking outside", () => {
+    const handleClose = vi.fn();
+    render(
+      <Modal open onClose={handleClose} labelledBy="modal-title">
+        <ModalHeader>
+          <ModalTitle id="modal-title">Modale</ModalTitle>
+        </ModalHeader>
+      </Modal>,
+    );
+
+    const overlay = screen.getByTestId("modal-overlay");
+    fireEvent.click(overlay);
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it("changes active tab when trigger is pressed", () => {
+    render(
+      <Tabs defaultValue="overview">
+        <TabList>
+          <TabTrigger value="overview">Vue</TabTrigger>
+          <TabTrigger value="details">Détails</TabTrigger>
+        </TabList>
+        <TabPanels>
+          <TabPanel value="overview">
+            <p>Données de synthèse</p>
+          </TabPanel>
+          <TabPanel value="details">
+            <p>Données détaillées</p>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(screen.getByText("Données de synthèse")).toBeVisible();
+    const detailsTrigger = screen.getByRole("tab", { name: "Détails" });
+    fireEvent.click(detailsTrigger);
+    expect(screen.getByText("Données détaillées")).toBeVisible();
+  });
+
+  it("displays and dismisses toast notifications", async () => {
+    render(
+      <ToastProvider duration={50}>
+        <ToastTester />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Afficher un toast" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("toast-count").textContent).toBe("1");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toast-count").textContent).toBe("0");
+    });
+  });
+});

--- a/services/web_dashboard/src/components/ui/form-field.jsx
+++ b/services/web_dashboard/src/components/ui/form-field.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { cn } from "../../lib/utils.js";
+
+export function Form({ className, ...props }) {
+  return <form className={cn("flex flex-col gap-6", className)} {...props} />;
+}
+
+export function FormField({ className, ...props }) {
+  return <div className={cn("flex flex-col gap-2", className)} {...props} />;
+}
+
+export function FormLabel({ className, ...props }) {
+  return <label className={cn("text-sm font-medium text-slate-300", className)} {...props} />;
+}
+
+export function FormControl({ className, ...props }) {
+  return <div className={cn("flex flex-col gap-2", className)} {...props} />;
+}
+
+export function FormDescription({ className, ...props }) {
+  return <p className={cn("text-xs text-slate-400", className)} {...props} />;
+}
+
+const MESSAGE_VARIANTS = {
+  default: "text-xs text-slate-300",
+  success: "text-xs text-emerald-300",
+  warning: "text-xs text-amber-300",
+  error: "text-xs text-rose-300",
+};
+
+export function FormMessage({ className, variant = "default", ...props }) {
+  return <p className={cn(MESSAGE_VARIANTS[variant] || MESSAGE_VARIANTS.default, className)} {...props} />;
+}

--- a/services/web_dashboard/src/components/ui/index.js
+++ b/services/web_dashboard/src/components/ui/index.js
@@ -1,0 +1,21 @@
+export { Badge } from "./badge.jsx";
+export { Button } from "./button.jsx";
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "./card.jsx";
+export { Form, FormControl, FormDescription, FormField, FormLabel, FormMessage } from "./form-field.jsx";
+export { Input, Textarea } from "./input.jsx";
+export { Modal, ModalBody, ModalDescription, ModalFooter, ModalHeader, ModalTitle, ModalClose } from "./modal.jsx";
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableContent,
+  TableElement,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table.jsx";
+export { Tabs, TabList, TabPanel, TabPanels, TabTrigger } from "./tabs.jsx";
+export { ToastProvider, useToast } from "./toast.jsx";
+export { Spinner } from "./spinner.jsx";
+export { Select } from "./select.jsx";

--- a/services/web_dashboard/src/components/ui/input.jsx
+++ b/services/web_dashboard/src/components/ui/input.jsx
@@ -1,0 +1,24 @@
+import React, { forwardRef } from "react";
+import { cn } from "../../lib/utils.js";
+
+const BASE_INPUT_CLASSES =
+  "flex h-11 w-full items-center rounded-xl border border-slate-800/70 bg-slate-900/60 px-4 text-sm text-slate-100 shadow-inner shadow-slate-950/40 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 placeholder:text-slate-500 disabled:cursor-not-allowed disabled:opacity-60";
+
+export const Input = forwardRef(function Input({ className, ...props }, ref) {
+  return <input ref={ref} className={cn(BASE_INPUT_CLASSES, className)} {...props} />;
+});
+
+export const Textarea = forwardRef(function Textarea({ className, rows = 3, ...props }, ref) {
+  return (
+    <textarea
+      ref={ref}
+      rows={rows}
+      className={cn(
+        BASE_INPUT_CLASSES,
+        "min-h-[2.75rem] resize-y py-3 leading-relaxed",
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/services/web_dashboard/src/components/ui/modal.jsx
+++ b/services/web_dashboard/src/components/ui/modal.jsx
@@ -1,0 +1,150 @@
+import React, { createContext, forwardRef, useCallback, useContext, useEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "../../lib/utils.js";
+
+const ModalContext = createContext(null);
+
+const SIZES = {
+  sm: "max-w-md",
+  md: "max-w-2xl",
+  lg: "max-w-4xl",
+};
+
+export function Modal({ open, onClose, size = "md", className, children, labelledBy, description }) {
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose?.();
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, handleKeyDown]);
+
+  const value = useMemo(
+    () => ({ onClose }),
+    [onClose],
+  );
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <ModalContext.Provider value={value}>
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div
+          className="absolute inset-0 bg-slate-950/80 backdrop-blur-sm"
+          aria-hidden="true"
+          data-testid="modal-overlay"
+          onClick={() => onClose?.()}
+        />
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={labelledBy}
+          aria-describedby={description}
+          className={cn(
+            "relative z-10 flex w-full flex-col gap-4 rounded-3xl border border-slate-800/70 bg-slate-900/80 p-6 text-slate-100 shadow-2xl shadow-slate-950/60",
+            SIZES[size] || SIZES.md,
+            className,
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </ModalContext.Provider>,
+    document.body,
+  );
+}
+
+export function ModalHeader({ className, ...props }) {
+  return <header className={cn("flex flex-col gap-1", className)} {...props} />;
+}
+
+export function ModalTitle({ className, ...props }) {
+  return <h2 className={cn("text-2xl font-semibold text-white", className)} {...props} />;
+}
+
+export function ModalDescription({ className, ...props }) {
+  return <p className={cn("text-sm text-slate-400", className)} {...props} />;
+}
+
+export function ModalBody({ className, ...props }) {
+  return <div className={cn("flex flex-col gap-4", className)} {...props} />;
+}
+
+export function ModalFooter({ className, children, ...props }) {
+  const context = useContext(ModalContext);
+
+  const enhancedChildren = useMemo(() => {
+    if (typeof context?.onClose !== "function") {
+      return children;
+    }
+
+    return React.Children.map(children, (child) => {
+      if (!React.isValidElement(child)) {
+        return child;
+      }
+      if (child.props?.["data-modal-dismiss"]) {
+        return React.cloneElement(child, {
+          onClick: (event) => {
+            child.props?.onClick?.(event);
+            context.onClose();
+          },
+        });
+      }
+      return child;
+    });
+  }, [children, context]);
+
+  return (
+    <footer className={cn("flex flex-wrap items-center justify-end gap-3 pt-2", className)} {...props}>
+      {enhancedChildren}
+    </footer>
+  );
+}
+
+export const ModalClose = forwardRef(function ModalClose({ asChild = false, onClick, className, children, ...props }, ref) {
+  const context = useContext(ModalContext);
+  const handleClick = useCallback(
+    (event) => {
+      onClick?.(event);
+      context?.onClose?.();
+    },
+    [onClick, context],
+  );
+
+  if (asChild && children && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ref,
+      onClick: (event) => {
+        children.props?.onClick?.(event);
+        handleClick(event);
+      },
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      ref={ref}
+      onClick={handleClick}
+      className={cn(
+        "inline-flex h-10 min-w-[2.5rem] items-center justify-center rounded-xl border border-slate-800/70 bg-transparent px-4 text-sm font-medium text-slate-300 transition hover:bg-slate-800/60 hover:text-white",
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/services/web_dashboard/src/components/ui/primitives.stories.jsx
+++ b/services/web_dashboard/src/components/ui/primitives.stories.jsx
@@ -1,0 +1,196 @@
+import React, { useState } from "react";
+import {
+  Button,
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormMessage,
+  Input,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  Select,
+  Spinner,
+  TabList,
+  TabTrigger,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Table,
+  TableBody,
+  TableCell,
+  TableContent,
+  TableElement,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Textarea,
+  ToastProvider,
+  useToast,
+} from "./index.js";
+
+export default {
+  title: "UI/Primitives",
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export const FormControls = {
+  name: "Champs de formulaire",
+  render: () => (
+    <Form className="w-full max-w-lg">
+      <FormField>
+        <FormLabel htmlFor="storybook-email">Adresse e-mail</FormLabel>
+        <FormControl>
+          <Input id="storybook-email" placeholder="nom@domaine.com" />
+        </FormControl>
+        <FormMessage variant="default">L'adresse doit être valide.</FormMessage>
+      </FormField>
+      <FormField>
+        <FormLabel htmlFor="storybook-comment">Commentaire</FormLabel>
+        <FormControl>
+          <Textarea id="storybook-comment" placeholder="Décrivez votre besoin" rows={4} />
+        </FormControl>
+      </FormField>
+      <FormField>
+        <FormLabel htmlFor="storybook-select">Tri</FormLabel>
+        <FormControl>
+          <Select id="storybook-select" defaultValue="latest">
+            <option value="latest">Plus récent</option>
+            <option value="alpha">Alphabétique</option>
+          </Select>
+        </FormControl>
+      </FormField>
+    </Form>
+  ),
+};
+
+export const ModalExample = {
+  name: "Modale",
+  render: () => {
+    function Example() {
+      const [open, setOpen] = useState(false);
+      return (
+        <div className="space-y-4">
+          <Button variant="primary" onClick={() => setOpen(true)}>
+            Ouvrir la modale
+          </Button>
+          <Modal open={open} onClose={() => setOpen(false)} labelledBy="storybook-modal-title">
+            <ModalHeader>
+              <ModalTitle id="storybook-modal-title">Confirmation</ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              <p className="text-sm text-slate-300">Cette modale illustre la présentation par défaut.</p>
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="ghost" data-modal-dismiss>
+                Fermer
+              </Button>
+              <Button variant="primary" onClick={() => setOpen(false)}>
+                Confirmer
+              </Button>
+            </ModalFooter>
+          </Modal>
+        </div>
+      );
+    }
+
+    return <Example />;
+  },
+};
+
+export const TabsExample = {
+  name: "Onglets",
+  render: () => (
+    <Tabs defaultValue="overview">
+      <TabList>
+        <TabTrigger value="overview">Vue d'ensemble</TabTrigger>
+        <TabTrigger value="details">Détails</TabTrigger>
+      </TabList>
+      <TabPanels>
+        <TabPanel value="overview">
+          <p>Affichez ici une synthèse des informations principales.</p>
+        </TabPanel>
+        <TabPanel value="details">
+          <p>Détaillez le contenu complémentaire dans ce panneau.</p>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  ),
+};
+
+function ToastStory() {
+  const { show } = useToast();
+  return (
+    <div className="flex flex-col gap-3">
+      <Button
+        variant="primary"
+        onClick={() =>
+          show({
+            title: "Notification",
+            description: "Toast déclenché depuis Storybook.",
+            variant: "info",
+            actionLabel: "Compris",
+          })
+        }
+      >
+        Lancer un toast
+      </Button>
+    </div>
+  );
+}
+
+export const ToastNotifications = {
+  name: "Toasts",
+  render: () => (
+    <ToastProvider>
+      <ToastStory />
+    </ToastProvider>
+  ),
+};
+
+export const TableExample = {
+  name: "Tableau",
+  render: () => (
+    <Table className="w-full max-w-3xl">
+      <TableContent>
+        <TableElement>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Stratégie</TableHead>
+              <TableHead>Performance</TableHead>
+              <TableHead>Risque</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>Momentum AI</TableCell>
+              <TableCell>+14,2 %</TableCell>
+              <TableCell>Modéré</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Scalper X</TableCell>
+              <TableCell>+7,8 %</TableCell>
+              <TableCell>Élevé</TableCell>
+            </TableRow>
+          </TableBody>
+        </TableElement>
+      </TableContent>
+    </Table>
+  ),
+};
+
+export const SpinnerExample = {
+  name: "Spinner",
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+    </div>
+  ),
+};

--- a/services/web_dashboard/src/components/ui/select.jsx
+++ b/services/web_dashboard/src/components/ui/select.jsx
@@ -1,0 +1,22 @@
+import React, { forwardRef } from "react";
+import { cn } from "../../lib/utils.js";
+
+const BASE_SELECT_CLASSES =
+  "flex h-11 w-full items-center rounded-xl border border-slate-800/70 bg-slate-900/60 px-4 text-sm text-slate-100 shadow-inner shadow-slate-950/40 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 appearance-none disabled:cursor-not-allowed disabled:opacity-60";
+
+export const Select = forwardRef(function Select({ className, children, ...props }, ref) {
+  return (
+    <div className="relative w-full">
+      <select ref={ref} className={cn(BASE_SELECT_CLASSES, "pr-10", className)} {...props}>
+        {children}
+      </select>
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"
+      >
+        <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </div>
+  );
+});

--- a/services/web_dashboard/src/components/ui/spinner.jsx
+++ b/services/web_dashboard/src/components/ui/spinner.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { cn } from "../../lib/utils.js";
+
+const SIZES = {
+  sm: "h-4 w-4 border-2",
+  md: "h-6 w-6 border-[3px]",
+  lg: "h-10 w-10 border-4",
+};
+
+export function Spinner({ size = "md", className, "aria-label": ariaLabel = "Chargement", ...props }) {
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      className="inline-flex items-center justify-center"
+    >
+      <span
+        className={cn(
+          "inline-block animate-spin rounded-full border-slate-700 border-t-sky-400",
+          SIZES[size] || SIZES.md,
+          className,
+        )}
+        {...props}
+      />
+    </span>
+  );
+}

--- a/services/web_dashboard/src/components/ui/table.jsx
+++ b/services/web_dashboard/src/components/ui/table.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { cn } from "../../lib/utils.js";
+
+export function Table({ className, ...props }) {
+  return <div className={cn("overflow-hidden rounded-2xl border border-slate-800/60", className)} {...props} />;
+}
+
+export function TableContent({ className, ...props }) {
+  return <div className={cn("overflow-x-auto", className)} {...props} />;
+}
+
+export function TableElement({ className, ...props }) {
+  return (
+    <table
+      className={cn(
+        "min-w-full border-collapse bg-slate-900/70 text-left text-sm text-slate-200 shadow-2xl shadow-slate-950/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableHeader({ className, ...props }) {
+  return <thead className={cn("bg-slate-900/80 text-xs uppercase text-slate-400", className)} {...props} />;
+}
+
+export function TableBody({ className, ...props }) {
+  return <tbody className={cn("divide-y divide-slate-800/60", className)} {...props} />;
+}
+
+export function TableRow({ className, ...props }) {
+  return (
+    <tr
+      className={cn(
+        "transition hover:bg-slate-800/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableHead({ className, ...props }) {
+  return <th className={cn("px-5 py-3 font-semibold tracking-wide", className)} scope="col" {...props} />;
+}
+
+export function TableCell({ className, ...props }) {
+  return <td className={cn("px-5 py-4 align-middle text-slate-200", className)} {...props} />;
+}
+
+export function TableCaption({ className, ...props }) {
+  return <caption className={cn("px-5 py-3 text-left text-xs text-slate-500", className)} {...props} />;
+}

--- a/services/web_dashboard/src/components/ui/tabs.jsx
+++ b/services/web_dashboard/src/components/ui/tabs.jsx
@@ -1,0 +1,107 @@
+import React, { createContext, useCallback, useContext, useId, useMemo, useState } from "react";
+import { cn } from "../../lib/utils.js";
+
+const TabsContext = createContext(null);
+
+export function Tabs({ value, defaultValue, onValueChange, className, children }) {
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const controlled = value !== undefined;
+  const activeValue = controlled ? value : internalValue;
+
+  const setValue = useCallback(
+    (nextValue) => {
+      if (!controlled) {
+        setInternalValue(nextValue);
+      }
+      onValueChange?.(nextValue);
+    },
+    [controlled, onValueChange],
+  );
+
+  const context = useMemo(
+    () => ({ value: activeValue, setValue, controlled }),
+    [activeValue, setValue, controlled],
+  );
+
+  return (
+    <TabsContext.Provider value={context}>
+      <div className={cn("flex flex-col gap-4", className)}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+function useTabsContext() {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error("Tabs components must be used within <Tabs>");
+  }
+  return context;
+}
+
+export function TabList({ className, children, ...props }) {
+  return (
+    <div
+      role="tablist"
+      className={cn(
+        "inline-flex w-fit items-center gap-1 rounded-2xl border border-slate-800/60 bg-slate-900/70 p-1 text-sm shadow-inner shadow-slate-950/40",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function TabTrigger({ value, className, id, children, ...props }) {
+  const { value: activeValue, setValue } = useTabsContext();
+  const selected = activeValue === value;
+  const generatedId = useId();
+  const tabId = id ?? generatedId;
+
+  const handleSelect = useCallback(
+    (event) => {
+      props.onClick?.(event);
+      setValue(value);
+    },
+    [props, setValue, value],
+  );
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      id={tabId}
+      aria-selected={selected}
+      className={cn(
+        "relative inline-flex items-center justify-center rounded-xl px-4 py-2 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500",
+        selected
+          ? "bg-sky-500/90 text-slate-900 shadow shadow-sky-900/40"
+          : "text-slate-300 hover:text-white",
+        className,
+      )}
+      onClick={handleSelect}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TabPanels({ className, children, ...props }) {
+  return (
+    <div className={cn("rounded-3xl border border-slate-800/60 bg-slate-900/70 p-6 shadow-2xl shadow-slate-950/40", className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function TabPanel({ value, className, children, ...props }) {
+  const { value: activeValue } = useTabsContext();
+  const hidden = activeValue !== value;
+  return (
+    <div role="tabpanel" hidden={hidden} className={cn("flex flex-col gap-4 text-sm text-slate-200", className)} {...props}>
+      {!hidden && children}
+    </div>
+  );
+}

--- a/services/web_dashboard/src/components/ui/toast.jsx
+++ b/services/web_dashboard/src/components/ui/toast.jsx
@@ -1,0 +1,156 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "../../lib/utils.js";
+
+const ToastContext = createContext(null);
+let toastCounter = 0;
+
+const VARIANTS = {
+  default: "border-slate-700 bg-slate-900/90 text-slate-100",
+  success: "border-emerald-500/50 bg-emerald-500/15 text-emerald-200",
+  warning: "border-amber-500/50 bg-amber-500/15 text-amber-200",
+  danger: "border-rose-500/50 bg-rose-500/15 text-rose-200",
+  info: "border-sky-500/50 bg-sky-500/15 text-sky-200",
+};
+
+export function ToastProvider({ children, duration = 4000, placement = "bottom-right" }) {
+  const [toasts, setToasts] = useState([]);
+  const timeoutsRef = useRef(new Map());
+
+  const clearExistingTimeout = useCallback((id) => {
+    const timeoutId = timeoutsRef.current.get(id);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutsRef.current.delete(id);
+    }
+  }, []);
+
+  const dismiss = useCallback(
+    (id) => {
+      clearExistingTimeout(id);
+      setToasts((previous) => previous.filter((toast) => toast.id !== id));
+    },
+    [clearExistingTimeout],
+  );
+
+  const show = useCallback(
+    ({ title, description, variant = "default", actionLabel, onAction, duration: toastDuration }) => {
+      const id = `toast-${toastCounter++}`;
+      setToasts((previous) => [...previous, { id, title, description, variant, actionLabel, onAction }]);
+      const timeoutDelay = toastDuration ?? duration;
+      if (timeoutDelay > 0) {
+        const timeout = setTimeout(() => {
+          dismiss(id);
+        }, timeoutDelay);
+        timeoutsRef.current.set(id, timeout);
+      }
+      return id;
+    },
+    [dismiss, duration],
+  );
+
+  useEffect(() => {
+    return () => {
+      timeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutsRef.current.clear();
+    };
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      show,
+      dismiss,
+      toasts,
+    }),
+    [show, dismiss, toasts],
+  );
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismiss} placement={placement} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used inside a <ToastProvider>");
+  }
+  return context;
+}
+
+function ToastViewport({ toasts, onDismiss, placement }) {
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  const placementClass = {
+    "bottom-right": "bottom-6 right-6 items-end",
+    "bottom-left": "bottom-6 left-6 items-start",
+    "top-right": "top-6 right-6 items-end",
+    "top-left": "top-6 left-6 items-start",
+  }[placement];
+
+  return createPortal(
+    <div className={cn("pointer-events-none fixed z-[60] flex w-full max-w-sm flex-col gap-3", placementClass)}>
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} onDismiss={onDismiss} />
+      ))}
+    </div>,
+    document.body,
+  );
+}
+
+function ToastItem({ toast, onDismiss }) {
+  const handleDismiss = useCallback(() => {
+    onDismiss(toast.id);
+  }, [onDismiss, toast.id]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "pointer-events-auto flex flex-col gap-2 rounded-2xl border px-4 py-3 shadow-lg shadow-slate-950/40 backdrop-blur",
+        VARIANTS[toast.variant] || VARIANTS.default,
+      )}
+    >
+      {toast.title && <p className="text-sm font-semibold text-white">{toast.title}</p>}
+      {toast.description && <p className="text-sm text-slate-200">{toast.description}</p>}
+      {(toast.actionLabel || toast.onAction) && (
+        <div className="flex items-center gap-2">
+          {toast.actionLabel && (
+            <button
+              type="button"
+              className="rounded-lg bg-slate-800/60 px-3 py-1 text-xs font-medium text-slate-200 transition hover:bg-slate-800"
+              onClick={() => {
+                toast.onAction?.();
+                handleDismiss();
+              }}
+            >
+              {toast.actionLabel}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="ml-auto text-xs uppercase tracking-wide text-slate-400 transition hover:text-slate-100"
+          >
+            Fermer
+          </button>
+        </div>
+      )}
+      {!toast.actionLabel && !toast.onAction && (
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="self-end text-xs uppercase tracking-wide text-slate-400 transition hover:text-slate-100"
+        >
+          Fermer
+        </button>
+      )}
+    </div>
+  );
+}

--- a/services/web_dashboard/src/marketplace/MarketplaceApp.jsx
+++ b/services/web_dashboard/src/marketplace/MarketplaceApp.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ListingCard from "./ListingCard.jsx";
 import useApi from "../hooks/useApi.js";
+import { Button, Form, FormControl, FormField, FormLabel, Input, Select } from "../components/ui/index.js";
 
 function buildQuery(filters) {
   const params = {};
@@ -96,76 +97,96 @@ function MarketplaceApp({ listingsEndpoint, reviewsEndpointTemplate }) {
       </header>
 
       <section className="marketplace__filters" aria-label={t("Filtres de recherche")}>
-        <form
+        <Form
           className="marketplace-filters"
           onSubmit={(event) => {
             event.preventDefault();
           }}
         >
           <div className="marketplace-filters__row">
-            <label className="marketplace-filters__field">
-              <span className="marketplace-filters__label">{t("Rechercher")}</span>
-              <input
-                type="search"
-                name="search"
-                value={filters.search}
-                onChange={handleInputChange}
-                placeholder={t("Nom de stratégie")}
-                className="input"
-              />
-            </label>
-            <label className="marketplace-filters__field">
-              <span className="marketplace-filters__label">{t("Performance min.")}</span>
-              <input
-                type="number"
-                step="0.1"
-                min="0"
-                name="minPerformance"
-                value={filters.minPerformance}
-                onChange={handleInputChange}
-                className="input"
-              />
-            </label>
-            <label className="marketplace-filters__field">
-              <span className="marketplace-filters__label">{t("Risque max.")}</span>
-              <input
-                type="number"
-                step="0.1"
-                min="0"
-                name="maxRisk"
-                value={filters.maxRisk}
-                onChange={handleInputChange}
-                className="input"
-              />
-            </label>
-            <label className="marketplace-filters__field">
-              <span className="marketplace-filters__label">{t("Prix max. (USD)")}</span>
-              <input
-                type="number"
-                min="0"
-                name="maxPrice"
-                value={filters.maxPrice}
-                onChange={handleInputChange}
-                className="input"
-              />
-            </label>
-            <label className="marketplace-filters__field">
-              <span className="marketplace-filters__label">{t("Tri")}</span>
-              <select name="sort" value={filters.sort} onChange={handleInputChange} className="input">
-                {sortOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <FormField className="marketplace-filters__field">
+              <FormLabel htmlFor="marketplace-filter-search" className="marketplace-filters__label">
+                {t("Rechercher")}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  id="marketplace-filter-search"
+                  type="search"
+                  name="search"
+                  value={filters.search}
+                  onChange={handleInputChange}
+                  placeholder={t("Nom de stratégie")}
+                />
+              </FormControl>
+            </FormField>
+            <FormField className="marketplace-filters__field">
+              <FormLabel htmlFor="marketplace-filter-min-performance" className="marketplace-filters__label">
+                {t("Performance min.")}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  id="marketplace-filter-min-performance"
+                  type="number"
+                  step="0.1"
+                  min="0"
+                  name="minPerformance"
+                  value={filters.minPerformance}
+                  onChange={handleInputChange}
+                />
+              </FormControl>
+            </FormField>
+            <FormField className="marketplace-filters__field">
+              <FormLabel htmlFor="marketplace-filter-max-risk" className="marketplace-filters__label">
+                {t("Risque max.")}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  id="marketplace-filter-max-risk"
+                  type="number"
+                  step="0.1"
+                  min="0"
+                  name="maxRisk"
+                  value={filters.maxRisk}
+                  onChange={handleInputChange}
+                />
+              </FormControl>
+            </FormField>
+            <FormField className="marketplace-filters__field">
+              <FormLabel htmlFor="marketplace-filter-max-price" className="marketplace-filters__label">
+                {t("Prix max. (USD)")}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  id="marketplace-filter-max-price"
+                  type="number"
+                  min="0"
+                  name="maxPrice"
+                  value={filters.maxPrice}
+                  onChange={handleInputChange}
+                />
+              </FormControl>
+            </FormField>
+            <FormField className="marketplace-filters__field">
+              <FormLabel htmlFor="marketplace-filter-sort" className="marketplace-filters__label">
+                {t("Tri")}
+              </FormLabel>
+              <FormControl>
+                <Select id="marketplace-filter-sort" name="sort" value={filters.sort} onChange={handleInputChange}>
+                  {sortOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </Select>
+              </FormControl>
+            </FormField>
           </div>
           <div className="marketplace-filters__actions">
-            <button type="button" className="button button--ghost" onClick={resetFilters} disabled={!hasActiveFilters}>
+            <Button type="button" variant="ghost" onClick={resetFilters} disabled={!hasActiveFilters}>
               {t("Réinitialiser")}
-            </button>
+            </Button>
           </div>
-        </form>
+        </Form>
       </section>
 
       <section className="marketplace__results" aria-live="polite">

--- a/services/web_dashboard/src/marketplace/ReviewForm.jsx
+++ b/services/web_dashboard/src/marketplace/ReviewForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Button, FormControl, FormField, FormLabel, FormMessage, Select, Textarea } from "../components/ui/index.js";
 
 function ReviewForm({ onSubmit, status, errorMessage }) {
   const { t } = useTranslation();
@@ -18,34 +19,42 @@ function ReviewForm({ onSubmit, status, errorMessage }) {
     <form className="review-form" onSubmit={handleSubmit}>
       <h3 className="heading heading--sm">{t("Partager un avis")}</h3>
       <div className="review-form__fields">
-        <label className="review-form__field">
-          <span className="review-form__label">{t("Note")}</span>
-          <select value={rating} onChange={(event) => setRating(event.target.value)} className="input">
-            {[1, 2, 3, 4, 5].map((value) => (
-              <option key={value} value={value}>
-                {t("{value} / 5", { value })}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="review-form__field review-form__field--grow">
-          <span className="review-form__label">{t("Commentaire")}</span>
-          <textarea
-            value={comment}
-            onChange={(event) => setComment(event.target.value)}
-            className="input"
-            rows={3}
-            placeholder={t("Décrivez votre expérience")}
-          />
-        </label>
+        <FormField className="review-form__field">
+          <FormLabel htmlFor="review-rating" className="review-form__label">
+            {t("Note")}
+          </FormLabel>
+          <FormControl>
+            <Select id="review-rating" value={rating} onChange={(event) => setRating(event.target.value)}>
+              {[1, 2, 3, 4, 5].map((value) => (
+                <option key={value} value={value}>
+                  {t("{value} / 5", { value })}
+                </option>
+              ))}
+            </Select>
+          </FormControl>
+        </FormField>
+        <FormField className="review-form__field review-form__field--grow">
+          <FormLabel htmlFor="review-comment" className="review-form__label">
+            {t("Commentaire")}
+          </FormLabel>
+          <FormControl>
+            <Textarea
+              id="review-comment"
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              rows={3}
+              placeholder={t("Décrivez votre expérience")}
+            />
+          </FormControl>
+        </FormField>
       </div>
       <div className="review-form__actions">
-        <button type="submit" className="button" disabled={status === "submitting"}>
+        <Button type="submit" variant="secondary" disabled={status === "submitting"}>
           {status === "submitting" ? t("Envoi…") : t("Envoyer")}
-        </button>
-        {status === "success" && <span className="text text--success">{t("Avis enregistré")}</span>}
+        </Button>
+        {status === "success" && <FormMessage variant="success">{t("Avis enregistré")}</FormMessage>}
         {status === "error" && (
-          <span className="text text--critical">{errorMessage || t("Erreur lors de l'envoi")}</span>
+          <FormMessage variant="error">{errorMessage || t("Erreur lors de l'envoi")}</FormMessage>
         )}
       </div>
     </form>

--- a/services/web_dashboard/src/pages/Account/AccountRegisterPage.jsx
+++ b/services/web_dashboard/src/pages/Account/AccountRegisterPage.jsx
@@ -1,6 +1,20 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { bootstrap } from "../../bootstrap";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormMessage,
+  Input,
+} from "../../components/ui/index.js";
 
 export default function AccountRegisterPage() {
   const { t } = useTranslation();
@@ -14,40 +28,53 @@ export default function AccountRegisterPage() {
           {t("Inscrivez-vous pour accéder au tableau de bord, gérer vos stratégies et configurer vos clés API.")}
         </p>
       </header>
-      <section className="card" aria-labelledby="register-title">
-        <div className="card__header">
-          <h2 id="register-title" className="heading heading--lg">
-            {t("Inscription")}
-          </h2>
-          <p className="text text--muted">
+      <Card aria-labelledby="register-title">
+        <CardHeader>
+          <CardTitle id="register-title">{t("Inscription")}</CardTitle>
+          <CardDescription>
             {t("Renseignez une adresse e-mail valide et un mot de passe respectant nos exigences de sécurité.")}
-          </p>
-        </div>
-        <div className="card__body">
-          <form className="form-grid" action="/account/register" method="post">
-            <label className="designer-field">
-              <span className="designer-field__label text text--muted">{t("Adresse e-mail")}</span>
-              <input type="email" name="email" autoComplete="email" required defaultValue={data.formEmail || ""} />
-            </label>
-            <label className="designer-field">
-              <span className="designer-field__label text text--muted">{t("Mot de passe")}</span>
-              <input type="password" name="password" autoComplete="new-password" required />
-            </label>
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="gap-6">
+          <Form className="form-grid" action="/account/register" method="post">
+            <FormField>
+              <FormLabel htmlFor="register-email">{t("Adresse e-mail")}</FormLabel>
+              <FormControl>
+                <Input
+                  id="register-email"
+                  type="email"
+                  name="email"
+                  autoComplete="email"
+                  required
+                  defaultValue={data.formEmail || ""}
+                />
+              </FormControl>
+            </FormField>
+            <FormField>
+              <FormLabel htmlFor="register-password">{t("Mot de passe")}</FormLabel>
+              <FormControl>
+                <Input id="register-password" type="password" name="password" autoComplete="new-password" required />
+              </FormControl>
+            </FormField>
             {data.errorMessage && (
-              <p className="text text--critical" role="alert">
+              <FormMessage variant="error" role="alert">
                 {data.errorMessage}
-              </p>
+              </FormMessage>
             )}
-            <button type="submit" className="button button--primary">
-              {t("Créer mon compte")}
-            </button>
-          </form>
+            <div>
+              <Button type="submit" variant="primary">
+                {t("Créer mon compte")}
+              </Button>
+            </div>
+          </Form>
           <p className="text text--muted">
             {t("Déjà inscrit ?")}
-            <a href="/account/login">{t("Se connecter")}</a>
+            <a href="/account/login" className="ml-1">
+              {t("Se connecter")}
+            </a>
           </p>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add shared Input, Select, Tabs, Modal, Toast, Table, Spinner, and form helper components for the dashboard
- refactor marketplace filters, review form, and account registration page to consume the new primitives
- document the primitives in Storybook and add Vitest coverage for key interactions

## Testing
- npm run test -- src/components/ui/__tests__/primitives.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68fbfd6ab8bc8332aa23aa4d869c832a