### PR TITLE
feat(web-dashboard): share strategy tool shell and add routing test

### DIFF
--- a/services/web_dashboard/src/App.routes.test.jsx
+++ b/services/web_dashboard/src/App.routes.test.jsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter, Outlet } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+
+function createPageStub(testId) {
+  const Component = () => <div data-testid={testId}>{testId}</div>;
+  Component.displayName = `Mock${testId}`;
+  return Component;
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: {
+      language: "fr",
+      resolvedLanguage: "fr",
+      changeLanguage: () => Promise.resolve(),
+    },
+  }),
+}));
+
+vi.mock("./layouts/DashboardLayout.jsx", () => ({
+  default: function MockDashboardLayout() {
+    return (
+      <div data-testid="dashboard-layout">
+        <Outlet />
+      </div>
+    );
+  },
+}));
+
+vi.mock("./components/ProtectedRoute.jsx", () => ({
+  default: function MockProtectedRoute({ children }) {
+    return <>{children}</>;
+  },
+}));
+
+vi.mock("./pages/Dashboard/DashboardPage.jsx", () => ({ default: createPageStub("dashboard-page") }));
+vi.mock("./pages/Follower/FollowerDashboardPage.jsx", () => ({ default: createPageStub("follower-page") }));
+vi.mock("./pages/Marketplace/MarketplacePage.jsx", () => ({ default: createPageStub("marketplace-page") }));
+vi.mock("./pages/Strategies/StrategiesPage.jsx", () => ({ default: createPageStub("strategies-page") }));
+vi.mock("./pages/Strategies/StrategyExpressPage.jsx", () => ({ default: createPageStub("strategy-express-page") }));
+vi.mock("./pages/Strategies/StrategyDocumentationPage.jsx", () => ({
+  default: createPageStub("strategy-documentation-page"),
+}));
+vi.mock("./pages/Strategies/StrategyDesignerPage.jsx", () => ({
+  default: createPageStub("strategy-designer-page"),
+}));
+vi.mock("./pages/Strategies/StrategyBacktestPage.jsx", () => ({
+  default: createPageStub("strategy-backtest-page"),
+}));
+vi.mock("./pages/Strategies/AIStrategyAssistantPage.jsx", () => ({
+  default: createPageStub("strategy-ai-assistant-page"),
+}));
+vi.mock("./pages/Help/HelpCenterPage.jsx", () => ({ default: createPageStub("help-center-page") }));
+vi.mock("./pages/Status/StatusPage.jsx", () => ({ default: createPageStub("status-page") }));
+vi.mock("./pages/trading/OrdersPage.jsx", () => ({ default: createPageStub("orders-page") }));
+vi.mock("./pages/trading/PositionsPage.jsx", () => ({ default: createPageStub("positions-page") }));
+vi.mock("./pages/trading/ExecutePage.jsx", () => ({ default: createPageStub("execute-page") }));
+vi.mock("./pages/MarketPage.jsx", () => ({ default: createPageStub("market-page") }));
+vi.mock("./pages/AlertsPage.jsx", () => ({ default: createPageStub("alerts-page") }));
+vi.mock("./pages/ReportsPage.jsx", () => ({ default: createPageStub("reports-page") }));
+vi.mock("./pages/SettingsPage.jsx", () => ({ default: createPageStub("settings-page") }));
+vi.mock("./pages/Account/AccountLoginPage.jsx", () => ({ default: createPageStub("account-login-page") }));
+vi.mock("./pages/Account/AccountRegisterPage.jsx", () => ({ default: createPageStub("account-register-page") }));
+vi.mock("./pages/NotFound/NotFoundPage.jsx", () => ({ default: createPageStub("not-found-page") }));
+vi.mock("./pages/Onboarding/OnboardingPage.jsx", () => ({
+  default: createPageStub("onboarding-page"),
+}));
+
+import App from "./App.jsx";
+
+describe("App routing", () => {
+  const renderAppAt = (path) =>
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+  const routeCases = [
+    { path: "/strategies/designer", testId: "strategy-designer-page" },
+    { path: "/strategies/backtest", testId: "strategy-backtest-page" },
+    { path: "/strategies/ai-assistant", testId: "strategy-ai-assistant-page" },
+    { path: "/onboarding", testId: "onboarding-page" },
+  ];
+
+  routeCases.forEach(({ path, testId }) => {
+    it(`renders the expected wrapper when navigating to ${path}`, () => {
+      renderAppAt(path);
+
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
+    });
+  });
+});

--- a/services/web_dashboard/src/pages/Strategies/AIStrategyAssistantPage.jsx
+++ b/services/web_dashboard/src/pages/Strategies/AIStrategyAssistantPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { AIStrategyAssistant } from "../../strategies/assistant/index.js";
 import { bootstrap } from "../../bootstrap";
