### PR TITLE
Add optimistic clone handling to strategies list

### DIFF
--- a/services/web_dashboard/src/pages/Strategies/StrategiesList.test.jsx
+++ b/services/web_dashboard/src/pages/Strategies/StrategiesList.test.jsx
@@ -162,6 +162,7 @@ describe("StrategiesListView", () => {
     await user.click(screen.getAllByRole("button", { name: /cloner/i })[0]);
     await waitFor(() => expect(createMock).toHaveBeenCalled());
     expect(createMock).toHaveBeenCalledWith({}, { endpoint: "/strategies/strat-2/clone" });
+    expect(await screen.findByText("Momentum Gamma (Clone)")).toBeInTheDocument();
     expect(screen.getByText("Stratégie clonée avec succès.")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add optimistic cache updates when cloning strategies so new entries appear immediately in the list
- clear feedback and restore previous cache values if cloning fails while keeping the list stale for later refetches
- extend strategies list tests to cover the optimistic clone rendering path

## Testing
- npm test -- --run Tests: StrategiesList

------
https://chatgpt.com/codex/tasks/task_e_68fc32b163d4833287cbc6bf2fee2be9