### PR TITLE
fix: correct Makefile indentation (use tabs instead of spaces)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ native-down:
 	./scripts/dev/native_down.sh
 
 demo-up:
-        docker compose up -d postgres redis
-        docker compose up -d --build auth_service user_service billing_service streaming streaming_gateway market_data \
-                order_router algo_engine reports alert_engine notification_service inplay web_dashboard \
-                prometheus grafana
+	docker compose up -d postgres redis
+	docker compose up -d --build auth_service user_service billing_service streaming streaming_gateway market_data \
+		order_router algo_engine reports alert_engine notification_service inplay web_dashboard \
+		prometheus grafana
 
 demo-down:
 	docker compose down -v


### PR DESCRIPTION
## Summary

Fixes #262 

The `demo-up` target in the Makefile was using spaces instead of tabs for indentation, causing a "missing separator" error when running `make demo-up`.

## Changes

- Replaced spaces with tabs in the `demo-up` target (lines 29-32)
- Ensures proper Makefile syntax

## Testing

```bash
make -n demo-up  # Dry run - no errors
```

## Related Issue

This addresses the first critical issue identified in #262. Other infrastructure improvements (health checks, etc.) can be handled separately if needed.