+import StrategyToolPageShell from "./StrategyToolPageShell.jsx";
 
 export default function AIStrategyAssistantPage() {
   const { t } = useTranslation();
@@ -15,17 +16,14 @@ export default function AIStrategyAssistantPage() {
     {};
 
   return (
-    <div className="strategy-assistant-page">
-      <header className="page-header">
-        <h1 className="heading heading--xl">{t("Assistant IA pour stratégies")}</h1>
-        <p className="text text--muted">
-          {t(
-            "Décrivez votre idée en langage naturel pour obtenir des suggestions et un brouillon de stratégie."
-          )}
-        </p>
-      </header>
-
+    <StrategyToolPageShell
+      className="strategy-assistant-page"
+      title={t("Assistant IA pour stratégies")}
+      description={t(
+        "Décrivez votre idée en langage naturel pour obtenir des suggestions et un brouillon de stratégie."
+      )}
+    >
       <AIStrategyAssistant {...config} />
-    </div>
+    </StrategyToolPageShell>
   );
 }

--- a/services/web_dashboard/src/pages/Strategies/StrategyBacktestPage.jsx
+++ b/services/web_dashboard/src/pages/Strategies/StrategyBacktestPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { StrategyBacktestConsole } from "../../strategies/backtest/index.js";
 import { bootstrap } from "../../bootstrap";
+import StrategyToolPageShell from "./StrategyToolPageShell.jsx";
 
 export default function StrategyBacktestPage() {
   const { t } = useTranslation();
@@ -15,17 +16,14 @@ export default function StrategyBacktestPage() {
     {};
 
   return (
-    <div className="strategy-backtest-page">
-      <header className="page-header">
-        <h1 className="heading heading--xl">{t("Backtests de stratégies")}</h1>
-        <p className="text text--muted">
-          {t(
-            "Sélectionnez un actif, une période et lancez un backtest pour visualiser les performances historiques."
-          )}
-        </p>
-      </header>
-
+    <StrategyToolPageShell
+      className="strategy-backtest-page"
+      title={t("Backtests de stratégies")}
+      description={t(
+        "Sélectionnez un actif, une période et lancez un backtest pour visualiser les performances historiques."
+      )}
+    >
       <StrategyBacktestConsole {...config} />
-    </div>
+    </StrategyToolPageShell>
   );
 }

--- a/services/web_dashboard/src/pages/Strategies/StrategyDesignerPage.jsx
+++ b/services/web_dashboard/src/pages/Strategies/StrategyDesignerPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { StrategyDesigner } from "../../strategies/designer/index.js";
 import { bootstrap } from "../../bootstrap";
+import StrategyToolPageShell from "./StrategyToolPageShell.jsx";
 
 export default function StrategyDesignerPage() {
   const { t } = useTranslation();
@@ -15,17 +16,14 @@ export default function StrategyDesignerPage() {
     {};
 
   return (
-    <div className="strategy-designer-page">
-      <header className="page-header">
-        <h1 className="heading heading--xl">{t("Éditeur de stratégies")}</h1>
-        <p className="text text--muted">
-          {t(
-            "Assemblez blocs de conditions, indicateurs et actions pour concevoir votre stratégie algorithmique."
-          )}
-        </p>
-      </header>
-
+    <StrategyToolPageShell
+      className="strategy-designer-page"
+      title={t("Éditeur de stratégies")}
+      description={t(
+        "Assemblez blocs de conditions, indicateurs et actions pour concevoir votre stratégie algorithmique."
+      )}
+    >
       <StrategyDesigner {...config} />
-    </div>
+    </StrategyToolPageShell>
   );
 }

--- a/services/web_dashboard/src/pages/Strategies/StrategyExpressPage.jsx
+++ b/services/web_dashboard/src/pages/Strategies/StrategyExpressPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { OneClickStrategyBuilder } from "../../strategies/simple/index.js";
 import { bootstrap } from "../../bootstrap";
+import StrategyToolPageShell from "./StrategyToolPageShell.jsx";
 
 export default function StrategyExpressPage() {
   const { t } = useTranslation();
@@ -9,14 +10,12 @@ export default function StrategyExpressPage() {
     bootstrap?.data?.strategyExpress || bootstrap?.config?.strategyExpress || {};
 
   return (
-    <div className="strategy-express-page">
-      <header className="page-header">
-        <h1 className="heading heading--xl">{t("Stratégie express")}</h1>
-        <p className="text text--muted">
-          {t("Créez une stratégie en quelques clics et lancez un backtest instantané.")}
-        </p>
-      </header>
+    <StrategyToolPageShell
+      className="strategy-express-page"
+      title={t("Stratégie express")}
+      description={t("Créez une stratégie en quelques clics et lancez un backtest instantané.")}
+    >
       <OneClickStrategyBuilder {...config} />
-    </div>
+    </StrategyToolPageShell>
   );
 }

--- a/services/web_dashboard/src/pages/Strategies/StrategyToolPageShell.jsx
+++ b/services/web_dashboard/src/pages/Strategies/StrategyToolPageShell.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function StrategyToolPageShell({ className, title, description, children }) {
+  const classes = ["strategy-tool-page", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={classes}>
+      <header className="page-header">
+        <h1 className="heading heading--xl">{title}</h1>
+        {description ? <p className="text text--muted">{description}</p> : null}
+      </header>
+      {children}
+    </div>
+  );
+}
+
+StrategyToolPageShell.propTypes = {
+  className: PropTypes.string,
+  title: PropTypes.node.isRequired,
+  description: PropTypes.node,
+  children: PropTypes.node.isRequired,
+};
+
+StrategyToolPageShell.defaultProps = {
+  className: "",
+  description: null,
+};


### PR DESCRIPTION
## Summary
- extract a reusable `StrategyToolPageShell` so strategy wrappers share the same layout chrome
- refactor the strategy express, designer, backtest, and AI assistant pages to consume the shell while still wiring bootstrap configs
- add a vitest routing smoke test to ensure the new strategy and onboarding routes render inside the SPA

## Testing
- npm test -- src/App.routes.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68fc2eb7e1fc8332a34cbb9197bde550